### PR TITLE
fix(approvals): raw-fetch notifier — bypass bot.api.sendMessage silent-drop

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -1883,3 +1883,78 @@ rather than re-speccing from scratch.
 - [x] availableInMCP === true verified post-PUT
 - [x] Supabase update scoped to single row by primary key
 - [x] No stack traces exposed via Telegram errors
+
+---
+
+## 2026-04-28 — Approval notifier: bypass `bot.api.sendMessage` (raw fetch workaround)
+
+Workaround for a silent-drop on the outbound approval notifier path:
+`bot.api.sendMessage` from inside the `@grammyjs/runner`-managed process
+returned without error and without delivery. No "Telegram send failed"
+log line ever fired (catch never hit). Independent verification:
+- `curl https://api.telegram.org/bot$TOKEN/sendMessage` → delivered.
+- `new Bot(token).api.sendMessage(...)` from a one-shot script under
+  `/root/QClaw` (same node_modules, same `.env`) → delivered (msg id
+  `2843`).
+- The same call from inside the long-running QClaw process → no error,
+  no delivery.
+
+Root cause is suspected to be an interaction between the runner's
+update-fetch loop and the bot's outbound API client (possibly an
+internal queue / abort signal / connection-pool state). **Tracked as
+a separate investigation; not addressed in this PR.**
+
+### Change
+
+`src/index.js` notifier callback:
+- Replace `await bot.api.sendMessage(ownerChatId, text)` with a raw
+  `fetch('https://api.telegram.org/bot${token}/sendMessage', …)` POST.
+- Cache the bot token at notifier-wire time (one `secrets.get` call at
+  boot, not per-notification).
+- On HTTP 401, refresh the token from `secrets.get` once and retry —
+  so a BotFather rotation while the process is running doesn't
+  permanently wedge the notifier.
+- 10 s `AbortSignal.timeout` so a network stall can't hold up the
+  approval flow indefinitely.
+- Keep the `tgChannel` availability check as a fast-fail (channel never
+  came up → don't try to send), but the actual send no longer depends
+  on the bot reference.
+- Surface non-OK responses via `log.warn` with status + first 200 chars
+  of the body, so future failures are visible (this was the missing
+  signal that made the silent-drop hard to diagnose).
+
+The bot's own API client is still used for everything else (chat
+replies via `bot.on('message:text')`, `bot.command(...)` responses,
+the inline `bot.hears` approval-reply parser added in PR #2). The
+workaround is scoped to the single notifier callback.
+
+### Tests
+
+- `node tests/smoke.test.js` → 22/22
+- `node tests/approvals.test.js` → 13/13
+- Manual smoke (post-deploy, run by Tyson):
+  - [ ] Trigger an approval from Telegram (or via Charlie tool call).
+        Confirm `⚠️ Approval needed [N] …` arrives at chat
+        `1375806243` within 5 s.
+  - [ ] Reply `✅ <id>`. Confirm row resolves to `approved` and the
+        original tool action proceeds.
+  - [ ] Trigger another, wait 10 min without replying — confirm the
+        timeout still fires.
+
+### Branch / PR
+
+- `fix/notifier-raw-fetch`, off `origin/main` (`5a5b546`).
+- Single-file change to `src/index.js`. No new dependencies.
+- Deploy via `git merge --no-ff origin/fix/notifier-raw-fetch` onto
+  `/root/QClaw`'s local `main` (which already carries the concurrency
+  fix from PR #2). No conflicts expected — PR #2's changes are in
+  `src/channels/manager.js` + `src/agents/registry.js`, this PR only
+  touches `src/index.js`. After merge, `pm2 restart quantumclaw`.
+
+### Out of scope (deferred)
+
+- Root-cause analysis of why `bot.api.sendMessage` silently drops in
+  runner context. Separate investigation; not blocking the gate fix.
+- The previous Telegram-side 429/502 storm on the prior process
+  (PID 2230128) — already cleared by the post-rotation restart;
+  unrelated to this PR.

--- a/src/index.js
+++ b/src/index.js
@@ -433,21 +433,34 @@ class QuantumClaw {
       log.warn(`Channel startup failed: ${err.message} — dashboard still available`);
     }
 
-    // Wire Telegram approval notifier — resolves this.channels.bot at call
-    // time so the bot reference from a successful ChannelManager.startAll()
-    // is always used regardless of when this block ran. Send failures are
-    // caught inside so a broken notifier never breaks the approval flow.
+    // Wire Telegram approval notifier. Bypasses bot.api.sendMessage and hits
+    // Telegram's HTTP API directly — bot.api.sendMessage was observed to
+    // silently drop messages when called from inside the @grammyjs/runner-
+    // managed process (no error, no delivery; see 2026-04-28 build log).
+    // Root cause of the bot.api drop is tracked separately; this is a
+    // workaround that guarantees delivery via raw fetch.
     const ownerChatId = this.config.channels?.telegram?.ownerChatId || 1375806243;
     if (this.approvalGate) {
+      // Cache the token at wire time for perf, but allow refresh on 401 so a
+      // BotFather rotation while the process is running doesn't permanently
+      // wedge the notifier.
+      let cachedToken = (await this.secrets.get('telegram_bot_token'))?.trim() || null;
+      const refreshToken = async () => {
+        const t = (await this.secrets.get('telegram_bot_token'))?.trim();
+        if (t) cachedToken = t;
+        return cachedToken;
+      };
+
       this.approvalGate.setNotifier(async ({ id, agent, tool, action, detail, riskLevel }) => {
-        // ChannelManager is a manager over multiple channel instances; the
-        // grammy bot lives on the individual TelegramChannel accessible by name.
+        // Fast-fail if the channel never came up at all — keeps the message
+        // out of a state where it would be sent to a token-less bot. We don't
+        // depend on tgChannel.bot for the actual send.
         const tgChannel = this.channels?._channelsByName?.get('telegram');
-        const bot = tgChannel?.bot;
-        if (!bot?.api?.sendMessage) {
-          log.warn(`Approval notifier: Telegram bot unavailable (id=${id})`);
+        if (!tgChannel) {
+          log.warn(`Approval notifier: Telegram channel unavailable (id=${id})`);
           return;
         }
+
         const text =
           `⚠️ Approval needed [${id}]\n` +
           `Tool: ${tool}\n` +
@@ -456,13 +469,40 @@ class QuantumClaw {
           `Action: ${String(action || '').slice(0, 200)}\n` +
           (detail ? `\nDetail:\n${String(detail).slice(0, 500)}\n` : '') +
           `\nReply ✅ ${id} or ❌ ${id} — auto-denies after 10 min.`;
+
+        const send = (token) =>
+          fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ chat_id: ownerChatId, text }),
+            signal: AbortSignal.timeout(10000),
+          });
+
         try {
-          await bot.api.sendMessage(ownerChatId, text);
+          let token = cachedToken || (await refreshToken());
+          if (!token) {
+            log.warn(`Approval notifier: no bot token available (id=${id})`);
+            return;
+          }
+          let res = await send(token);
+          // Token rotation reload: a 401 from Telegram strongly implies the
+          // cached token is stale. Refresh once and retry; if the same value
+          // comes back, don't loop.
+          if (res.status === 401) {
+            const fresh = await refreshToken();
+            if (fresh && fresh !== token) {
+              res = await send(fresh);
+            }
+          }
+          if (!res.ok) {
+            const body = await res.text().catch(() => '');
+            log.warn(`Approval notifier: Telegram send failed (id=${id}, status=${res.status}): ${body.slice(0, 200)}`);
+          }
         } catch (err) {
-          log.warn(`Approval notifier: Telegram send failed (id=${id}): ${err.message}`);
+          log.warn(`Approval notifier: Telegram send error (id=${id}): ${err.message}`);
         }
       });
-      log.info('Approval gate Telegram notifier wired');
+      log.info('Approval gate Telegram notifier wired (raw fetch)');
     }
 
     // ── Layer 7: Dashboard (non-fatal but highly recommended) ──


### PR DESCRIPTION
## Summary

Workaround for the **silent-drop** on the approval notifier path. `bot.api.sendMessage` from inside the long-running `@grammyjs/runner`-managed process returns without error and without delivery — catch never fires, no `Telegram send failed` log line, no message at the user's Telegram.

Replaces the single `bot.api.sendMessage` call inside the notifier callback with a raw `fetch()` POST to `https://api.telegram.org/bot${token}/sendMessage`. Bypasses the bot's API client entirely.

## Why a workaround, not a root-cause fix

Independent verification rules out the env, token, network path, chat id, and the grammy library itself:
- `curl https://api.telegram.org/bot$TOKEN/sendMessage` — delivered.
- A one-shot `new Bot(token).api.sendMessage(...)` from inside `/root/QClaw` (same node_modules, same `.env`, same node version) — delivered (msg id `2843`).
- The same call from inside the long-running QClaw process — no error, no delivery.

The interaction between the runner's update-fetch loop and the bot's outbound API client is **tracked as a separate investigation** (deferred). This PR ships the unblocker.

## Change — single file

`src/index.js` notifier callback (lines ~436–466 → expanded):
- Replace `await bot.api.sendMessage(ownerChatId, text)` with raw `fetch(...)` POST. `Content-Type: application/json`, body `{chat_id, text}`, `signal: AbortSignal.timeout(10000)` so a network stall can't wedge the approval flow indefinitely.
- **Cache the token at wire time** — one `await this.secrets.get('telegram_bot_token')` at boot, not per-notification.
- **Reload-safe on rotation**: if Telegram returns `401`, refresh from `secrets.get` once and retry. If the same value comes back, don't loop.
- Keep the `tgChannel` availability check as a **fast-fail** (channel never came up → skip the send), but the actual send no longer depends on `tgChannel.bot`.
- **Surface non-OK responses** — `log.warn` with status code and the first 200 chars of the body. This was the missing signal that made the silent-drop hard to diagnose; future failures will be visible.

The bot's own API client is still used for everything else (chat replies, command responses, the `bot.hears` approval-reply parser added in PR #2). The workaround is scoped to the single notifier callback.

## Tests

- `node tests/smoke.test.js` → **22/22**
- `node tests/approvals.test.js` → **13/13**
- Manual (Tyson, post-deploy):
  - [ ] Trigger an approval. Confirm `⚠️ Approval needed [N] …` arrives at chat `1375806243` within 5 s.
  - [ ] Reply `✅ <id>`. Confirm row resolves to `approved` and the original tool action proceeds.
  - [ ] Trigger another, wait 10 min without replying — confirm the timeout still fires.

## Deploy

Branch is off `origin/main` (`5a5b546`). Production's local `main` already carries PR #2's concurrency fix (merge commit `8413b96`). Single-file change to `src/index.js`, no new dependencies, no conflicts expected.

```bash
ssh qclaw
sudo git -C /root/QClaw fetch origin
sudo git -C /root/QClaw merge --no-ff origin/fix/notifier-raw-fetch
sudo pm2 restart quantumclaw
sudo pm2 logs quantumclaw --lines 30
```

## Out of scope (deferred)

- Root-cause analysis of why `bot.api.sendMessage` silently drops in runner context. Separate investigation.
- The previous Telegram-side 429/502 storm on PID 2230128 — already cleared by the post-rotation restart at 06:53:40 UTC. Unrelated.