### PR TITLE
fix(charlie): approval gate concurrency — bot.hears via runner + per-agent mutex

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -1744,3 +1744,79 @@ Listed so next session can decide what to do with each:
 - (this commit) — session close summary
 
 origin/main HEAD before this commit: `7dc182051551b0e54c8b2f6c00c761ae3b6c77f2`.
+
+---
+
+## 2026-04-27 — Approval gate concurrency fix
+
+Fixes the deterministic deadlock-by-origin documented in the prior audit:
+when an approval was requested from inside a tool call inside
+`bot.on('message:text')`'s `await agent.process(...)` chain, the user's
+`✅ <id>` reply could not be processed because the same handler instance
+that owns the reply parser was the one awaiting the approval Promise.
+Production data: ~25 timeouts vs 1 success (`[7]`) over 5 days, with the
+single success originating from a heartbeat task — i.e., outside the
+chat handler's await chain.
+
+### Changes
+
+`src/channels/manager.js`
+- New dependency `@grammyjs/runner@2.0.3`.
+- Inline approval-reply branch removed from `bot.on('message:text')` and
+  re-registered as a top-level `bot.hears(APPROVAL_REPLY_RE, …)` placed
+  before `message:text`. Under the runner's concurrent middleware, emoji
+  replies dispatch in parallel with any in-flight `agent.process()`.
+- `bot.start({drop_pending_updates:true})` replaced with
+  `run(bot, { runner: { fetch: { allowed_updates: ['message','callback_query'] } } })`.
+  `drop_pending_updates` is still applied via the existing
+  `deleteWebhook({drop_pending_updates:true})`.
+- `stop()` now calls `_runner.stop()`.
+- `handleApprovalReply` extracted as an exported function so it can be
+  unit-tested without spinning up a real Bot. The `bot.hears` callback
+  is a one-line wrapper.
+
+`src/agents/registry.js`
+- Concurrent dispatch would let two `agent.process()` calls for the
+  same agent run in parallel — both reading the same history snapshot,
+  running separate LLM calls, then writing interleaved turns. (Audit §3
+  conversation-history hazard.)
+- Added a module-level mutex (Map<agentName, Promise>) and a
+  `_withAgentLock(name, fn)` helper. Reflex-tier responses skip the lock
+  (no history I/O). Everything from `graphQuery` through the second
+  `addMessage` is held under the lock, restoring the same serialization
+  grammY's default sequential middleware used to provide.
+- Body extracted to `_processNonReflex(message, context, route, textMessage)`
+  so the lock wrap doesn't reindent ~165 lines. No logic change.
+- Mutex exported as `__agentLockForTests` for the concurrency test only.
+
+The existing `/approve <id>` and `/deny <id>` slash commands are
+untouched. All other handlers (audited as concurrency-safe) are now
+running through the runner.
+
+### Tests
+
+- `node tests/smoke.test.js` → 22/22
+- `node tests/approvals.test.js` → 13/13 (added `process.exit(failed?1:0)`
+  so it doesn't hang on armed 10-min timeouts)
+- `node tests/approval-parser-handler.test.js` → **29/29** new — full
+  regex input matrix plus handler behaviour (authorized success,
+  already-resolved, unauthorized silent ignore, nonexistent id, deny
+  aliases, deny-with-tail-as-reason)
+- `node tests/agent-mutex.test.js` → **7/7** new — same-key
+  serialization, history consistency under concurrency, different-key
+  parallel execution, lock release on throw, post-throw reacquire
+
+### Deploy
+
+PM2 still owns the process (root's PM2, id 2 `quantumclaw`):
+```
+ssh qclaw
+sudo git -C /root/QClaw fetch origin
+sudo git -C /root/QClaw merge --no-ff origin/fix/approval-gate-concurrency
+sudo pm2 restart quantumclaw
+sudo pm2 logs quantumclaw --lines 30
+```
+
+Tyson runs the manual smoke from Telegram once deployed. The headline
+`[37]`-class failure should disappear: emoji replies resolve approvals
+even while a chat handler is mid-`agent.process()`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "3.1020.0",
         "@clack/prompts": "^0.9.1",
+        "@grammyjs/runner": "2.0.3",
         "busboy": "1.6.0",
         "canvas": "3.2.3",
         "chalk": "^5.4.1",
@@ -1108,6 +1109,21 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@grammyjs/runner": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@grammyjs/runner/-/runner-2.0.3.tgz",
+      "integrity": "sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.20.0 || >=14.13.1"
+      },
+      "peerDependencies": {
+        "grammy": "^1.13.1"
       }
     },
     "node_modules/@grammyjs/types": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.1020.0",
     "@clack/prompts": "^0.9.1",
+    "@grammyjs/runner": "2.0.3",
     "busboy": "1.6.0",
     "canvas": "3.2.3",
     "chalk": "^5.4.1",

--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -10,6 +10,32 @@ import { join } from 'path';
 import { log } from '../core/logger.js';
 import { parseSkill, skillToTools, executeSkillTool } from './skill-parser.js';
 
+// Per-agent serialization for the conversation read-modify-write in process().
+// Two concurrent process() calls for the same agent would otherwise read the
+// same history snapshot, run the LLM in parallel, then both append turns —
+// the second LLM never sees the first turn, and the DB log interleaves out
+// of order. The mutex re-establishes the serialization that grammY's default
+// (sequential) middleware used to provide before we switched to runner.
+// Reflex-tier responses skip this lock (no history I/O).
+const _agentLocks = new Map();
+
+async function _withAgentLock(name, fn) {
+  while (_agentLocks.has(name)) {
+    await _agentLocks.get(name);
+  }
+  let release;
+  const lock = new Promise((r) => { release = r; });
+  _agentLocks.set(name, lock);
+  try {
+    return await fn();
+  } finally {
+    _agentLocks.delete(name);
+    release();
+  }
+}
+
+export { _withAgentLock as __agentLockForTests };
+
 export class AgentRegistry {
   constructor(config, services) {
     this.config = config;
@@ -235,6 +261,19 @@ export class Agent {
         model: null
       };
     }
+
+    // Non-reflex path: serialize per-agent so concurrent calls don't read
+    // the same history snapshot, parallel-LLM, then write interleaved turns.
+    return _withAgentLock(this.name, () =>
+      this._processNonReflex(message, context, route, textMessage)
+    );
+  }
+
+  // Held under per-agent lock by process(). Body unchanged from the original
+  // post-reflex section; extracted only so the lock wrap doesn't reindent the
+  // whole method. See _withAgentLock at the top of this file for rationale.
+  async _processNonReflex(message, context, route, textMessage) {
+    const { router, memory, audit } = this.services;
 
     // Build context — now uses structured knowledge + selective history
     const graphContext = route.extendedContext

--- a/src/channels/manager.js
+++ b/src/channels/manager.js
@@ -5,7 +5,52 @@
  * Each channel is a simple adapter: receive messages → agent → send response.
  */
 
+import { run } from '@grammyjs/runner';
 import { log } from '../core/logger.js';
+
+// Anchored at start of message. Matches "✅ 37", "✅37", "✅ 37 thanks",
+// "approve 37", "yes 37", and the deny variants. Trailing chars after the
+// id are kept on the message text (handler reads them as the deny reason).
+export const APPROVAL_REPLY_RE = /^([✅❌]|approve|deny|yes|no)\s*#?(\d+)/i;
+
+// Extracted so it's directly testable without spinning up a Bot. The bot.hears
+// callback is a thin wrapper that calls this with the approvals subsystem
+// from the channel instance.
+export async function handleApprovalReply(ctx, { allowedUsers, approvals }) {
+  if (!allowedUsers.includes(ctx.from.id)) return;
+  const verb = ctx.match[1].toLowerCase();
+  const id = parseInt(ctx.match[2], 10);
+  const isApprove = verb === '✅' || verb === 'approve' || verb === 'yes';
+  const actor = `telegram:${ctx.from.username || ctx.from.id}`;
+  const tail = ctx.message.text.slice(ctx.match[0].length).trim();
+
+  try {
+    if (isApprove) {
+      const result = approvals.approve(id, actor);
+      if (result?.alreadyResolved) {
+        await ctx.reply(`⚠️ Approval [${id}] was already ${result.status}.`);
+      } else {
+        await ctx.reply(`✅ Approved [${id}].`);
+        log.info(`Approval ${id} granted by ${actor} via inline reply`);
+      }
+    } else {
+      const reason = tail || 'denied by owner';
+      const result = approvals.deny(id, actor, reason);
+      if (result?.alreadyResolved) {
+        await ctx.reply(`⚠️ Approval [${id}] was already ${result.status}.`);
+      } else {
+        await ctx.reply(`❌ Denied [${id}].`);
+        log.info(`Approval ${id} denied by ${actor} via inline reply: ${reason}`);
+      }
+    }
+  } catch (e) {
+    if (e.code === 'NOT_FOUND') {
+      await ctx.reply(`No pending approval with ID ${id}.`);
+    } else {
+      await ctx.reply(`⚠️ Couldn't ${isApprove ? 'approve' : 'deny'} [${id}]: ${e.message}`);
+    }
+  }
+}
 
 export class ChannelManager {
   constructor(config, agents, secrets, approvals, deliveryQueue) {
@@ -99,6 +144,7 @@ class TelegramChannel {
     this.secrets = secrets;
     this.approvals = approvals;
     this.bot = null;
+    this._runner = null;
     this.pendingPairings = new Map();
   }
 
@@ -257,34 +303,16 @@ class TelegramChannel {
       log.info(`Approval ${id} denied by ${denier}: ${reason}`);
     });
 
-    this.bot.on('message:text', async (ctx) => {
-      // Inline approval replies — match before slash-command handling so plain
-      // "✅ 42" / "❌ 42" / "approve 42" / "deny 42" all work.
-      const approvalReply = ctx.message.text.trim().match(/^([✅❌]|approve|deny|yes|no)\s*#?(\d+)\s*(.*)$/i);
-      if (approvalReply && allowedUsers.includes(ctx.from.id)) {
-        const verb = approvalReply[1].toLowerCase();
-        const id = parseInt(approvalReply[2], 10);
-        const rest = approvalReply[3] || '';
-        const approve = verb === '✅' || verb === 'approve' || verb === 'yes';
-        const pending = this.approvals.pending();
-        const item = pending.find(p => p.id === id);
-        if (!item) {
-          await ctx.reply(`No pending approval with ID ${id}.`);
-          return;
-        }
-        const actor = `telegram:${ctx.from.username || ctx.from.id}`;
-        if (approve) {
-          this.approvals.approve(id, actor);
-          await ctx.reply(`✅ Approved [${id}]: ${item.action}`);
-          log.info(`Approval ${id} granted by ${actor} via inline reply`);
-        } else {
-          this.approvals.deny(id, actor, rest || 'denied by owner');
-          await ctx.reply(`❌ Denied [${id}]: ${item.action}`);
-          log.info(`Approval ${id} denied by ${actor} via inline reply`);
-        }
-        return;
-      }
+    // Inline approval replies. Registered as bot.hears (separate handler from
+    // message:text) so the runner can dispatch concurrently — emoji replies
+    // are not blocked by an in-flight agent.process() call inside message:text.
+    // See QCLAW_BUILD_LOG.md (2026-04-27 concurrency fix) for the deadlock
+    // this addresses. handleApprovalReply is exported for unit tests.
+    this.bot.hears(APPROVAL_REPLY_RE, (ctx) =>
+      handleApprovalReply(ctx, { allowedUsers, approvals: this.approvals })
+    );
 
+    this.bot.on('message:text', async (ctx) => {
       if (ctx.message.text.startsWith('/')) return;
 
       const userId = ctx.from.id;
@@ -387,19 +415,24 @@ await ctx.reply(
       await this.bot.api.deleteWebhook({ drop_pending_updates: true });
     } catch {}
 
-    this.bot.start({
-      drop_pending_updates: true,
-      onStart: () => {
-        if (allowedUsers.length === 0) {
-          log.info('Telegram: send /start to your bot to begin pairing');
-        } else {
-          log.success(`Telegram: ready (${allowedUsers.length} user${allowedUsers.length === 1 ? '' : 's'})`);
-        }
+    // Use @grammyjs/runner so middleware dispatches concurrently — required so
+    // bot.hears (approval-reply parser) is not blocked by a long-running
+    // agent.process() in bot.on('message:text'). drop_pending_updates is
+    // already handled by deleteWebhook above, so it isn't needed here.
+    try {
+      this._runner = run(this.bot, {
+        runner: { fetch: { allowed_updates: ['message', 'callback_query'] } },
+      });
+      if (allowedUsers.length === 0) {
+        log.info('Telegram: send /start to your bot to begin pairing');
+      } else {
+        log.success(`Telegram: ready (${allowedUsers.length} user${allowedUsers.length === 1 ? '' : 's'})`);
       }
-    }).catch(err => {
+    } catch (err) {
       log.error(`Telegram polling error: ${err.message}`);
       this.bot = null;
-    });
+      this._runner = null;
+    }
   }
   _chunkMessage(text, maxLen) {
     if (text.length <= maxLen) return [text];
@@ -468,8 +501,13 @@ await ctx.reply(
   }
 
   async stop() {
-    if (this.bot) {
-      await this.bot.stop();
+    if (this._runner) {
+      try {
+        await this._runner.stop();
+      } catch (err) {
+        log.debug(`Runner stop error: ${err.message}`);
+      }
+      this._runner = null;
     }
   }
 }

--- a/tests/agent-mutex.test.js
+++ b/tests/agent-mutex.test.js
@@ -1,0 +1,108 @@
+/**
+ * Per-agent mutex (registry.js __agentLockForTests).
+ *
+ * Confirms that two concurrent process()-shaped sequences for the same agent
+ * serialize cleanly: history read → write happens atomically per agent so a
+ * second caller never sees a stale snapshot.
+ *
+ * Run: node tests/agent-mutex.test.js
+ */
+
+import { __agentLockForTests as withLock } from '../src/agents/registry.js';
+
+let passed = 0;
+let failed = 0;
+
+function check(label, cond, detail = '') {
+  if (cond) { console.log(`  ✓ ${label}`); passed++; }
+  else { console.error(`  ✗ ${label}${detail ? ' — ' + detail : ''}`); failed++; }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  // ── 1. Same key serializes — critical sections never overlap.
+  let activeOnA = 0;
+  let maxConcurrent = 0;
+  const trace = [];
+  const work = (label) =>
+    withLock('agentA', async () => {
+      activeOnA++;
+      maxConcurrent = Math.max(maxConcurrent, activeOnA);
+      trace.push(`enter:${label}`);
+      await sleep(15);
+      trace.push(`leave:${label}`);
+      activeOnA--;
+    });
+  await Promise.all([work('A1'), work('A2'), work('A3')]);
+  check('same-key: max concurrency was 1', maxConcurrent === 1, `got ${maxConcurrent}`);
+  check('same-key: trace alternates enter/leave per op',
+    trace.join(',') === 'enter:A1,leave:A1,enter:A2,leave:A2,enter:A3,leave:A3',
+    `got ${trace.join(',')}`);
+
+  // ── 2. History read-modify-write is consistent under concurrent calls.
+  // Simulate the registry pattern: read → compute → write. Without the lock,
+  // last-writer-wins would clobber and the final length would be wrong.
+  const sharedHistory = [];
+  const turn = (msg) =>
+    withLock('agentB', async () => {
+      const snapshot = sharedHistory.slice();   // simulated getHistory()
+      await sleep(5);                            // simulated LLM call
+      sharedHistory.push(...snapshot.slice(-1), `t:${msg}`);
+    });
+  // Seed
+  sharedHistory.push('t:0');
+  await Promise.all([turn('1'), turn('2'), turn('3')]);
+  // Each turn appends the prior tail + its own marker. Order must reflect
+  // serialization: every appended marker should match the immediately-prior
+  // snapshot, which is the previous turn's marker.
+  const markers = sharedHistory.filter((s) => s.startsWith('t:'));
+  check('history: all 4 turns recorded', markers.length === 7,
+    `got ${markers.length}, history=${JSON.stringify(sharedHistory)}`);
+  // Last entry should be the third turn's marker.
+  check('history: final entry is t:3', sharedHistory[sharedHistory.length - 1] === 't:3');
+
+  // ── 3. Different keys run in parallel (no head-of-line blocking across agents).
+  let activeOnX = 0;
+  let activeOnY = 0;
+  let parallelObserved = false;
+  const heldX = withLock('agentX', async () => {
+    activeOnX++;
+    await sleep(40);
+    if (activeOnY > 0) parallelObserved = true;
+    activeOnX--;
+  });
+  const heldY = withLock('agentY', async () => {
+    activeOnY++;
+    await sleep(20);
+    if (activeOnX > 0) parallelObserved = true;
+    activeOnY--;
+  });
+  await Promise.all([heldX, heldY]);
+  check('different-key: agentX and agentY ran concurrently', parallelObserved);
+
+  // ── 4. Lock is released when inner fn throws — next caller proceeds.
+  let secondRan = false;
+  await withLock('agentZ', async () => { throw new Error('boom'); }).catch(() => {});
+  await withLock('agentZ', async () => { secondRan = true; });
+  check('throw releases the lock', secondRan);
+
+  // ── 5. Lock map cleans up — no leaked entries after the test.
+  // (Not asserting Map.size directly since module-level state is shared, but
+  //  confirming sequential acquire/release works after thrown errors.)
+  let third = 0;
+  for (let i = 0; i < 5; i++) {
+    await withLock('agentZ', async () => { third++; });
+  }
+  check('post-throw repeated acquire works', third === 5);
+}
+
+main()
+  .then(() => {
+    console.log(`\n${passed} passed, ${failed} failed`);
+    if (failed > 0) process.exit(1);
+  })
+  .catch((err) => {
+    console.error('unexpected:', err);
+    process.exit(1);
+  });

--- a/tests/approval-parser-handler.test.js
+++ b/tests/approval-parser-handler.test.js
@@ -1,0 +1,173 @@
+/**
+ * Inline approval-reply parser + handler input matrix.
+ * Drives handleApprovalReply against a faked grammY ctx and a real
+ * ExecApprovals on the JSON-fallback path.
+ *
+ * Run: node tests/approval-parser-handler.test.js
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  APPROVAL_REPLY_RE,
+  handleApprovalReply,
+} from '../src/channels/manager.js';
+import { ExecApprovals } from '../src/security/approvals.js';
+
+const dir = mkdtempSync(join(tmpdir(), 'qclaw-parser-'));
+let passed = 0;
+let failed = 0;
+
+function check(label, cond, detail = '') {
+  if (cond) { console.log(`  ✓ ${label}`); passed++; }
+  else { console.error(`  ✗ ${label}${detail ? ' — ' + detail : ''}`); failed++; }
+}
+
+// Build a fake ctx that mirrors the slice of grammY's Context the handler reads.
+function fakeCtx(text, userId = 1375806243, username = 'tysonven') {
+  const m = text.match(APPROVAL_REPLY_RE);
+  const replies = [];
+  return {
+    message: { text },
+    from: { id: userId, username },
+    match: m,
+    matched: !!m,
+    reply: async (s) => { replies.push(s); },
+    _replies: replies,
+  };
+}
+
+// ── Section 1: regex input matrix ─────────────────────────────────────
+console.log('Regex matrix:');
+const regexCases = [
+  // [input, expectedVerbLower, expectedId]
+  ['✅ 37',         '✅', '37'],
+  ['✅37',          '✅', '37'],
+  ['✅ 37 thanks',  '✅', '37'],
+  [' ✅ 37 ',       null, null],   // leading whitespace not allowed by ^
+  ['✅ 37',    '✅', '37'],   // NBSP between emoji and id
+  ['✅ 37\n',       '✅', '37'],
+  ['✅ #37',        '✅', '37'],   // optional # before id
+  ['❌ 37',         '❌', '37'],
+  ['❌37',          '❌', '37'],
+  ['approve 37',    'approve', '37'],
+  ['APPROVE 37',    'approve', '37'],   // case-insensitive
+  ['deny 37',       'deny', '37'],
+  ['yes 37',        'yes', '37'],
+  ['no 37',         'no', '37'],
+  ['hello ✅ 37',   null, null],   // mid-message rejected
+  ['✅',            null, null],   // emoji with no id
+  ['✅ abc',        null, null],   // non-numeric id
+  ['/approve 37',   null, null],   // slash command not matched here
+];
+
+for (const [input, expectedVerb, expectedId] of regexCases) {
+  const m = input.match(APPROVAL_REPLY_RE);
+  if (expectedId === null) {
+    check(`reject ${JSON.stringify(input)}`, !m);
+  } else {
+    const verbLower = m && m[1].toLowerCase();
+    const id = m && m[2];
+    check(
+      `match ${JSON.stringify(input)} → verb=${verbLower}, id=${id}`,
+      m && verbLower === expectedVerb && id === expectedId,
+      `got ${JSON.stringify(m && [verbLower, id])}`,
+    );
+  }
+}
+
+// ── Section 2: handler behaviour against a real ExecApprovals ─────────
+console.log('\nHandler behaviour:');
+
+const approvals = new ExecApprovals({ _dir: dir });
+approvals.attach(null);
+
+const ALLOWED = [1375806243];
+const NOT_ALLOWED = [1375806243];   // doesn't include the rogue id below
+
+async function run() {
+  // 2a. happy-path approve — pending row, allowed user, ✅ <id>
+  const p1 = approvals.request('charlie', 'shell_exec', 'whoami', 'low');
+  const id1 = approvals.pending()[0].id;
+  const ctx1 = fakeCtx(`✅ ${id1}`);
+  await handleApprovalReply(ctx1, { allowedUsers: ALLOWED, approvals });
+  check('approve: ctx.reply was called with success message',
+    ctx1._replies.length === 1 && ctx1._replies[0] === `✅ Approved [${id1}].`);
+  const r1 = await p1;
+  check('approve: original Promise resolved approved:true',
+    r1.approved === true && r1.id === id1);
+
+  // 2b. approve again — already-resolved branch
+  const ctx1b = fakeCtx(`✅ ${id1}`);
+  await handleApprovalReply(ctx1b, { allowedUsers: ALLOWED, approvals });
+  check('approve again: warns "already approved"',
+    ctx1b._replies[0] === `⚠️ Approval [${id1}] was already approved.`);
+
+  // 2c. happy-path deny — pending row, allowed user, ❌ <id> with reason tail
+  const p2 = approvals.request('charlie', 'shell_exec', 'rm -rf', 'high');
+  const id2 = approvals.pending()[0].id;
+  const ctx2 = fakeCtx(`❌ ${id2} too risky`);
+  await handleApprovalReply(ctx2, { allowedUsers: ALLOWED, approvals });
+  check('deny: ctx.reply with denied message',
+    ctx2._replies[0] === `❌ Denied [${id2}].`);
+  const r2 = await p2;
+  check('deny: Promise resolved approved:false with tail as reason',
+    r2.approved === false && r2.reason === 'too risky');
+
+  // 2d. deny without tail — falls back to default reason
+  const p3 = approvals.request('charlie', 'shell_exec', 'foo', 'low');
+  const id3 = approvals.pending()[0].id;
+  const ctx3 = fakeCtx(`❌ ${id3}`);
+  await handleApprovalReply(ctx3, { allowedUsers: ALLOWED, approvals });
+  const r3 = await p3;
+  check('deny without tail: default reason "denied by owner"',
+    r3.reason === 'denied by owner');
+
+  // 2e. unauthorized user — silent ignore (no reply, no DB change)
+  const p4 = approvals.request('charlie', 'shell_exec', 'bar', 'low');
+  const id4 = approvals.pending()[0].id;
+  const ctx4 = fakeCtx(`✅ ${id4}`, /* userId */ 99999, 'rando');
+  await handleApprovalReply(ctx4, { allowedUsers: ALLOWED, approvals });
+  check('unauthorized user: no reply emitted',
+    ctx4._replies.length === 0);
+  check('unauthorized user: row still pending',
+    approvals.pending().some((p) => p.id === id4));
+
+  // 2f. nonexistent id — friendly NOT_FOUND reply, not an Error stack
+  const ctx5 = fakeCtx('✅ 99999');
+  await handleApprovalReply(ctx5, { allowedUsers: ALLOWED, approvals });
+  check('nonexistent id: replies "No pending approval with ID …"',
+    ctx5._replies[0] === 'No pending approval with ID 99999.');
+
+  // 2g. reflex aliases route correctly
+  const p5 = approvals.request('charlie', 'shell_exec', 'baz', 'low');
+  const id5 = approvals.pending()[0].id;
+  const ctx6 = fakeCtx(`yes ${id5}`);
+  await handleApprovalReply(ctx6, { allowedUsers: ALLOWED, approvals });
+  check('verb "yes" approves',
+    ctx6._replies[0] === `✅ Approved [${id5}].`);
+  await p5;
+
+  const p6 = approvals.request('charlie', 'shell_exec', 'qux', 'low');
+  const id6 = approvals.pending()[0].id;
+  const ctx7 = fakeCtx(`no ${id6}`);
+  await handleApprovalReply(ctx7, { allowedUsers: ALLOWED, approvals });
+  check('verb "no" denies',
+    ctx7._replies[0] === `❌ Denied [${id6}].`);
+  await p6;
+}
+
+run()
+  .then(() => {
+    console.log(`\n${passed} passed, ${failed} failed`);
+    rmSync(dir, { recursive: true, force: true });
+    // Each request() arms a 10-min setTimeout that keeps the event loop
+    // alive. Exit explicitly so the test process terminates promptly.
+    process.exit(failed > 0 ? 1 : 0);
+  })
+  .catch((err) => {
+    console.error('unexpected:', err);
+    rmSync(dir, { recursive: true, force: true });
+    process.exit(1);
+  });

--- a/tests/approvals.test.js
+++ b/tests/approvals.test.js
@@ -99,7 +99,9 @@ main()
   .then(() => {
     console.log(`\n${passed} passed, ${failed} failed`);
     rmSync(dir, { recursive: true, force: true });
-    if (failed > 0) process.exit(1);
+    // Each request() arms a 10-min setTimeout that keeps the event loop
+    // alive. Exit explicitly so the test process terminates promptly.
+    process.exit(failed > 0 ? 1 : 0);
   })
   .catch((err) => {
     console.error('unexpected:', err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,7 +4,6 @@
 
 "@agexhq/core@^1.0.0", "@agexhq/core@file:packages/agex-core":
   version "1.0.0"
-  resolved "file:packages/agex-core"
   dependencies:
     "@noble/ciphers" "^0.5.0"
     "@noble/curves" "^1.3.0"
@@ -82,7 +81,7 @@
     "@smithy/util-utf8" "^2.0.0"
     tslib "^2.6.2"
 
-"@aws-crypto/sha256-js@^5.2.0", "@aws-crypto/sha256-js@5.2.0":
+"@aws-crypto/sha256-js@5.2.0", "@aws-crypto/sha256-js@^5.2.0":
   version "5.2.0"
   resolved "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz"
   integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
@@ -98,7 +97,7 @@
   dependencies:
     tslib "^2.6.2"
 
-"@aws-crypto/util@^5.2.0", "@aws-crypto/util@5.2.0":
+"@aws-crypto/util@5.2.0", "@aws-crypto/util@^5.2.0":
   version "5.2.0"
   resolved "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz"
   integrity sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==
@@ -672,6 +671,13 @@
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
 
+"@grammyjs/runner@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/@grammyjs/runner/-/runner-2.0.3.tgz"
+  integrity sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A==
+  dependencies:
+    abort-controller "^3.0.0"
+
 "@grammyjs/types@3.24.0":
   version "3.24.0"
   resolved "https://registry.npmjs.org/@grammyjs/types/-/types-3.24.0.tgz"
@@ -717,7 +723,7 @@
   resolved "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz"
   integrity sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==
 
-"@noble/hashes@^1.3.3", "@noble/hashes@1.8.0":
+"@noble/hashes@1.8.0", "@noble/hashes@^1.3.3":
   version "1.8.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -1243,7 +1249,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.15.0:
+acorn@^8.15.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -1285,18 +1291,18 @@ base64-js@^1.3.1:
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-better-sqlite3@^9.4.3:
-  version "9.6.0"
-  resolved "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz"
-  integrity sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==
-  dependencies:
-    bindings "^1.5.0"
-    prebuild-install "^7.1.1"
-
 better-sqlite3@11.10.0:
   version "11.10.0"
   resolved "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz"
   integrity sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==
+  dependencies:
+    bindings "^1.5.0"
+    prebuild-install "^7.1.1"
+
+better-sqlite3@^9.4.3:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-9.6.0.tgz#b01e58ba7c48abcdc0383b8301206ee2ab81d271"
+  integrity sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"
@@ -1394,6 +1400,14 @@ callsites@^3.0.0:
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+canvas@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz"
+  integrity sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==
+  dependencies:
+    node-addon-api "^7.0.0"
+    prebuild-install "^7.1.3"
+
 chalk@^4.0.0:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
@@ -1449,17 +1463,17 @@ cookie-parser@1.4.7:
     cookie "0.7.2"
     cookie-signature "1.0.6"
 
-cookie-signature@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz"
-  integrity sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==
-
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
-cookie@~0.7.1, cookie@0.7.2:
+cookie-signature@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz"
+  integrity sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==
+
+cookie@0.7.2, cookie@~0.7.1:
   version "0.7.2"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
@@ -1473,19 +1487,19 @@ cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@^4.3.1, debug@^4.3.2, debug@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
-
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^4.3.1, debug@^4.3.2, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 decompress-response@^6.0.0:
   version "6.0.0"
@@ -1504,12 +1518,12 @@ deep-is@^0.1.3:
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-depd@~2.0.0, depd@2.0.0:
+depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-destroy@~1.2.0, destroy@1.2.0:
+destroy@1.2.0, destroy@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
@@ -1602,7 +1616,7 @@ eslint-visitor-keys@^4.2.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
-"eslint@^6.0.0 || ^7.0.0 || >=8.0.0", eslint@^9.0.0:
+eslint@^9.0.0:
   version "9.39.3"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz"
   integrity sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==
@@ -2151,15 +2165,15 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   resolved "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-ms@^2.1.1, ms@^2.1.3, ms@2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
+ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 napi-build-utils@^2.0.0:
   version "2.0.0"
@@ -2182,6 +2196,11 @@ node-abi@^3.3.0:
   integrity sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==
   dependencies:
     semver "^7.3.5"
+
+node-addon-api@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz"
+  integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
 
 node-fetch@^2.7.0:
   version "2.7.0"
@@ -2272,7 +2291,7 @@ picocolors@^1.0.0, picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-prebuild-install@^7.1.1:
+prebuild-install@^7.1.1, prebuild-install@^7.1.3:
   version "7.1.3"
   resolved "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz"
   integrity sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==
@@ -2362,7 +2381,7 @@ resolve-from@^4.0.0:
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-safe-buffer@^5.0.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -2406,7 +2425,7 @@ serve-static@~1.16.2:
     parseurl "~1.3.3"
     send "~0.19.1"
 
-setprototypeof@~1.2.0, setprototypeof@1.2.0:
+setprototypeof@1.2.0, setprototypeof@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==


### PR DESCRIPTION
## Summary

Fixes the deterministic deadlock-by-origin documented in the prior audit. When an approval was requested from a tool call inside `bot.on('message:text')`'s `await agent.process(...)` chain, the user's `✅ <id>` reply could not be processed — the same handler instance that owns the reply parser was the one awaiting the approval Promise. Production: ~25 timeouts vs 1 success (`[7]`) over 5 days, with the lone success originating from a heartbeat task (outside the chat handler's await chain).

## Changes

### `src/channels/manager.js`
- Add dependency `@grammyjs/runner@2.0.3`.
- Extract approval-reply parser to `bot.hears(APPROVAL_REPLY_RE, …)` registered **before** `bot.on('message:text')`. Under the runner's concurrent middleware, emoji replies dispatch in parallel with any in-flight `agent.process()`.
- Replace `bot.start({drop_pending_updates:true})` with `run(bot, { runner: { fetch: { allowed_updates: ['message','callback_query'] } } })`. `drop_pending_updates` is still applied via the existing `deleteWebhook({drop_pending_updates:true})` at boot.
- Update `stop()` to call `_runner.stop()` for graceful shutdown.
- Extract `handleApprovalReply(ctx, { allowedUsers, approvals })` as an exported function so it's directly testable without spinning up a real Bot. The `bot.hears` callback is a one-line wrapper.

The existing `/approve <id>` and `/deny <id>` slash commands are untouched.

### `src/agents/registry.js`
- Concurrent dispatch would let two `agent.process()` calls for the same agent read the same history snapshot, run LLM in parallel, then write interleaved turns (audit §3 conversation-history hazard).
- Add a module-level per-agent async mutex (`Map<agentName, Promise>`) and a `_withAgentLock(name, fn)` helper. Reflex-tier responses skip the lock (no history I/O). Everything from `graphQuery` through the second `addMessage` is held under the lock — restoring the same serialization grammY's default sequential middleware used to give us.
- Extract the post-reflex body to `_processNonReflex(message, context, route, textMessage)` so the lock wrap doesn't reindent ~165 lines. No logic change.
- Export the helper as `__agentLockForTests` for the concurrency test only; not part of the runtime API.

## Tests

- `node tests/smoke.test.js` → **22/22** (was 21/22 — the local Mac `jsonwebtoken` ERR_MODULE_NOT_FOUND cleared by `npm install`).
- `node tests/approvals.test.js` → **13/13** (orphan-callback safety unchanged; added `process.exit(failed?1:0)` so the test process doesn't hang on armed 10-min timeouts).
- `node tests/approval-parser-handler.test.js` → **29/29** new — full regex input matrix from the prior spec (✅37, ✅ 37 thanks, NBSP, deny aliases, mid-message rejection, etc.) plus handler behaviour against a real `ExecApprovals` (authorized happy path, already-resolved branch, unauthorized silent ignore, nonexistent id → friendly NOT_FOUND reply, deny-with-tail-as-reason, `yes`/`no` aliases).
- `node tests/agent-mutex.test.js` → **7/7** new — same-key serialization (max concurrency = 1, traced enter/leave order), conversation history consistency under concurrent calls, different-key parallel execution (no head-of-line blocking across agents), lock release on throw, post-throw reacquire.

## Deploy (PM2 still owns the process — root's PM2, id 2)

```bash
ssh qclaw
sudo git -C /root/QClaw fetch origin
sudo git -C /root/QClaw merge --no-ff origin/fix/approval-gate-concurrency
sudo pm2 restart quantumclaw
sudo pm2 logs quantumclaw --lines 30
```

`/root/QClaw` still has the unpushed `26fe992` commit and the WIP files from the drift list — the `--no-ff` merge preserves them.

## Manual smoke (Tyson, from Telegram, after deploy)

- [ ] 1. Trigger any low-risk approval, capture `[id]`.
- [ ] 2. Reply `✅ <id>` → expect `✅ Approved [<id>].`, DB row flips to `approved`, original tool action proceeds.
- [ ] 3. Trigger another, reply `❌ <id> reason here` → expect `❌ Denied [<id>].`, DB row carries `reason='reason here'`.
- [ ] 4. Confirm pre-existing `/approve <id>` slash command still works.
- [ ] 5. **The headline test:** trigger an approval that comes from inside a Charlie chat reply (i.e., send Charlie a message that prompts a tool call requiring approval). Reply `✅ <id>` while Charlie is still composing a response. Should resolve under 5 seconds, not 10 minutes.
- [ ] 6. Trigger an approval and don't reply — confirm 10-minute timeout still fires.

## Out of scope (deferred, unchanged from prior list)

- Cognee reconnect storms (amplifier of slow chat handlers — not this PR).
- `/root/QClaw` ↔ `origin/main` drift cleanup (`26fe992` + WIP files).
- Local Mac PM2 zombie entry, plaintext credentials in local config — separate sessions.