### PR TITLE
fix(charlie): orphan-callback safety on process restart

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -1477,3 +1477,78 @@ still gated.
   Deferred.
 - GitHub PAT embedded in `/root/QClaw` origin URL — visible in
   `git remote -v`. Separate rotation task if not already tracked.
+
+---
+
+## 2026-04-27 — Approval gate: orphan-callback safety
+
+Small defensive change to `ExecApprovals.approve/deny`. On process restart
+the in-memory `pendingCallbacks` Map empties; previously the SQL row update
+ran but the resolution call site silently no-op'd. Now:
+- Read the row first; throw `Error('not found')` for nonexistent ids.
+- Return `{alreadyResolved:true,status}` for rows already approved/denied
+  (instead of running a second UPDATE that does nothing because of the
+  `WHERE status='pending'` clause — same outcome, but the call site now
+  knows what happened).
+- When `pendingCallbacks.get(id)` is empty, log a warning instead of
+  silently dropping the resolution. Row still updates correctly.
+
+The original requester's Promise stays unresolved on the orphan path
+— a full DB-backed callback queue is a larger architectural change,
+out of scope for this PR.
+
+### Origin of this PR — and what it isn't
+
+Started as a fix for "approval gate timing out every approval since
+2026-04-22" after I diagnosed the bug as a missing emoji parser. That
+diagnosis was wrong — `b08d64b` (2026-04-21) already added the
+`/^([✅❌]|approve|deny|yes|no)\s*#?(\d+)\s*(.*)$/i` parser inside
+`bot.on('message:text')`, line 263 of channels/manager.js. The parser
+works correctly (verified against the diagnostic input matrix).
+
+The actual headline bug is **handler concurrency**: `bot.on('message:text')`
+runs `await agent.process(text)` synchronously, which blocks grammY's
+update loop. When Charlie's chat handler stalls (Cognee reconnect storms,
+slow tool calls, etc.) the user's emoji-reply sits undelivered until the
+previous chat completes — by which time the 10-minute timeout has already
+denied the row. Production logs for [37] show a 13-minute silence between
+the previous chat completion (09:41:16) and the next (09:54:17), with the
+[37] timeout firing at 09:54:13 inside that gap.
+
+`pm2 logs quantumclaw --lines 5000` confirms exactly **1 successful
+approval** (`[7] granted by telegram:tysonven via inline reply` at
+21:23:34) against ~49 timeouts — consistent with messages occasionally
+arriving while the chat handler is between calls.
+
+Headline-bug fix (extract `approvalReply` to a `bot.hears()` registered
+before `bot.on('message:text')`, or fire-and-forget the agent call) is
+tracked separately. This PR only ships the small defensive change; the
+gate will still time out approvals until the concurrency fix lands.
+
+### Changes
+- `src/security/approvals.js` — orphan-callback safety + return shape.
+- `tests/approvals.test.js` — 13 cases (happy path, already-resolved,
+  not-found, orphan-callback for both approve and deny). JSON fallback
+  path so no SQLite dep.
+
+### Test results
+- `node tests/approvals.test.js` → 13/13 pass
+- `node tests/smoke.test.js` → 21/22 (pre-existing local `jsonwebtoken`
+  module-not-found, unrelated)
+
+### Deferred to other sessions
+- Real headline fix: handler concurrency / approval reply pre-empting
+  long chat handler.
+- Cognee reconnect storms (probable amplifier of the concurrency bug).
+- QClaw on `qclaw` is under root's PM2 (not raw node — diagnostic
+  correction). `flowos` user has its own empty PM2 instance, which is
+  what threw me earlier.
+- `charlie-watcher` PM2 entry exists (id 4, runs
+  `bash src/agents/task-watcher.sh`) — name is real, role is task-queue
+  watching, not Telegram listening.
+- `/root/QClaw` has 1 unpushed commit (`26fe992`) and 3 WIP files
+  (`monte_carlo.py`, `n8n-api.md`, `yarn.lock`) — Pillar 7 drift, parked.
+- Local Mac PM2 zombie entry `quantumclaw` (PID 1381) — `pm2 delete`
+  on the Mac.
+- Plaintext credentials in local `~/.quantumclaw/config.json`
+  (`dashboard.authToken`, `dashboard.pin`, `dashboard.tunnelToken`).

--- a/src/security/approvals.js
+++ b/src/security/approvals.js
@@ -71,28 +71,77 @@ export class ExecApprovals {
     return promise;
   }
 
-  approve(id, by = 'owner') {
+  _readRow(id) {
     if (this._useJson) {
-      const item = this._data?.items?.find(i => i.id === id && i.status === 'pending');
-      if (item) { item.status = 'approved'; item.resolved = new Date().toISOString(); item.resolved_by = by; this._saveJson(); }
+      if (!this._data) this._data = this._loadJson();
+      return this._data.items.find(i => i.id === id) || null;
+    }
+    return this.db.prepare('SELECT id, status FROM approvals WHERE id = ?').get(id) || null;
+  }
+
+  approve(id, by = 'owner') {
+    const row = this._readRow(id);
+    if (!row) {
+      const err = new Error('not found');
+      err.code = 'NOT_FOUND';
+      throw err;
+    }
+    if (row.status !== 'pending') {
+      return { alreadyResolved: true, status: row.status };
+    }
+
+    if (this._useJson) {
+      const item = this._data.items.find(i => i.id === id);
+      item.status = 'approved';
+      item.resolved = new Date().toISOString();
+      item.resolved_by = by;
+      this._saveJson();
     } else {
       this.db.prepare('UPDATE approvals SET status = \'approved\', resolved = datetime(\'now\'), resolved_by = ? WHERE id = ? AND status = \'pending\'').run(by, id);
     }
+
     const cb = this.pendingCallbacks.get(id);
-    if (cb) { cb.resolve({ approved: true, id }); this.pendingCallbacks.delete(id); }
+    if (cb) {
+      cb.resolve({ approved: true, id });
+      this.pendingCallbacks.delete(id);
+    } else {
+      log.warn(`Approval ${id} resolved=approved by=${by} but no in-memory callback (process restart?). Original requester will not be unblocked.`);
+    }
     log.success(`Approved: [${id}]`);
+    return { alreadyResolved: false };
   }
 
   deny(id, by = 'owner', reason = '') {
+    const row = this._readRow(id);
+    if (!row) {
+      const err = new Error('not found');
+      err.code = 'NOT_FOUND';
+      throw err;
+    }
+    if (row.status !== 'pending') {
+      return { alreadyResolved: true, status: row.status };
+    }
+
     if (this._useJson) {
-      const item = this._data?.items?.find(i => i.id === id && i.status === 'pending');
-      if (item) { item.status = 'denied'; item.resolved = new Date().toISOString(); item.resolved_by = by; item.reason = reason; this._saveJson(); }
+      const item = this._data.items.find(i => i.id === id);
+      item.status = 'denied';
+      item.resolved = new Date().toISOString();
+      item.resolved_by = by;
+      item.reason = reason;
+      this._saveJson();
     } else {
       this.db.prepare('UPDATE approvals SET status = \'denied\', resolved = datetime(\'now\'), resolved_by = ?, reason = ? WHERE id = ? AND status = \'pending\'').run(by, reason, id);
     }
+
     const cb = this.pendingCallbacks.get(id);
-    if (cb) { cb.resolve({ approved: false, id, reason }); this.pendingCallbacks.delete(id); }
+    if (cb) {
+      cb.resolve({ approved: false, id, reason });
+      this.pendingCallbacks.delete(id);
+    } else {
+      log.warn(`Approval ${id} resolved=denied by=${by} but no in-memory callback (process restart?). Original requester will not be unblocked.`);
+    }
     log.info(`Denied: [${id}] ${reason}`);
+    return { alreadyResolved: false };
   }
 
   pending() {

--- a/tests/approvals.test.js
+++ b/tests/approvals.test.js
@@ -1,0 +1,108 @@
+/**
+ * ExecApprovals — orphan-callback safety + return shape.
+ * Uses the JSON-fallback path so no SQLite dependency is required.
+ * Run: node tests/approvals.test.js
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ExecApprovals } from '../src/security/approvals.js';
+
+const dir = mkdtempSync(join(tmpdir(), 'qclaw-approvals-'));
+let passed = 0;
+let failed = 0;
+
+function check(label, cond, detail = '') {
+  if (cond) { console.log(`  ✓ ${label}`); passed++; }
+  else { console.error(`  ✗ ${label}${detail ? ' — ' + detail : ''}`); failed++; }
+}
+
+async function main() {
+  const approvals = new ExecApprovals({ _dir: dir });
+  approvals.attach(null); // force JSON path
+
+  // ── 1. approve() resolves the pending Promise and returns alreadyResolved:false
+  const p1 = approvals.request('charlie', 'shell_exec', 'whoami', 'low');
+  check('request creates pending row', approvals.pending().length === 1);
+  const id1 = approvals.pending()[0].id;
+
+  const ret1 = approvals.approve(id1, 'tg:test');
+  check('approve returns alreadyResolved:false', ret1?.alreadyResolved === false);
+
+  const result1 = await p1;
+  check('original Promise resolves with approved:true',
+    result1.approved === true && result1.id === id1);
+
+  // ── 2. approve() on an already-resolved row returns alreadyResolved:true
+  const ret2 = approvals.approve(id1, 'tg:test');
+  check('second approve returns alreadyResolved:true with status approved',
+    ret2?.alreadyResolved === true && ret2.status === 'approved');
+
+  // ── 3. approve() on nonexistent id throws "not found"
+  let threw = false, msg = '';
+  try { approvals.approve(99999, 'tg:test'); }
+  catch (e) { threw = true; msg = e.message; }
+  check('approve on nonexistent id throws "not found"',
+    threw && msg === 'not found', `got threw=${threw} msg=${msg}`);
+
+  // ── 4. deny() resolves Promise with approved:false
+  const p2 = approvals.request('charlie', 'n8n_workflow_update', 'foo', 'high');
+  const id2 = approvals.pending()[0].id;
+  const retD = approvals.deny(id2, 'tg:test', 'Denied by user');
+  check('deny returns alreadyResolved:false', retD?.alreadyResolved === false);
+  const result2 = await p2;
+  check('Promise resolves with approved:false and reason',
+    result2.approved === false && result2.reason === 'Denied by user');
+
+  // ── 5. orphan-callback path: row updates, no throw, no callback
+  // Simulate a process restart between request and approval by clearing the
+  // pendingCallbacks Map but leaving the row in JSON state.
+  const p3 = approvals.request('charlie', 'shell_exec', 'orphan', 'low');
+  const id3 = approvals.pending()[0].id;
+  let p3State = 'pending';
+  p3.then(() => { p3State = 'resolved'; }).catch(() => { p3State = 'rejected'; });
+
+  approvals.pendingCallbacks.delete(id3); // simulate restart
+  const retO = approvals.approve(id3, 'tg:test');
+  check('orphan approve does not throw and returns alreadyResolved:false',
+    retO?.alreadyResolved === false);
+
+  const row = approvals._data.items.find(i => i.id === id3);
+  check('orphan approve updates row to approved',
+    row && row.status === 'approved' && row.resolved_by === 'tg:test');
+
+  await new Promise(r => setTimeout(r, 10));
+  check('orphan: original Promise stays pending (no fake resolution)',
+    p3State === 'pending');
+
+  // ── 6. deny() also handles orphan path
+  const p4 = approvals.request('charlie', 'shell_exec', 'orphan2', 'low');
+  const id4 = approvals.pending()[0].id;
+  approvals.pendingCallbacks.delete(id4);
+  const retOD = approvals.deny(id4, 'tg:test', 'why');
+  check('orphan deny does not throw',
+    retOD?.alreadyResolved === false);
+  const row4 = approvals._data.items.find(i => i.id === id4);
+  check('orphan deny updates row to denied',
+    row4 && row4.status === 'denied' && row4.reason === 'why');
+
+  // ── 7. deny() on nonexistent throws
+  let threwD = false, msgD = '';
+  try { approvals.deny(99999, 'tg:test', 'x'); }
+  catch (e) { threwD = true; msgD = e.message; }
+  check('deny on nonexistent throws "not found"',
+    threwD && msgD === 'not found');
+}
+
+main()
+  .then(() => {
+    console.log(`\n${passed} passed, ${failed} failed`);
+    rmSync(dir, { recursive: true, force: true });
+    if (failed > 0) process.exit(1);
+  })
+  .catch((err) => {
+    console.error('unexpected:', err);
+    rmSync(dir, { recursive: true, force: true });
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Small defensive change to `ExecApprovals.approve/deny`. **Not the fix for the headline 'every approval times out' bug** — that's handler concurrency, tracked separately. See "What this PR isn't" below.

On process restart the in-memory `pendingCallbacks` Map is empty; previously the SQL row update ran but the resolution call site silently no-op'd, leaving the row in a half-resolved state. Now:

- Read the row first; throw `Error('not found')` for nonexistent ids.
- Return `{alreadyResolved:true,status}` for rows already approved/denied (the call site can detect it instead of silently re-running an UPDATE that does nothing because of the `WHERE status='pending'` clause).
- When `pendingCallbacks.get(id)` is empty, log a warning instead of silently dropping the resolution. Row still updates correctly.

The original requester's Promise stays unresolved on the orphan path — a full DB-backed callback queue is a larger architectural change, out of scope.

## What this PR isn't

This PR was originally opened as "approval gate accepts ✅/❌ replies" — that diagnosis was wrong. `b08d64b` (2026-04-21) already added the parser inside `bot.on('message:text')`:

```js
const approvalReply = ctx.message.text.trim().match(/^([✅❌]|approve|deny|yes|no)\s*#?(\d+)\s*(.*)$/i);
```

Verified against the original input matrix — every case matches and extracts the id correctly.

The actual root cause is **handler concurrency**: `bot.on('message:text')` runs `await agent.process(text)` synchronously, which blocks grammY's update loop. When Charlie's chat handler stalls (Cognee reconnect storms, slow tool calls, etc.), the user's emoji-reply sits undelivered until the previous chat completes — by which time the 10-minute timeout has already denied the row. Production logs for `[37]` show a 13-minute silence between the previous chat completion (09:41:16) and the next (09:54:17), with the `[37]` timeout firing at 09:54:13 inside that gap.

Verification: `pm2 logs quantumclaw --lines 5000` shows exactly **1 successful approval** (`[7] granted by telegram:tysonven via inline reply` at 21:23:34) against ~49 timeouts. ~1/50 success rate fits the slow-chat-handler hypothesis (probabilistic), not a deterministic deadlock.

The headline fix (extract `approvalReply` to a `bot.hears()` registered before `bot.on('message:text')`, or fire-and-forget the agent call) is **owned by a separate session**. The gate will continue timing out approvals until that lands. **No Telegram smoke test on this PR** — there's nothing user-visible to verify yet.

## Tests

- `node tests/approvals.test.js` → **13/13** (happy path, already-resolved, not-found, orphan-callback for both approve and deny)
- `node tests/smoke.test.js` → 21/22 (the 1 failure is the pre-existing local Mac `jsonwebtoken` ERR_MODULE_NOT_FOUND — unrelated)

## Deploy

QClaw on `qclaw` is under root's PM2 (PM2 id 2, name `quantumclaw`, parent PID 1622071 = PM2 God Daemon). Earlier diagnostic note about "raw node" was wrong — `flowos`'s PM2 is empty, root's is the production one. Restart mechanism: `sudo pm2 restart quantumclaw`.

```
ssh qclaw
sudo git -C /root/QClaw fetch origin
sudo git -C /root/QClaw merge --no-ff origin/fix/approval-gate-emoji-parser
sudo pm2 restart quantumclaw
sudo pm2 logs quantumclaw --lines 30
```

`--no-ff` merge into local `main` to preserve the 1 unpushed prod commit (`26fe992 feat: migrate Crete R2 to dedicated bucket with custom domain`) and 3 WIP files (`monte_carlo.py`, `n8n-api.md`, `yarn.lock`). The `/root/QClaw` ↔ `origin/main` drift is parked for a separate cleanup session.

## Out of scope (deferred)

- Real headline fix: handler concurrency / approval reply pre-empting long chat handler
- Cognee reconnect storms (probable amplifier of the concurrency bug)
- `/root/QClaw` ↔ `origin/main` drift cleanup
- Local Mac PM2 zombie entry (`pm2 delete quantumclaw` on the Mac)
- Plaintext credentials in `~/.quantumclaw/config.json` on the Mac