### PR TITLE
fix(approvals): unify request paths so notifier always fires

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -1883,3 +1883,88 @@ rather than re-speccing from scratch.
 - [x] availableInMCP === true verified post-PUT
 - [x] Supabase update scoped to single row by primary key
 - [x] No stack traces exposed via Telegram errors
+
+---
+
+## 2026-04-28 — Approval gate: unify request paths so notifier always fires
+
+The actual root cause of the production approval-gate failures.
+
+`src/tools/executor.js` calls `approvalGate.requestApproval(...)` for
+every tier-classified tool call inside `agent.process()`.
+`requestApproval` delegated straight to `approvals.request()` and
+**bypassed the notifier entirely**. Only `requestInlineApproval` (used by
+`shell_exec` and `n8n_workflow_update` directly) ever fired the
+notifier.
+
+Result: every executor-driven approval created a row, logged
+`⏸️  Approval required: …`, then sat invisible until the 10-min timeout
+denied it. No Telegram prompt was ever sent for those — which is why
+the logs showed `Approval needed: [N]` but no `Telegram send failed`,
+no `Telegram bot unavailable`, no `No notifier wired` warnings: the
+notifier code was never reached on that path. The PR #3 raw-fetch
+workaround for `bot.api.sendMessage` was real but addressed a
+*separate* silent-drop in the notifier transport, not the missing
+notifier dispatch on the executor path.
+
+### Change — single file
+
+`src/security/approval-gate.js` `requestApproval`:
+- Replace its body (which did `approvals.request(...)` directly) with
+  a delegation to `requestInlineApproval`. Same payload shape — `agent`,
+  `tool`, `action`, `detail`, `riskLevel`. Single approval-creation
+  code path. Single notifier dispatch.
+- Existing `log.warn('⏸️  Approval required: …')` line kept so log
+  format stays consistent with previous output.
+
+### Tests
+
+- `node tests/smoke.test.js` → 22/22
+- `node tests/approvals.test.js` → 13/13
+- `node tests/approval-gate-notifier.test.js` → **13/13** new
+  - notifier fires exactly once on `requestApproval`
+  - payload contains agent / tool / numeric id / riskLevel / action /
+    detail with the right shape
+  - works without a notifier (warns, still resolves)
+  - notifier-throws path is non-fatal (approval resolves regardless)
+  - `requestInlineApproval` (existing callers: `shell_exec`,
+    `n8n_workflow_update`) still fires the notifier — sanity check on
+    the shared code path
+
+### Deploy
+
+Branch off `origin/main` (`5a5b546`). Single-file change to
+`src/security/approval-gate.js` plus one new test file. No new deps.
+
+```
+ssh qclaw
+sudo git -C /root/QClaw fetch origin
+sudo git -C /root/QClaw merge --no-ff origin/fix/approval-gate-unify
+sudo pm2 restart quantumclaw
+sudo pm2 logs quantumclaw --lines 30
+```
+
+PR #2 (concurrency) and PR #3 (raw-fetch) are already on prod's local
+`main`. This PR layers on top — no conflicts expected on
+`approval-gate.js` (PR #2 didn't touch it; PR #3 didn't touch it).
+
+### Why earlier PRs missed this
+
+Both #2 and #3 were correct as far as they went, but neither path was
+the failing one in production:
+- #2 fixed the `bot.hears` reply parser and the agent concurrency
+  hazard. Needed for once approvals start arriving via Telegram.
+- #3 worked around the `bot.api.sendMessage` silent drop in runner
+  context. Needed for the notifier transport to actually reach
+  Telegram.
+- This PR fixes the *missing* notifier dispatch on the executor path.
+
+The three are independent and stack: the executor's approval row now
+fires the notifier (this PR) → the notifier sends via raw fetch (#3) →
+the user's `✅ <id>` reply arrives via concurrent middleware (#2) →
+the row resolves.
+
+### Out of scope (unchanged)
+
+- Root-cause investigation of why `bot.api.sendMessage` silently drops
+  in runner context. Tracked separately; PR #3's workaround stays.

--- a/src/security/approval-gate.js
+++ b/src/security/approval-gate.js
@@ -209,8 +209,19 @@ export class ApprovalGate {
 
     log.warn(`⏸️  Approval required: ${action}`);
 
-    const result = await this.approvals.request(agent, toolName, detail, riskLevel);
-    return result;
+    // Delegate to requestInlineApproval so the notifier always fires —
+    // there should be one approval-creation code path, not two.
+    // Pre-fix: this path called approvals.request() directly and bypassed
+    // the notifier, so executor-driven approvals (the path used by
+    // tier-classified tool calls in agent.process()) timed out silently
+    // with no Telegram prompt ever sent.
+    return this.requestInlineApproval({
+      agent,
+      tool: toolName,
+      action,
+      detail,
+      riskLevel,
+    });
   }
 
   /**

--- a/tests/approval-gate-notifier.test.js
+++ b/tests/approval-gate-notifier.test.js
@@ -1,0 +1,147 @@
+/**
+ * Approval gate — requestApproval must fire the notifier.
+ *
+ * Pre-fix: requestApproval called approvals.request() directly and bypassed
+ * the notifier entirely. The executor (src/tools/executor.js) hits this path
+ * for every tier-classified tool call, so production approvals from that
+ * path timed out silently — no Telegram prompt was ever sent.
+ *
+ * Post-fix: requestApproval delegates to requestInlineApproval, sharing the
+ * single notifier-firing approval-creation code path.
+ *
+ * Run: node tests/approval-gate-notifier.test.js
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ExecApprovals } from '../src/security/approvals.js';
+import { ApprovalGate } from '../src/security/approval-gate.js';
+
+const dir = mkdtempSync(join(tmpdir(), 'qclaw-gate-'));
+let passed = 0;
+let failed = 0;
+
+function check(label, cond, detail = '') {
+  if (cond) { console.log(`  ✓ ${label}`); passed++; }
+  else { console.error(`  ✗ ${label}${detail ? ' — ' + detail : ''}`); failed++; }
+}
+
+// Let pending microtasks drain so the await chain inside requestInlineApproval
+// reaches the notifier call before we assert.
+const tick = () => new Promise((r) => setImmediate(r));
+
+async function main() {
+  const approvals = new ExecApprovals({ _dir: dir });
+  approvals.attach(null); // JSON path so no SQLite dep
+
+  const gate = new ApprovalGate(approvals);
+
+  // ── 1. requestApproval fires the notifier with the right payload shape
+  const calls = [];
+  gate.setNotifier(async (payload) => { calls.push(payload); });
+
+  const p1 = gate.requestApproval(
+    'charlie',
+    'shell_exec',
+    { command: 'whoami' },
+    'high',
+  );
+  // Wait for the notifier to be invoked (it's awaited inside requestInlineApproval).
+  await tick();
+  await tick();
+
+  check('notifier fired exactly once', calls.length === 1,
+    `got ${calls.length} calls`);
+  check('notifier received agent="charlie"',
+    calls[0]?.agent === 'charlie');
+  check('notifier received tool="shell_exec"',
+    calls[0]?.tool === 'shell_exec');
+  check('notifier received numeric id',
+    Number.isInteger(calls[0]?.id) && calls[0].id > 0);
+  check('notifier received riskLevel="high"',
+    calls[0]?.riskLevel === 'high');
+  check('action string includes the tool name and args',
+    typeof calls[0]?.action === 'string'
+      && calls[0].action.includes('shell_exec')
+      && calls[0].action.includes('whoami'));
+  check('detail string includes agent name',
+    typeof calls[0]?.detail === 'string'
+      && calls[0].detail.includes('charlie'));
+
+  // Resolve so the test can finish — requestApproval awaits the approval.
+  approvals.approve(calls[0].id, 'tg:test');
+  const result1 = await p1;
+  check('returned promise resolves with approved:true',
+    result1?.approved === true && result1?.id === calls[0].id);
+
+  // ── 2. requestApproval still works when no notifier is wired
+  const gate2 = new ApprovalGate(approvals);
+  const p2 = gate2.requestApproval(
+    'charlie',
+    'n8n_workflow_update',
+    { workflowId: 'abc' },
+    'medium',
+  );
+  // Approve via the row id from pending() since no notifier captured it.
+  await tick();
+  const pendingNow = approvals.pending();
+  const id2 = pendingNow[0]?.id;
+  check('row was created even with no notifier',
+    Number.isInteger(id2));
+  approvals.approve(id2, 'tg:test');
+  const result2 = await p2;
+  check('no-notifier path still resolves correctly',
+    result2?.approved === true && result2?.id === id2);
+
+  // ── 3. notifier failure is non-fatal — approval still resolves
+  const gate3 = new ApprovalGate(approvals);
+  gate3.setNotifier(async () => { throw new Error('boom'); });
+
+  const p3 = gate3.requestApproval(
+    'charlie',
+    'shell_exec',
+    { command: 'ls' },
+    'low',
+  );
+  await tick();
+  await tick();
+  const id3 = approvals.pending()[0]?.id;
+  check('row created despite notifier throwing', Number.isInteger(id3));
+  approvals.approve(id3, 'tg:test');
+  const result3 = await p3;
+  check('approval resolves even when notifier throws',
+    result3?.approved === true);
+
+  // ── 4. requestInlineApproval (existing callers: shell_exec, n8n) still
+  //       fires the notifier — same code path, sanity check.
+  const gate4 = new ApprovalGate(approvals);
+  const calls4 = [];
+  gate4.setNotifier(async (payload) => { calls4.push(payload); });
+  const p4 = gate4.requestInlineApproval({
+    agent: 'charlie',
+    tool: 'shell_exec',
+    action: 'shell_exec({"command":"id"})',
+    detail: 'inline detail',
+    riskLevel: 'medium',
+  });
+  await tick();
+  await tick();
+  check('requestInlineApproval still fires notifier',
+    calls4.length === 1 && calls4[0].tool === 'shell_exec');
+  approvals.approve(calls4[0].id, 'tg:test');
+  await p4;
+}
+
+main()
+  .then(() => {
+    console.log(`\n${passed} passed, ${failed} failed`);
+    rmSync(dir, { recursive: true, force: true });
+    // approvals.request() arms 10-min setTimeouts; exit explicitly.
+    process.exit(failed > 0 ? 1 : 0);
+  })
+  .catch((err) => {
+    console.error('unexpected:', err);
+    rmSync(dir, { recursive: true, force: true });
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

**The actual root cause of the production approval-gate failures.**

`src/tools/executor.js` calls `approvalGate.requestApproval(...)` for every tier-classified tool call inside `agent.process()`. `requestApproval` delegated straight to `approvals.request()` and **bypassed the notifier entirely**. Only `requestInlineApproval` (used directly by `shell_exec` and `n8n_workflow_update`) ever fired the notifier.

Result: every executor-driven approval created a row, logged `⏸️  Approval required: …`, then sat invisible until the 10-min timeout denied it. No Telegram prompt was ever sent for those — which explains why production logs showed `Approval needed: [N]` but no `Telegram send failed`, no `Telegram bot unavailable`, no `No notifier wired` warnings: the notifier code was never reached on that path.

## Change — single file

`src/security/approval-gate.js` `requestApproval`:
- Replace its body (which did `await approvals.request(...)` directly) with a delegation to `requestInlineApproval` that builds the same `{ agent, tool, action, detail, riskLevel }` payload. Single approval-creation code path. Single notifier dispatch.
- Existing `log.warn('⏸️  Approval required: …')` line kept so log format stays consistent.

## How this stacks with #2 and #3

The three fixes are independent and address different parts of the chain:

| PR | Fixes |
|---|---|
| #2 — concurrency | `bot.hears` reply parser, agent `_withAgentLock` mutex, runner setup. Needed once approvals start arriving via Telegram. |
| #3 — raw fetch | `bot.api.sendMessage` silent-drop workaround on the notifier transport. Needed for the notifier transport to actually reach Telegram. |
| **this PR** | `requestApproval` now actually invokes the notifier. Needed so executor-path approvals reach the transport in the first place. |

Combined flow with all three landed: the executor's approval row fires the notifier (this PR) → the notifier sends via raw fetch (#3) → the user's `✅ <id>` reply arrives via concurrent middleware (#2) → the row resolves.

## Tests

- `node tests/smoke.test.js` → **22/22**
- `node tests/approvals.test.js` → **13/13**
- `node tests/approval-gate-notifier.test.js` → **13/13** new
  - notifier fires exactly once on `requestApproval`
  - payload contains `agent` / `tool` / numeric `id` / `riskLevel` / `action` / `detail` with the right shape
  - works without a notifier (warns, still resolves)
  - notifier-throws path is non-fatal (approval still resolves)
  - `requestInlineApproval` (existing direct callers) still fires the notifier — sanity check on the shared code path

## Deploy

Branch off `origin/main` (`5a5b546`). Single-file change to `src/security/approval-gate.js`, plus one new test file. No new dependencies.

```bash
ssh qclaw
sudo git -C /root/QClaw fetch origin
sudo git -C /root/QClaw merge --no-ff origin/fix/approval-gate-unify
sudo pm2 restart quantumclaw
sudo pm2 logs quantumclaw --lines 30
```

PRs #2 and #3 are already on prod's local `main`. This layers cleanly on top — no conflicts expected on `approval-gate.js` (#2 touched `channels/manager.js` + `agents/registry.js`; #3 touched `index.js`).

## Out of scope (unchanged)

- Root-cause investigation of why `bot.api.sendMessage` silently drops in runner context. Separate; PR #3's workaround stays.