### PR TITLE
feat(memory): cap KnowledgeStore context at 8KB to prevent memory bloat

### DIFF
--- a/src/memory/knowledge.js
+++ b/src/memory/knowledge.js
@@ -244,7 +244,11 @@ export class KnowledgeStore {
       }
     }
 
-    return parts.join('\n');
+    const result = parts.join('\n');
+    if (result.length > 8000) {
+      return result.substring(0, 8000) + '\n[... context truncated for memory safety]';
+    }
+    return result;
   }
 
   /**


### PR DESCRIPTION
## What does this PR do?

Caps KnowledgeStore context payload at 8KB in `getContextForQuery` to prevent memory bloat. Adds a truncation guard with explicit "[... context truncated for memory safety]" marker so consumers can detect when truncation happened.

## Type of change

- [x] Bug fix

## Checklist

- [x] I've tested this locally
- [ ] I've updated docs if needed
- [x] British English used in docs/comments
- [x] No new dependencies added (or justified why)