### PR TITLE
fix(ghl-marketing): cap IG hashtags + promote error.description (Slice 2)

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -9047,3 +9047,153 @@ Reactivation gated on:
 1. Polymarket fund situation resolved
 2. trading-worker diagnostic + restart dispatch landed
 3. Confirmation that at least one Market Scanner manual run returns valid JSON end-to-end
+
+## 2026-05-13 — Slice 2: GHL Bug 3 fix (Cap Hashtags + Compute Final error promotion)
+
+Root cause for Bug 3 captured in `/tmp/ig_failure_a19997f3.md` (execution
+`940561`, draft `a19997f3-3a85-4ab2-94b8-f289564228b7`, 2026-05-13 19:40 UTC):
+the `IG Post (Blotato)` node failed with `error.description: "Instagram allows
+a maximum of 5 hashtags per post."` against an `instagram_caption` containing
+15 hashtags. Cap Hashtags pattern from commit `e4ad82c` (Apr 29) only landed
+on Infographic V2 (`kJ2EdkOeEAwVbMwU`) — the GHL Marketing Content Generator
+was never protected. Secondary issue: `Compute Final` in the GHL Publisher
+mapped only the synthesized top-level `json.error` string to
+`publish_errors.{platform}`, dropping the more diagnostic
+`runDataItem.error.description` field — so every Blotato failure logged the
+same useless generic message to Supabase.
+
+**Branch:** `cc/slice2-ghl-hashtag-cap-20260513` (created from `main` @
+`2e5d2cb`, after stashing pre-existing `src/memory/knowledge.js` WIP into
+`stash@{0}` — not authored by this session).
+
+### Workflows touched (both via PUT through `https://webhook.flowos.tech/api/v1`)
+
+**`Awo65rdSe5BvDHtC` — GHL Marketing: Content Generator (11 → 12 nodes)**
+
+- **Added Code node `Cap Hashtags`** at position `[1504, 304]`, typeVersion 2,
+  id `a1000001-0001-4000-8000-000000000020`. Mirrors the
+  `kJ2EdkOeEAwVbMwU > Cap Hashtags` pattern (`MAX_HASHTAGS=5`,
+  `caption.replace(/#\w+/g, ...)`), trimmed to the single
+  `instagram_caption` field that exists in the GHL schema. Whitespace
+  cleanup: collapses runs of spaces/tabs, drops indent on continuation
+  lines, caps consecutive blanks to one. Pass-through for empty / missing
+  / `≤5` hashtags. Emits `_hashtag_cap_applied: { max, original_count,
+  dropped, at }` metadata for forward visibility (not persisted — stripped
+  by `Save to Supabase`'s explicit field whitelist).
+- **Rewired connections:** `Assign Image URL → Cap Hashtags →
+  Save to Supabase` (was `Assign Image URL → Save to Supabase`). Insertion
+  point is last gate before persistence, so Cap Hashtags sees the
+  final-shape row including `image_url` — and `Save to Supabase`'s body is
+  unchanged (it whitelists fields via `JSON.stringify({...})` literal, so
+  `_hashtag_cap_applied` doesn't leak into the DB row).
+- Position-shifted `Save to Supabase`, `Send to Telegram`, `Heartbeat:
+  Success` right by `+160px` to make room. Other 8 nodes unchanged.
+
+**`fonuRTyqepxdyIdf` — GHL Marketing: Publisher (15 → 15 nodes, 1 node modified)**
+
+- **Compute Final** jsCode updated to read the runData item itself (sibling
+  fields `.json` and `.error`) instead of only `.json`, so that
+  `runDataItem.error.description` from `NodeApiError` can be promoted into
+  `publish_errors.{platform}`. Per-platform mapping order is now:
+  `node.error?.description → node.json.error.message → node.json.error.* →
+  node.json.message → generic fallback`. Existing LinkedIn `LI Guard`
+  short-circuit path preserved verbatim. FB Graph API success detection
+  (`.id && !.error`) preserved. No other nodes touched in this workflow.
+
+### PUT verification (live)
+
+- **Awo65rdSe5BvDHtC:** PUT `HTTP=200` @ `2026-05-13T20:29:42.993Z`. Re-GET
+  confirms 12 nodes, `Cap Hashtags` present, `Assign Image URL.main[0]` →
+  `Cap Hashtags`, `Cap Hashtags.main[0]` → `Save to Supabase`, and
+  `settings.availableInMCP=true`.
+- **fonuRTyqepxdyIdf:** PUT `HTTP=200` @ `2026-05-13T20:30:34.190Z`. Re-GET
+  confirms `Compute Final` jsCode contains `fb?.error?.description`,
+  `igB?.error?.description`, `li?.error?.description`, all existing
+  fallback chains intact (`fbJson?.error?.error_user_msg`, `guard.skip_linkedin`
+  path), and `settings.availableInMCP=true`.
+
+### `availableInMCP` re-enable mechanism (brief-conflict surfaced)
+
+Brief specified `POST /api/v1/workflows/{id}/setAvailableInMCP` with body
+`{"available": true}`. That endpoint returned `HTTP=405 POST method not
+allowed` on the live n8n. Canonical mechanism per
+`src/tools/n8n-workflow-update.js:171` is to include
+`availableInMCP: true` inside the workflow's `settings` object on the PUT
+body — n8n PUT does NOT auto-flip this to false on update (the live
+settings already had `availableInMCP: true` and the PUT preserved it).
+Brief was operating on stale info; corrected approach used. Re-GETs on
+both workflows confirm the flag remained `true` post-PUT.
+
+### Live drift (Awo65 only) — surfaced not fixed
+
+Diffing live vs `~/QClaw/n8n-workflows/Awo65rdSe5BvDHtC-*.json` (the
+pre-Slice-2 disk copy) showed:
+- Cosmetic node-position drift (~10px shifts across all nodes).
+- Live has NO `Supabase FSC` (`Nd2uuX5t9KEwbQPv`) credential reference on
+  `Fetch Recent Hooks` / `Save to Supabase`; disk had the no-op empty
+  reference. Consistent with `project_n8n_supabase_fsc_credential.md` — the
+  FSC credential is empty httpHeaderAuth, auth happens via inline
+  `$env.SUPABASE_ANON_KEY` headers. Not load-bearing.
+- Live omits explicit `"method": "GET"` on `Fetch Recent Hooks` (defaults
+  to GET); disk had it explicit.
+
+Worked from LIVE for the PUT (single source of truth). Disk JSONs refreshed
+from post-PUT GETs, so any prior drift is overwritten with the new live state.
+
+### Smoke tests
+
+**Cap Hashtags (Content Generator):** Public n8n REST API does not expose
+ad-hoc execution of scheduled workflows (brief allowed UI fallback); live
+trigger would also burn a Claude API call + insert a `pending_approval`
+row, so I used the brief's static-equivalent: replicated the live jsCode
+locally and ran it against the exact `instagram_caption` from execution
+`940561` (the one that caused Bug 3). Output: 15 hashtags → 5, first 5
+kept (`#gohighlevel #ghl #automation #workflows #saas`), 10 dropped, all
+other row fields preserved verbatim, `_hashtag_cap_applied` metadata
+populated. Edge cases: empty caption pass-through, missing caption
+pass-through, `≤5` hashtags pass-through (dropped=0). The node body served
+by n8n is what was tested (pulled via re-GET, not the pre-PUT version).
+**No row written to `marketing_drafts`. No Claude / Telegram / Supabase
+call made for the smoke.**
+
+**Compute Final (Publisher):** Per brief, no live re-publish (would create
+duplicates on FB/LinkedIn). Static read of post-PUT jsCode confirms
+description-promotion for all three platforms with existing fallback
+chains preserved.
+
+### Security gate
+
+- [x] No hardcoded credentials added — Cap Hashtags is logic-only; Compute
+  Final reads existing in-runData error fields. Confirmed by static grep:
+  no `Bearer `, `api_key`, `token=`, `password=` strings introduced.
+- [x] No new webhooks (no webhook nodes added).
+- [x] No new endpoints.
+- [x] No RLS changes (no schema or policy touched).
+- [x] No financial features touched.
+- [x] `~/.quantumclaw/.env` and `/home/n8nadmin/n8n-project/.env` perms
+      unchanged at 600 — neither file written.
+- [x] `availableInMCP: true` re-confirmed via re-GET on both workflows
+      (location: `settings.availableInMCP`, not top-level).
+- [x] No stack traces or secrets exposed in error mappings — Compute Final
+      reads only `error.description` + `error.message` strings, no auth
+      payloads. `_hashtag_cap_applied` carries integer counts + ISO
+      timestamp only, no PII.
+
+### Out of scope (defer)
+
+- LinkedIn media wiring (`postContentMediaUrls`) — Slice 3.
+- Crete pipeline (Image Router gating + FB/LI media wiring) — Slice 4.
+- Regenerate-wipes-image_url investigation — Slice 1.5.
+- Prompt-level hashtag instruction tightening — backlog.
+- Republishing `a19997f3` — Tyson decided to accept partial, move on.
+
+### References
+
+- `/tmp/ig_failure_a19997f3.md` — root-cause dump for Bug 3.
+- `/tmp/marketing_image_audit_20260513.md` — full audit verdict (Bugs 1+2+3
+  context, brief-conflict log).
+- Commit `e4ad82c` — Cap Hashtags pattern source (Infographic V2,
+  `kJ2EdkOeEAwVbMwU`).
+- Memory: `project_n8n_qclaw_topology.md` (PUT body shape `{name, nodes,
+  connections, settings}`).
+- Memory: `project_n8n_supabase_fsc_credential.md` (FSC credential is no-op).

--- a/n8n-workflows/Awo65rdSe5BvDHtC-ghl-marketing-content-generator.json
+++ b/n8n-workflows/Awo65rdSe5BvDHtC-ghl-marketing-content-generator.json
@@ -1,7 +1,11 @@
 {
+  "updatedAt": "2026-05-13T20:29:42.993Z",
+  "createdAt": "2026-04-13T12:03:02.932Z",
   "id": "Awo65rdSe5BvDHtC",
   "name": "GHL Marketing: Content Generator",
   "description": null,
+  "active": true,
+  "isArchived": false,
   "nodes": [
     {
       "parameters": {
@@ -19,8 +23,8 @@
       "type": "n8n-nodes-base.scheduleTrigger",
       "typeVersion": 1.2,
       "position": [
-        200,
-        300
+        208,
+        304
       ]
     },
     {
@@ -32,13 +36,12 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        420,
-        300
+        432,
+        304
       ]
     },
     {
       "parameters": {
-        "method": "GET",
         "url": "https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts?select=hooks_used,instagram_hook_text&status=eq.published&order=created_at.desc&limit=10",
         "sendHeaders": true,
         "headerParameters": {
@@ -67,14 +70,8 @@
       "typeVersion": 4.2,
       "position": [
         640,
-        300
+        304
       ],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "Nd2uuX5t9KEwbQPv",
-          "name": "Supabase FSC"
-        }
-      },
       "alwaysOutputData": true
     },
     {
@@ -86,14 +83,16 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        860,
-        300
+        864,
+        304
       ]
     },
     {
       "parameters": {
         "method": "POST",
         "url": "https://api.anthropic.com/v1/messages",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -116,17 +115,15 @@
               "responseFormat": "json"
             }
           }
-        },
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth"
+        }
       },
       "id": "a1000001-0001-4000-8000-000000000005",
       "name": "Generate Content (Claude)",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        1080,
-        300
+        1088,
+        304
       ],
       "credentials": {
         "httpHeaderAuth": {
@@ -144,8 +141,8 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1300,
-        300
+        1248,
+        304
       ]
     },
     {
@@ -189,15 +186,9 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        1520,
-        300
-      ],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "Nd2uuX5t9KEwbQPv",
-          "name": "Supabase FSC"
-        }
-      }
+        1744,
+        304
+      ]
     },
     {
       "parameters": {
@@ -212,9 +203,10 @@
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
       "position": [
-        1740,
-        300
+        1904,
+        304
       ],
+      "webhookId": "78c28696-5041-402a-a116-2f5c00bc05d3",
       "credentials": {
         "telegramApi": {
           "id": "UR6xX8CchGBKaP3h",
@@ -231,8 +223,21 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1410,
-        300
+        1424,
+        304
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Cap IG hashtags to 5; defensive against AI drift\n// Pattern source: kJ2EdkOeEAwVbMwU 'Cap Hashtags' (commit e4ad82c, Apr 29)\nconst MAX_HASHTAGS = 5;\nconst item = $input.first().json;\nconst caption = item.instagram_caption;\nif (typeof caption !== 'string' || !caption) {\n  return [{ json: item }];\n}\nlet count = 0;\nconst stripped = caption.replace(/#\\w+/g, (m) => (++count <= MAX_HASHTAGS ? m : ''));\nconst cleaned = stripped\n  .replace(/[ \\t]+/g, ' ')\n  .replace(/\\n[ \\t]+/g, '\\n')\n  .replace(/\\n{3,}/g, '\\n\\n')\n  .trim();\nreturn [{\n  json: {\n    ...item,\n    instagram_caption: cleaned,\n    _hashtag_cap_applied: { max: MAX_HASHTAGS, original_count: count, dropped: Math.max(0, count - MAX_HASHTAGS), at: new Date().toISOString() }\n  }\n}];"
+      },
+      "id": "a1000001-0001-4000-8000-000000000020",
+      "name": "Cap Hashtags",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1504,
+        304
       ]
     },
     {
@@ -245,20 +250,20 @@
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
       "position": [
-        400,
-        300
+        432,
+        544
       ],
+      "retryOnFail": true,
+      "maxTries": 2,
+      "waitBetweenTries": 2000,
+      "id": "66497534-563c-4884-a001-87c1125f6b07",
       "credentials": {
         "postgres": {
           "id": "qGUxEHfEZkZGdAcZ",
           "name": "Supabase Postgres DB"
         }
       },
-      "continueOnFail": true,
-      "retryOnFail": true,
-      "maxTries": 2,
-      "waitBetweenTries": 2000,
-      "id": "66497534-563c-4884-a001-87c1125f6b07"
+      "continueOnFail": true
     },
     {
       "parameters": {
@@ -270,20 +275,20 @@
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
       "position": [
-        1990,
-        300
+        2160,
+        304
       ],
+      "retryOnFail": true,
+      "maxTries": 2,
+      "waitBetweenTries": 2000,
+      "id": "b42f1173-aba3-4e18-8688-234a00bd876d",
       "credentials": {
         "postgres": {
           "id": "qGUxEHfEZkZGdAcZ",
           "name": "Supabase Postgres DB"
         }
       },
-      "continueOnFail": true,
-      "retryOnFail": true,
-      "maxTries": 2,
-      "waitBetweenTries": 2000,
-      "id": "b42f1173-aba3-4e18-8688-234a00bd876d"
+      "continueOnFail": true
     }
   ],
   "connections": {
@@ -373,7 +378,7 @@
       "main": [
         [
           {
-            "node": "Save to Supabase",
+            "node": "Cap Hashtags",
             "type": "main",
             "index": 0
           }
@@ -395,11 +400,519 @@
           }
         ]
       ]
+    },
+    "Cap Hashtags": {
+      "main": [
+        [
+          {
+            "node": "Save to Supabase",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
   "settings": {
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": true
+  },
+  "staticData": {
+    "node:Cron MWF 07:00 UTC": {
+      "recurrenceRules": []
+    }
+  },
+  "meta": null,
+  "pinData": {},
+  "versionId": "9404b9b6-a95d-4610-9932-7864f158fd7d",
+  "activeVersionId": "9404b9b6-a95d-4610-9932-7864f158fd7d",
+  "versionCounter": 69,
+  "triggerCount": 1,
+  "shared": [
+    {
+      "updatedAt": "2026-04-13T12:03:02.932Z",
+      "createdAt": "2026-04-13T12:03:02.932Z",
+      "role": "workflow:owner",
+      "workflowId": "Awo65rdSe5BvDHtC",
+      "projectId": "KwpTDWcFWL3DfyW3",
+      "project": {
+        "updatedAt": "2026-04-08T20:28:08.726Z",
+        "createdAt": "2025-06-06T11:27:14.830Z",
+        "id": "KwpTDWcFWL3DfyW3",
+        "name": "Tyson Venables <tysonvenables@protonmail.com>",
+        "type": "personal",
+        "icon": null,
+        "description": null,
+        "creatorId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+        "projectRelations": [
+          {
+            "updatedAt": "2025-06-06T11:27:14.830Z",
+            "createdAt": "2025-06-06T11:27:14.830Z",
+            "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+            "projectId": "KwpTDWcFWL3DfyW3",
+            "user": {
+              "updatedAt": "2026-05-13T02:04:11.362Z",
+              "createdAt": "2025-06-06T11:27:13.858Z",
+              "id": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+              "email": "tysonvenables@protonmail.com",
+              "firstName": "Tyson",
+              "lastName": "Venables",
+              "personalizationAnswers": {
+                "version": "v4",
+                "personalization_survey_submitted_at": "2025-06-06T11:42:52.454Z",
+                "personalization_survey_n8n_version": "1.95.3",
+                "companySize": "<20",
+                "companyType": "saas",
+                "role": "business-owner",
+                "reportedSource": "friend"
+              },
+              "settings": {
+                "userActivated": true,
+                "easyAIWorkflowOnboarded": true,
+                "firstSuccessfulWorkflowId": "WVXrFCjb8wO7RWRX",
+                "userActivatedAt": 1751062185356,
+                "npsSurvey": {
+                  "responded": true,
+                  "lastShownAt": 1769430963515
+                }
+              },
+              "disabled": false,
+              "mfaEnabled": false,
+              "lastActiveAt": "2026-05-13",
+              "isPending": false
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "tags": [],
+  "activeVersion": {
+    "updatedAt": "2026-05-13T20:29:42.997Z",
+    "createdAt": "2026-05-13T20:29:42.997Z",
+    "versionId": "9404b9b6-a95d-4610-9932-7864f158fd7d",
+    "workflowId": "Awo65rdSe5BvDHtC",
+    "nodes": [
+      {
+        "parameters": {
+          "rule": {
+            "interval": [
+              {
+                "field": "cronExpression",
+                "expression": "0 7 * * 1,3,5"
+              }
+            ]
+          }
+        },
+        "id": "a1000001-0001-4000-8000-000000000001",
+        "name": "Cron MWF 07:00 UTC",
+        "type": "n8n-nodes-base.scheduleTrigger",
+        "typeVersion": 1.2,
+        "position": [
+          208,
+          304
+        ]
+      },
+      {
+        "parameters": {
+          "jsCode": "const dayOfWeek = new Date().getDay();\nconst postTypes = { 1: 'pain-led', 3: 'value-led', 5: 'offer-led' };\nconst postType = postTypes[dayOfWeek] || 'value-led';\nreturn [{ json: { postType, date: new Date().toISOString().split('T')[0] } }];"
+        },
+        "id": "a1000001-0001-4000-8000-000000000002",
+        "name": "Determine Post Type",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          432,
+          304
+        ]
+      },
+      {
+        "parameters": {
+          "url": "https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts?select=hooks_used,instagram_hook_text&status=eq.published&order=created_at.desc&limit=10",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+              }
+            ]
+          },
+          "options": {
+            "response": {
+              "response": {
+                "responseFormat": "json"
+              }
+            }
+          }
+        },
+        "id": "a1000001-0001-4000-8000-000000000003",
+        "name": "Fetch Recent Hooks",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          640,
+          304
+        ],
+        "alwaysOutputData": true
+      },
+      {
+        "parameters": {
+          "jsCode": "const postType = $('Determine Post Type').first().json.postType;\nconst recentRows = $input.first().json;\nlet recentHooks = [];\nif (Array.isArray(recentRows)) {\n  recentRows.forEach(r => {\n    if (r.instagram_hook_text) recentHooks.push(r.instagram_hook_text);\n    if (Array.isArray(r.hooks_used)) recentHooks.push(...r.hooks_used);\n  });\n}\nrecentHooks = [...new Set(recentHooks)];\nreturn [{ json: { postType, recentHooks: recentHooks.join(', ') || 'none' } }];"
+        },
+        "id": "a1000001-0001-4000-8000-000000000004",
+        "name": "Prepare Prompt Data",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          864,
+          304
+        ]
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "https://api.anthropic.com/v1/messages",
+          "authentication": "genericCredentialType",
+          "genericAuthType": "httpHeaderAuth",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "anthropic-version",
+                "value": "2023-06-01"
+              },
+              {
+                "name": "content-type",
+                "value": "application/json"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ model: 'claude-sonnet-4-20250514', max_tokens: 2000, system: \"You are a marketing copywriter for GHL Support Specialist. Product: AI-powered 24/7 support for GoHighLevel users. URL: support.flowos.tech/ghl/landing. Price: $29/month or $290/year. Founders Offer: first 50 members get 3 months free with code GHLPOWER50.\\n\\nTone: Direct, practical, slightly irreverent. Speak like a GHL power user. No corporate language. Short sentences. No em dashes. No hashtags in body copy (Instagram hashtags go in a separate block).\\n\\nNever say: game-changer, revolutionary, unlock your potential, or generic SaaS language.\\n\\nThree pain points to rotate:\\n1. Time lost \\u2014 hours in YouTube, Facebook groups, help docs\\n2. Support frustration \\u2014 tickets take days, group answers unreliable\\n3. Confidence gap \\u2014 'I know GHL can do this, I just don't know how'\\n\\nOne promise: Ask it anything about GHL. Get an expert answer in seconds.\\n\\nUse specific GHL terms: workflows, automations, pipelines, funnels, SaaS mode, merge fields, calendars, triggers, actions.\", messages: [{ role: 'user', content: 'Generate a ' + $json.postType + ' organic post for GHL Support Specialist. Today is ' + new Date().toLocaleDateString('en-US', {weekday:'long',month:'long',day:'numeric'}) + '.\\n\\nProvide output as JSON with these exact keys:\\n- facebook_post (plain text, no hashtags, 100-200 words)\\n- linkedin_post (plain text, no hashtags, 80-150 words)\\n- instagram_caption (with hashtag block at end, 60-120 words before hashtags)\\n- instagram_hook_text (5-8 words, overlay text for image)\\n- ad_headline (under 10 words)\\n- ad_body (80-120 words, includes pain point + solution + Founders Offer + URL with UTMs: support.flowos.tech/ghl/landing?utm_source=facebook&utm_medium=paid_social&utm_campaign=founders_offer)\\n- ad_cta (3-4 words for button text)\\n- retargeting_copy (60-100 words, acknowledges they visited, restates value, urgency)\\n\\nDo NOT repeat any of these recently used hooks: ' + $json.recentHooks + '\\n\\nReturn ONLY valid JSON. No markdown fences. No explanation.' }] }) }}",
+          "options": {
+            "response": {
+              "response": {
+                "responseFormat": "json"
+              }
+            }
+          }
+        },
+        "id": "a1000001-0001-4000-8000-000000000005",
+        "name": "Generate Content (Claude)",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1088,
+          304
+        ],
+        "credentials": {
+          "httpHeaderAuth": {
+            "id": "V9YcuDfp9lqydyDH",
+            "name": "Anthropic Header Auth"
+          }
+        }
+      },
+      {
+        "parameters": {
+          "jsCode": "const response = $input.first().json;\nconst content = response.content?.[0]?.text;\nif (!content) throw new Error('No content in Claude response: ' + JSON.stringify(response).substring(0, 500));\n\nlet parsed;\ntry {\n  const cleaned = content.replace(/```json\\n?/g, '').replace(/```\\n?/g, '').trim();\n  parsed = JSON.parse(cleaned);\n} catch (e) {\n  throw new Error('Failed to parse Claude response: ' + e.message + '\\nRaw: ' + content.substring(0, 500));\n}\n\nreturn [{\n  json: {\n    ...parsed,\n    post_type: $('Determine Post Type').first().json.postType,\n    status: 'pending_approval'\n  }\n}];"
+        },
+        "id": "a1000001-0001-4000-8000-000000000006",
+        "name": "Parse Response",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          1248,
+          304
+        ]
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "name": "Prefer",
+                "value": "return=representation"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ post_type: $json.post_type, status: 'pending_approval', facebook_post: $json.facebook_post, linkedin_post: $json.linkedin_post, instagram_caption: $json.instagram_caption, instagram_hook_text: $json.instagram_hook_text, ad_headline: $json.ad_headline, ad_body: $json.ad_body, ad_cta: $json.ad_cta, retargeting_copy: $json.retargeting_copy, hooks_used: [$json.instagram_hook_text], image_url: $json.image_url }) }}",
+          "options": {
+            "response": {
+              "response": {
+                "responseFormat": "json"
+              }
+            }
+          }
+        },
+        "id": "a1000001-0001-4000-8000-000000000007",
+        "name": "Save to Supabase",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1744,
+          304
+        ]
+      },
+      {
+        "parameters": {
+          "chatId": "1375806243",
+          "text": "=\ud83d\udce3 <b>New GHL marketing draft ready for review</b>\nType: {{ $('Parse Response').first().json.post_type }}\nDraft ID: <code>{{ $json[0].id }}</code>\n\nReview at https://agentboardroom.flowos.tech (GHL Marketing tab).",
+          "additionalFields": {
+            "parse_mode": "HTML"
+          }
+        },
+        "id": "a1000001-0001-4000-8000-000000000008",
+        "name": "Send to Telegram",
+        "type": "n8n-nodes-base.telegram",
+        "typeVersion": 1.2,
+        "position": [
+          1904,
+          304
+        ],
+        "webhookId": "78c28696-5041-402a-a116-2f5c00bc05d3",
+        "credentials": {
+          "telegramApi": {
+            "id": "UR6xX8CchGBKaP3h",
+            "name": "Flow States Ads Bot"
+          }
+        }
+      },
+      {
+        "parameters": {
+          "jsCode": "// Map post_type -> R2 template URL; rotation for Mon/Wed/Fri.\nconst BASE = 'https://pub-1fa192ebc8ff40dba2b9a0f1890e6f7a.r2.dev/marketing-templates';\nconst IMAGE_MAP = {\n  'pain-led':  BASE + '/ghl-template-pain-led.jpg',\n  'value-led': BASE + '/ghl-template-value-led.jpg',\n  'offer-led': BASE + '/ghl-template-offer-led.jpg'\n};\nconst draft = $input.first().json;\nconst image_url = IMAGE_MAP[draft.post_type] || IMAGE_MAP['value-led'];\nreturn [{ json: { ...draft, image_url } }];"
+        },
+        "id": "a1000001-0001-4000-8000-000000000009",
+        "name": "Assign Image URL",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          1424,
+          304
+        ]
+      },
+      {
+        "parameters": {
+          "jsCode": "// Cap IG hashtags to 5; defensive against AI drift\n// Pattern source: kJ2EdkOeEAwVbMwU 'Cap Hashtags' (commit e4ad82c, Apr 29)\nconst MAX_HASHTAGS = 5;\nconst item = $input.first().json;\nconst caption = item.instagram_caption;\nif (typeof caption !== 'string' || !caption) {\n  return [{ json: item }];\n}\nlet count = 0;\nconst stripped = caption.replace(/#\\w+/g, (m) => (++count <= MAX_HASHTAGS ? m : ''));\nconst cleaned = stripped\n  .replace(/[ \\t]+/g, ' ')\n  .replace(/\\n[ \\t]+/g, '\\n')\n  .replace(/\\n{3,}/g, '\\n\\n')\n  .trim();\nreturn [{\n  json: {\n    ...item,\n    instagram_caption: cleaned,\n    _hashtag_cap_applied: { max: MAX_HASHTAGS, original_count: count, dropped: Math.max(0, count - MAX_HASHTAGS), at: new Date().toISOString() }\n  }\n}];"
+        },
+        "id": "a1000001-0001-4000-8000-000000000020",
+        "name": "Cap Hashtags",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          1504,
+          304
+        ]
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'started'::text, 'GHL Marketing: Content Generator'::text, '{{ $execution.id }}'::text);",
+          "options": {}
+        },
+        "name": "Heartbeat: Start",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          432,
+          544
+        ],
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "66497534-563c-4884-a001-87c1125f6b07",
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'success'::text, 'GHL Marketing: Content Generator'::text, '{{ $execution.id }}'::text);",
+          "options": {}
+        },
+        "name": "Heartbeat: Success",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          2160,
+          304
+        ],
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "b42f1173-aba3-4e18-8688-234a00bd876d",
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true
+      }
+    ],
+    "connections": {
+      "Cron MWF 07:00 UTC": {
+        "main": [
+          [
+            {
+              "node": "Determine Post Type",
+              "type": "main",
+              "index": 0
+            },
+            {
+              "node": "Heartbeat: Start",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Determine Post Type": {
+        "main": [
+          [
+            {
+              "node": "Fetch Recent Hooks",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Fetch Recent Hooks": {
+        "main": [
+          [
+            {
+              "node": "Prepare Prompt Data",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Prepare Prompt Data": {
+        "main": [
+          [
+            {
+              "node": "Generate Content (Claude)",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Generate Content (Claude)": {
+        "main": [
+          [
+            {
+              "node": "Parse Response",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Parse Response": {
+        "main": [
+          [
+            {
+              "node": "Assign Image URL",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Save to Supabase": {
+        "main": [
+          [
+            {
+              "node": "Send to Telegram",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Assign Image URL": {
+        "main": [
+          [
+            {
+              "node": "Cap Hashtags",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Heartbeat: Start": {
+        "main": [
+          []
+        ]
+      },
+      "Send to Telegram": {
+        "main": [
+          [
+            {
+              "node": "Heartbeat: Success",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Cap Hashtags": {
+        "main": [
+          [
+            {
+              "node": "Save to Supabase",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      }
+    },
+    "authors": "Tyson Venables",
+    "name": null,
+    "description": null,
+    "autosaved": false,
+    "workflowPublishHistory": [
+      {
+        "createdAt": "2026-05-13T20:29:43.194Z",
+        "id": 966,
+        "workflowId": "Awo65rdSe5BvDHtC",
+        "versionId": "9404b9b6-a95d-4610-9932-7864f158fd7d",
+        "event": "activated",
+        "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d"
+      }
+    ]
   }
 }

--- a/n8n-workflows/fonuRTyqepxdyIdf-ghl-marketing-publisher.json
+++ b/n8n-workflows/fonuRTyqepxdyIdf-ghl-marketing-publisher.json
@@ -1,7 +1,11 @@
 {
+  "updatedAt": "2026-05-13T20:30:34.190Z",
+  "createdAt": "2026-04-13T13:10:45.173Z",
   "id": "fonuRTyqepxdyIdf",
   "name": "GHL Marketing: Publisher",
   "description": null,
+  "active": true,
+  "isArchived": false,
   "nodes": [
     {
       "parameters": {
@@ -204,7 +208,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Inspect every platform node's run result and assemble final publish state.\nconst prep = $('Prepare').first().json;\nconst guard = $('LI Guard Apply').first().json;\n\nconst published = [];\nconst errors = {};\n\nconst readNode = (name) => {\n  try { return $(name).first()?.json; } catch { return undefined; }\n};\n\n// Facebook: Graph API returns { id: '...' } on success; error has { error: {...} }.\nconst fb = readNode('Facebook Post');\nif (fb && fb.id && !fb.error) published.push('facebook');\nelse errors.facebook = fb?.error?.message || fb?.error?.error_user_msg || fb?.message || 'unknown error';\n\n// Instagram via Blotato.\nconst igB = readNode('IG Post (Blotato)');\nif (igB && !igB.error) {\n  published.push('instagram');\n} else {\n  errors.instagram = igB?.error?.message\n    || igB?.error\n    || igB?.message\n    || 'unknown Blotato IG error';\n}\n\n// LinkedIn: skipped (4h guard) OR Blotato success.\nif (guard.skip_linkedin) {\n  errors.linkedin = guard.linkedin_skip_reason || 'skipped by 4h guard';\n} else {\n  const li = readNode('LinkedIn Post (Blotato)');\n  if (li && !li.error) published.push('linkedin');\n  else errors.linkedin = li?.error?.message || li?.message || 'unknown LinkedIn error';\n}\n\nconst all_ok = Object.keys(errors).length === 0;\nconst status = all_ok ? 'published' : 'partially_published';\n\nreturn [{\n  json: {\n    ...prep,\n    published_platforms: published,\n    publish_errors: errors,\n    final_status: status,\n    now_iso: new Date().toISOString(),\n  }\n}];"
+        "jsCode": "// Inspect every platform node's run result and assemble final publish state.\nconst prep = $('Prepare').first().json;\nconst guard = $('LI Guard Apply').first().json;\n\nconst published = [];\nconst errors = {};\n\n// Read the runData item itself (sibling fields .json and .error) so we can promote\n// the diagnostic NodeApiError.description (e.g. Blotato hashtag-cap reason)\n// rather than the synthesized generic top-level json.error string.\nconst readNode = (name) => {\n  try { return $(name).first(); } catch { return undefined; }\n};\n\n// Facebook: Graph API returns { id: '...' } on success; error has { error: {...} } in body.\nconst fb = readNode('Facebook Post');\nconst fbJson = fb?.json;\nif (fbJson?.id && !fbJson?.error) {\n  published.push('facebook');\n} else {\n  errors.facebook = fb?.error?.description\n    || fbJson?.error?.message\n    || fbJson?.error?.error_user_msg\n    || fbJson?.message\n    || 'unknown error';\n}\n\n// Instagram via Blotato.\nconst igB = readNode('IG Post (Blotato)');\nconst igJson = igB?.json;\nif (igJson && !igJson.error) {\n  published.push('instagram');\n} else {\n  errors.instagram = igB?.error?.description\n    || igJson?.error?.message\n    || igJson?.error\n    || igJson?.message\n    || 'unknown Blotato IG error';\n}\n\n// LinkedIn: skipped (4h guard) OR Blotato success.\nif (guard.skip_linkedin) {\n  errors.linkedin = guard.linkedin_skip_reason || 'skipped by 4h guard';\n} else {\n  const li = readNode('LinkedIn Post (Blotato)');\n  const liJson = li?.json;\n  if (liJson && !liJson.error) {\n    published.push('linkedin');\n  } else {\n    errors.linkedin = li?.error?.description\n      || liJson?.error?.message\n      || liJson?.message\n      || 'unknown LinkedIn error';\n  }\n}\n\nconst all_ok = Object.keys(errors).length === 0;\nconst status = all_ok ? 'published' : 'partially_published';\n\nreturn [{\n  json: {\n    ...prep,\n    published_platforms: published,\n    publish_errors: errors,\n    final_status: status,\n    now_iso: new Date().toISOString(),\n  }\n}];"
       },
       "id": "p0000001-0001-4000-8000-00000000000b",
       "name": "Compute Final",
@@ -546,5 +550,631 @@
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": true
+  },
+  "staticData": null,
+  "meta": null,
+  "pinData": {},
+  "versionId": "8c42e108-e51f-403a-ba09-55599047b7a1",
+  "activeVersionId": "8c42e108-e51f-403a-ba09-55599047b7a1",
+  "versionCounter": 114,
+  "triggerCount": 1,
+  "shared": [
+    {
+      "updatedAt": "2026-04-13T13:10:45.173Z",
+      "createdAt": "2026-04-13T13:10:45.173Z",
+      "role": "workflow:owner",
+      "workflowId": "fonuRTyqepxdyIdf",
+      "projectId": "KwpTDWcFWL3DfyW3",
+      "project": {
+        "updatedAt": "2026-04-08T20:28:08.726Z",
+        "createdAt": "2025-06-06T11:27:14.830Z",
+        "id": "KwpTDWcFWL3DfyW3",
+        "name": "Tyson Venables <tysonvenables@protonmail.com>",
+        "type": "personal",
+        "icon": null,
+        "description": null,
+        "creatorId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+        "projectRelations": [
+          {
+            "updatedAt": "2025-06-06T11:27:14.830Z",
+            "createdAt": "2025-06-06T11:27:14.830Z",
+            "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+            "projectId": "KwpTDWcFWL3DfyW3",
+            "user": {
+              "updatedAt": "2026-05-13T02:04:11.362Z",
+              "createdAt": "2025-06-06T11:27:13.858Z",
+              "id": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+              "email": "tysonvenables@protonmail.com",
+              "firstName": "Tyson",
+              "lastName": "Venables",
+              "personalizationAnswers": {
+                "version": "v4",
+                "personalization_survey_submitted_at": "2025-06-06T11:42:52.454Z",
+                "personalization_survey_n8n_version": "1.95.3",
+                "companySize": "<20",
+                "companyType": "saas",
+                "role": "business-owner",
+                "reportedSource": "friend"
+              },
+              "settings": {
+                "userActivated": true,
+                "easyAIWorkflowOnboarded": true,
+                "firstSuccessfulWorkflowId": "WVXrFCjb8wO7RWRX",
+                "userActivatedAt": 1751062185356,
+                "npsSurvey": {
+                  "responded": true,
+                  "lastShownAt": 1769430963515
+                }
+              },
+              "disabled": false,
+              "mfaEnabled": false,
+              "lastActiveAt": "2026-05-13",
+              "isPending": false
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "tags": [],
+  "activeVersion": {
+    "updatedAt": "2026-05-13T20:30:34.192Z",
+    "createdAt": "2026-05-13T20:30:34.192Z",
+    "versionId": "8c42e108-e51f-403a-ba09-55599047b7a1",
+    "workflowId": "fonuRTyqepxdyIdf",
+    "nodes": [
+      {
+        "parameters": {
+          "httpMethod": "POST",
+          "path": "ghl-marketing-publish",
+          "responseMode": "responseNode",
+          "options": {}
+        },
+        "id": "p0000001-0001-4000-8000-000000000001",
+        "name": "Webhook",
+        "type": "n8n-nodes-base.webhook",
+        "typeVersion": 2,
+        "position": [
+          32,
+          464
+        ],
+        "webhookId": "ghl-marketing-publish"
+      },
+      {
+        "parameters": {
+          "url": "=https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts?id=eq.{{ $json.body.draftId }}&select=*",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{ $env.SUPABASE_ANON_KEY }}"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{ $env.SUPABASE_ANON_KEY }}"
+              }
+            ]
+          },
+          "options": {
+            "response": {
+              "response": {
+                "responseFormat": "json"
+              }
+            }
+          }
+        },
+        "id": "p0000001-0001-4000-8000-000000000002",
+        "name": "Fetch Draft",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          224,
+          464
+        ]
+      },
+      {
+        "parameters": {
+          "jsCode": "const rows = $input.first().json;\nconst draft = Array.isArray(rows) ? rows[0] : rows;\nif (!draft || !draft.id) throw new Error('Draft not found');\n\nconst DEFAULT_IMAGE = $env.GHL_DEFAULT_IMAGE_URL\n  || 'https://pub-1fa192ebc8ff40dba2b9a0f1890e6f7a.r2.dev/marketing-templates/ghl-template-value-led.jpg';\nconst effective_image_url = draft.image_url || DEFAULT_IMAGE;\n\nreturn [{\n  json: {\n    ...draft,\n    effective_image_url,\n    published_platforms: [],\n    publish_errors: {},\n  }\n}];"
+        },
+        "id": "p0000001-0001-4000-8000-000000000003",
+        "name": "Prepare",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          432,
+          464
+        ]
+      },
+      {
+        "parameters": {
+          "url": "=https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts?published_platforms=cs.%5B%22linkedin%22%5D&published_at=gte.{{ new Date(Date.now()-4*3600*1000).toISOString() }}&select=id,published_at&order=published_at.desc&limit=1",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{ $env.SUPABASE_ANON_KEY }}"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{ $env.SUPABASE_ANON_KEY }}"
+              }
+            ]
+          },
+          "options": {
+            "response": {
+              "response": {
+                "responseFormat": "json"
+              }
+            }
+          }
+        },
+        "id": "p0000001-0001-4000-8000-000000000004",
+        "name": "LI Guard Check",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          624,
+          464
+        ],
+        "alwaysOutputData": true
+      },
+      {
+        "parameters": {
+          "jsCode": "// Read recent LinkedIn publish history; block if within 4 hours.\nconst prep = $('Prepare').first().json;\nconst rows = $input.first().json;\nconst recent = Array.isArray(rows) ? rows : [];\nconst skip_linkedin = recent.length > 0;\nconst linkedin_skip_reason = skip_linkedin\n  ? `4h-guard: last LinkedIn post at ${recent[0]?.published_at || 'unknown'}`\n  : null;\nreturn [{ json: { ...prep, skip_linkedin, linkedin_skip_reason } }];\n"
+        },
+        "id": "p0000001-0001-4000-8000-000000000005",
+        "name": "LI Guard Apply",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          832,
+          464
+        ]
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "=https://graph.facebook.com/v19.0/{{$env.FLOWOS_META_PAGE_ID}}/photos",
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={\n  \"url\": {{ JSON.stringify($json.effective_image_url) }},\n  \"caption\": {{ JSON.stringify($json.facebook_post || \"\") }},\n  \"access_token\": \"{{$env.FLOWOS_META_PAGE_ACCESS_TOKEN}}\"\n}",
+          "options": {
+            "response": {
+              "response": {
+                "responseFormat": "json"
+              }
+            }
+          }
+        },
+        "id": "p0000001-0001-4000-8000-000000000006",
+        "name": "Facebook Post",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1024,
+          464
+        ],
+        "alwaysOutputData": true,
+        "onError": "continueRegularOutput"
+      },
+      {
+        "parameters": {
+          "conditions": {
+            "options": {
+              "caseSensitive": true,
+              "leftValue": "",
+              "typeValidation": "loose"
+            },
+            "conditions": [
+              {
+                "id": "skip-li-cond",
+                "leftValue": "={{ $('LI Guard Apply').item.json.skip_linkedin }}",
+                "rightValue": true,
+                "operator": {
+                  "type": "boolean",
+                  "operation": "true",
+                  "singleValue": true
+                }
+              }
+            ],
+            "combinator": "and"
+          },
+          "options": {}
+        },
+        "id": "p0000001-0001-4000-8000-000000000009",
+        "name": "Skip LinkedIn?",
+        "type": "n8n-nodes-base.if",
+        "typeVersion": 2.2,
+        "position": [
+          1856,
+          464
+        ]
+      },
+      {
+        "parameters": {
+          "platform": "linkedin",
+          "accountId": {
+            "__rl": true,
+            "value": "11109",
+            "mode": "list",
+            "cachedResultName": "Tyson Venables",
+            "cachedResultUrl": "https://backend.blotato.com/v2/accounts/11109"
+          },
+          "postContentText": "={{ $('Prepare').item.json.linkedin_post || '' }}",
+          "options": {}
+        },
+        "id": "p0000001-0001-4000-8000-00000000000a",
+        "name": "LinkedIn Post (Blotato)",
+        "type": "@blotato/n8n-nodes-blotato.blotato",
+        "typeVersion": 2,
+        "position": [
+          2080,
+          688
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "blotatoApi": {
+            "id": "Bs2TEAOA9mVKfcR3",
+            "name": "Blotato account"
+          }
+        },
+        "onError": "continueRegularOutput"
+      },
+      {
+        "parameters": {
+          "jsCode": "// Inspect every platform node's run result and assemble final publish state.\nconst prep = $('Prepare').first().json;\nconst guard = $('LI Guard Apply').first().json;\n\nconst published = [];\nconst errors = {};\n\n// Read the runData item itself (sibling fields .json and .error) so we can promote\n// the diagnostic NodeApiError.description (e.g. Blotato hashtag-cap reason)\n// rather than the synthesized generic top-level json.error string.\nconst readNode = (name) => {\n  try { return $(name).first(); } catch { return undefined; }\n};\n\n// Facebook: Graph API returns { id: '...' } on success; error has { error: {...} } in body.\nconst fb = readNode('Facebook Post');\nconst fbJson = fb?.json;\nif (fbJson?.id && !fbJson?.error) {\n  published.push('facebook');\n} else {\n  errors.facebook = fb?.error?.description\n    || fbJson?.error?.message\n    || fbJson?.error?.error_user_msg\n    || fbJson?.message\n    || 'unknown error';\n}\n\n// Instagram via Blotato.\nconst igB = readNode('IG Post (Blotato)');\nconst igJson = igB?.json;\nif (igJson && !igJson.error) {\n  published.push('instagram');\n} else {\n  errors.instagram = igB?.error?.description\n    || igJson?.error?.message\n    || igJson?.error\n    || igJson?.message\n    || 'unknown Blotato IG error';\n}\n\n// LinkedIn: skipped (4h guard) OR Blotato success.\nif (guard.skip_linkedin) {\n  errors.linkedin = guard.linkedin_skip_reason || 'skipped by 4h guard';\n} else {\n  const li = readNode('LinkedIn Post (Blotato)');\n  const liJson = li?.json;\n  if (liJson && !liJson.error) {\n    published.push('linkedin');\n  } else {\n    errors.linkedin = li?.error?.description\n      || liJson?.error?.message\n      || liJson?.message\n      || 'unknown LinkedIn error';\n  }\n}\n\nconst all_ok = Object.keys(errors).length === 0;\nconst status = all_ok ? 'published' : 'partially_published';\n\nreturn [{\n  json: {\n    ...prep,\n    published_platforms: published,\n    publish_errors: errors,\n    final_status: status,\n    now_iso: new Date().toISOString(),\n  }\n}];"
+        },
+        "id": "p0000001-0001-4000-8000-00000000000b",
+        "name": "Compute Final",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          2336,
+          448
+        ]
+      },
+      {
+        "parameters": {
+          "method": "PATCH",
+          "url": "=https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts?id=eq.{{ $json.id }}",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "Prefer",
+                "value": "return=representation"
+              },
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "name": "apikey",
+                "value": "={{ $env.SUPABASE_ANON_KEY }}"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{ $env.SUPABASE_ANON_KEY }}"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({\n  status: $json.final_status,\n  published_at: $json.now_iso,\n  updated_at: $json.now_iso,\n  published_platforms: $json.published_platforms,\n  publish_errors: Object.keys($json.publish_errors).length ? $json.publish_errors : null\n}) }}",
+          "options": {
+            "response": {
+              "response": {
+                "responseFormat": "json"
+              }
+            }
+          }
+        },
+        "id": "p0000001-0001-4000-8000-00000000000c",
+        "name": "Update Supabase",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          2528,
+          448
+        ]
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "=https://api.telegram.org/bot{{$env.TELEGRAM_BOT_TOKEN}}/sendMessage",
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({\n  chat_id: 1375806243,\n  text: (function() {\n    const f = $('Compute Final').item.json;\n    const ok = f.published_platforms || [];\n    const errs = f.publish_errors || {};\n    const lines = ['<b>GHL Marketing \u2014 publish result</b>'];\n    lines.push('Draft: <code>' + f.id + '</code>');\n    lines.push('Status: <b>' + f.final_status + '</b>');\n    if (ok.length) lines.push('\u2705 Published: ' + ok.join(', '));\n    Object.entries(errs).forEach(([k,v]) => lines.push('\u274c ' + k + ': ' + v));\n    return lines.join('\\n');\n  })(),\n  parse_mode: 'HTML'\n}) }}",
+          "options": {
+            "response": {
+              "response": {
+                "responseFormat": "json"
+              }
+            }
+          }
+        },
+        "id": "p0000001-0001-4000-8000-00000000000d",
+        "name": "Telegram Notify",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          2736,
+          448
+        ]
+      },
+      {
+        "parameters": {
+          "respondWith": "json",
+          "responseBody": "={{ JSON.stringify({\n  ok: true,\n  draftId: $('Compute Final').item.json.id,\n  status: $('Compute Final').item.json.final_status,\n  published_platforms: $('Compute Final').item.json.published_platforms,\n  publish_errors: $('Compute Final').item.json.publish_errors\n}) }}",
+          "options": {}
+        },
+        "id": "p0000001-0001-4000-8000-00000000000e",
+        "name": "Respond",
+        "type": "n8n-nodes-base.respondToWebhook",
+        "typeVersion": 1.1,
+        "position": [
+          2928,
+          448
+        ]
+      },
+      {
+        "parameters": {
+          "accountId": {
+            "__rl": true,
+            "value": "27064",
+            "mode": "list",
+            "cachedResultName": "flow_os",
+            "cachedResultUrl": "https://backend.blotato.com/v2/accounts/27064"
+          },
+          "postContentText": "={{ $('Prepare').item.json.instagram_caption || '' }}",
+          "postContentMediaUrls": "={{ $('Prepare').item.json.effective_image_url }}",
+          "options": {}
+        },
+        "id": "p0000001-0001-4000-8000-0000000blot01",
+        "name": "IG Post (Blotato)",
+        "type": "@blotato/n8n-nodes-blotato.blotato",
+        "typeVersion": 2,
+        "position": [
+          1280,
+          464
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "blotatoApi": {
+            "id": "Bs2TEAOA9mVKfcR3",
+            "name": "Blotato account"
+          }
+        },
+        "onError": "continueRegularOutput"
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'started'::text, 'GHL Marketing: Publisher'::text, '{{ $execution.id }}'::text);",
+          "options": {}
+        },
+        "name": "Heartbeat: Start",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          232,
+          464
+        ],
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true,
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "2a8350e4-db4c-4f57-adb4-8d24463135dd"
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'success'::text, 'GHL Marketing: Publisher'::text, '{{ $execution.id }}'::text);",
+          "options": {}
+        },
+        "name": "Heartbeat: Success",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          2778,
+          448
+        ],
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true,
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "a2fd6542-0cb7-4428-ac45-11a4c66aa0b8"
+      }
+    ],
+    "connections": {
+      "Webhook": {
+        "main": [
+          [
+            {
+              "node": "Fetch Draft",
+              "type": "main",
+              "index": 0
+            },
+            {
+              "node": "Heartbeat: Start",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Fetch Draft": {
+        "main": [
+          [
+            {
+              "node": "Prepare",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Prepare": {
+        "main": [
+          [
+            {
+              "node": "LI Guard Check",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "LI Guard Check": {
+        "main": [
+          [
+            {
+              "node": "LI Guard Apply",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "LI Guard Apply": {
+        "main": [
+          [
+            {
+              "node": "Facebook Post",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Facebook Post": {
+        "main": [
+          [
+            {
+              "node": "IG Post (Blotato)",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Skip LinkedIn?": {
+        "main": [
+          [
+            {
+              "node": "Compute Final",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "LinkedIn Post (Blotato)",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "LinkedIn Post (Blotato)": {
+        "main": [
+          [
+            {
+              "node": "Compute Final",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Compute Final": {
+        "main": [
+          [
+            {
+              "node": "Update Supabase",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Update Supabase": {
+        "main": [
+          [
+            {
+              "node": "Telegram Notify",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Telegram Notify": {
+        "main": [
+          [
+            {
+              "node": "Heartbeat: Success",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "IG Post (Blotato)": {
+        "main": [
+          [
+            {
+              "node": "Skip LinkedIn?",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Heartbeat: Start": {
+        "main": [
+          []
+        ]
+      },
+      "Heartbeat: Success": {
+        "main": [
+          [
+            {
+              "node": "Respond",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      }
+    },
+    "authors": "Tyson Venables",
+    "name": null,
+    "description": null,
+    "autosaved": false,
+    "workflowPublishHistory": [
+      {
+        "createdAt": "2026-05-13T20:30:34.341Z",
+        "id": 967,
+        "workflowId": "fonuRTyqepxdyIdf",
+        "versionId": "8c42e108-e51f-403a-ba09-55599047b7a1",
+        "event": "activated",
+        "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- **Awo65rdSe5BvDHtC** (Content Generator): adds Code node `Cap Hashtags` between `Assign Image URL` and `Save to Supabase`. Caps `instagram_caption` to 5 hashtags (Blotato's IG limit). Pass-through for empty / missing / ≤5. Pattern mirrors commit `e4ad82c` (Infographic V2).
- **fonuRTyqepxdyIdf** (Publisher): `Compute Final` now prefers each platform node's `error.description` (the diagnostic NodeApiError reason) over the generic synthesized `json.error` string when populating `publish_errors.{platform}`. All existing fallbacks + the LinkedIn 4h-guard short-circuit preserved.

Root cause for Bug 3 documented in `/tmp/ig_failure_a19997f3.md` (execution `940561`, 2026-05-13 19:40 UTC, draft `a19997f3-3a85-4ab2-94b8-f289564228b7`). The Apr 29 "Cap Hashtags" commit only landed on Infographic V2 — the GHL Marketing pipeline was never protected.

## PUT verification

| Workflow | PUT | updatedAt | availableInMCP | Verify |
|---|---|---|---|---|
| Awo65rdSe5BvDHtC | HTTP 200 | 2026-05-13T20:29:42.993Z | true (in `settings`) | 12 nodes, Cap Hashtags wired |
| fonuRTyqepxdyIdf | HTTP 200 | 2026-05-13T20:30:34.190Z | true (in `settings`) | Compute Final contains `*?.error?.description` for all 3 platforms |

## Brief-conflicts surfaced

1. Working tree had pre-existing `M src/memory/knowledge.js` (5-line context-truncation guard from a prior session) — stashed to `stash@{0}` before branching off main. Not authored here.
2. Brief's `POST /api/v1/workflows/{id}/setAvailableInMCP` endpoint returned **HTTP 405**. Canonical mechanism (per `src/tools/n8n-workflow-update.js:171`) is `settings.availableInMCP: true` inside the PUT body. Both PUTs preserved the existing `true` value; re-GET confirms.
3. Live `Awo65rdSe5BvDHtC` diverged cosmetically from disk (position shifts, dropped no-op Supabase FSC credential reference, omitted explicit `method: GET`). Worked from LIVE as source of truth; disk JSONs refreshed from post-PUT GETs.

## Smoke tests

- **Cap Hashtags:** static replication of the live jsCode against the exact `instagram_caption` from execution `940561`. Result: 15 → 5 hashtags, first 5 kept (`#gohighlevel #ghl #automation #workflows #saas`), 10 dropped, all other fields preserved. Edge cases (empty / missing / ≤5) verified pass-through. Per brief, did NOT trigger a live execution (would burn Claude API + insert a real `pending_approval` row; public n8n REST API doesn't expose ad-hoc execution).
- **Compute Final:** per brief, no live re-publish (would duplicate FB/LinkedIn posts). Static post-PUT GET confirms description-promotion for all 3 platforms with fallback chains intact.

## Security gate (all green)

- [x] No hardcoded credentials added
- [x] No new webhooks / endpoints
- [x] No RLS / schema changes
- [x] No financial features touched
- [x] `.env` perms unchanged at 600 on both QClaw + n8n hosts (neither file written)
- [x] `availableInMCP: true` confirmed via re-GET on both workflows
- [x] No stack traces or secrets in error mappings — Compute Final reads only `error.description` + `error.message` strings

## Out of scope (deferred)

- LinkedIn media wiring → Slice 3
- Crete pipeline (Image Router gating + FB/LI media wiring) → Slice 4
- Regenerate-wipes-image_url investigation → Slice 1.5
- Republishing `a19997f3` — Tyson accepted the partial

## Test plan

- [ ] Pop `stash@{0}` back onto whichever branch the `knowledge.js` truncation guard belongs on
- [ ] Wait for next Cron MWF tick (Friday 11:00 UTC) to confirm Cap Hashtags fires in production with `_hashtag_cap_applied` metadata visible in the execution
- [ ] On next IG failure (any cause), confirm `publish_errors.instagram` in `marketing_drafts` contains the specific Blotato/Meta `error.description` instead of the generic "Your request is invalid…" string
- [ ] Manual re-review: confirm no FB/LinkedIn regression in the next Publisher execution (no node bodies for those platforms changed in this PR)
