### PR TITLE
fix(ghl-marketing): wire image URL into LinkedIn publish (Slice 3)

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -9197,3 +9197,99 @@ chains preserved.
 - Memory: `project_n8n_qclaw_topology.md` (PUT body shape `{name, nodes,
   connections, settings}`).
 - Memory: `project_n8n_supabase_fsc_credential.md` (FSC credential is no-op).
+
+## 2026-05-13 — Slice 3: GHL Bug 2 fix (LinkedIn media wiring)
+
+Per `/tmp/marketing_image_audit_20260513.md` Bug 2 verdict for the GHL
+Publisher: the `LinkedIn Post (Blotato)` node passed only `postContentText`
+and did not set `postContentMediaUrls`, so every successful LinkedIn post
+went out text-only — including the recent execution `940561` where FB and
+IG were image-attached but LinkedIn was image-less. IG's wiring was the
+template; this dispatch mirrors it onto LinkedIn.
+
+**Branch:** `cc/slice3-ghl-linkedin-media-20260513` (created from `main` @
+`d63e855`, after Slice 2 PR #10 + Slice 1.5 stash PR #11 both merged).
+
+### Workflow touched
+
+**`fonuRTyqepxdyIdf` — GHL Marketing: Publisher (15 → 15 nodes, 1 node modified)**
+
+Single parameter added to `LinkedIn Post (Blotato)`:
+
+```
+"postContentMediaUrls": "={{ $('Prepare').item.json.effective_image_url }}"
+```
+
+Exact mirror of the `IG Post (Blotato)` expression on the same workflow.
+Inserted between `postContentText` and `options` to match IG's parameter
+ordering. No other parameters touched — `platform: "linkedin"`,
+`accountId.value: "11109"` (Tyson Venables LinkedIn account), the
+`LI Guard Check` / `LI Guard Apply` / `Skip LinkedIn?` 4h rate-limiter
+chain, and the FB / IG nodes are all bytewise identical to the pre-Slice-3
+state.
+
+### PUT verification (live)
+
+- PUT `HTTP=200` @ `2026-05-13T21:10:28.744Z`.
+- Re-GET confirms:
+  - `LinkedIn Post (Blotato).parameters.postContentMediaUrls` =
+    `"={{ $('Prepare').item.json.effective_image_url }}"` (exact match to IG's expression).
+  - `IG Post (Blotato).parameters.postContentMediaUrls` unchanged.
+  - `Facebook Post.parameters.jsonBody` unchanged (Graph API `/photos`
+    with `url: effective_image_url` still wired correctly).
+  - `Compute Final` retains Slice 2's `error?.description` promotion across
+    all three platforms — verified by static substring check on the post-PUT
+    jsCode.
+  - `settings.availableInMCP=true`.
+- Diff of the disk JSON shows exactly one functional addition (the line
+  above), mirrored once in the live `nodes` section and once in the
+  `activeVersion.nodes` GET-response mirror, plus expected version-bump
+  metadata (versionId 8c42e108→7c081329, versionCounter 114→117,
+  workflowPublishHistory id 967→968).
+
+### Smoke test
+
+Per brief: live smoke test is optional because it creates a real LinkedIn
+post. **Skipped** — the next natural publish through the Publisher
+validates the fix end-to-end. Alternative validation: static post-PUT GET
+confirms the parameter is in place; the IG node uses the exact same
+expression on the same upstream `Prepare.effective_image_url` field and
+is known to be working in production (per executions `940561`, `937131`,
+and Apr 27+ history).
+
+Note: when the next LinkedIn publish fires, the 4h Blotato rate-limit
+guard (`LI Guard Check` + `LI Guard Apply` + `Skip LinkedIn?` IF) may
+short-circuit the LinkedIn branch if the previous LI post was less than
+4h ago. That's expected behaviour, preserved per scope — not a smoke
+failure.
+
+### Security gate
+
+- [x] No hardcoded credentials added — only added an `$('Prepare').item.json.effective_image_url` expression reference.
+- [x] No new webhooks (no new webhook nodes).
+- [x] No new endpoints (no new HTTP nodes).
+- [x] No RLS changes.
+- [x] No financial features touched.
+- [x] `~/.quantumclaw/.env` and `/home/n8nadmin/n8n-project/.env` perms
+      unchanged at 600 — neither file written.
+- [x] `settings.availableInMCP=true` confirmed via re-GET.
+- [x] No stack traces or secrets exposed — single expression reference,
+      no error-handling change, no logging change.
+- [x] Credential references unchanged — Blotato `accountId.value: "11109"`
+      on the LI node is the same as pre-Slice-3 (Tyson Venables LinkedIn).
+
+### Out of scope (deferred)
+
+- Crete pipeline (Image Router gating + FB/LI media wiring) — Slice 4.
+- Regenerate path on Approval Handler (carries image_url forward; also
+  bypasses Cap Hashtags) — Slice 5.
+- Republishing `a19997f3` (already partially_published, accepted).
+
+### References
+
+- `/tmp/marketing_image_audit_20260513.md` — Bug 2 verdict.
+- `/tmp/ig_failure_a19997f3.md` — execution `940561` dump showing
+  LinkedIn-text-only behaviour pre-Slice-3.
+- Slice 2 (PR #10, merged `c482013...d63e855`) — predecessor on this
+  workflow (Compute Final `error.description` promotion).
+- Memory: `project_n8n_qclaw_topology.md` (PUT body shape).

--- a/n8n-workflows/fonuRTyqepxdyIdf-ghl-marketing-publisher.json
+++ b/n8n-workflows/fonuRTyqepxdyIdf-ghl-marketing-publisher.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-05-13T20:30:34.190Z",
+  "updatedAt": "2026-05-13T21:10:28.744Z",
   "createdAt": "2026-04-13T13:10:45.173Z",
   "id": "fonuRTyqepxdyIdf",
   "name": "GHL Marketing: Publisher",
@@ -187,6 +187,7 @@
           "cachedResultUrl": "https://backend.blotato.com/v2/accounts/11109"
         },
         "postContentText": "={{ $('Prepare').item.json.linkedin_post || '' }}",
+        "postContentMediaUrls": "={{ $('Prepare').item.json.effective_image_url }}",
         "options": {}
       },
       "id": "p0000001-0001-4000-8000-00000000000a",
@@ -554,9 +555,9 @@
   "staticData": null,
   "meta": null,
   "pinData": {},
-  "versionId": "8c42e108-e51f-403a-ba09-55599047b7a1",
-  "activeVersionId": "8c42e108-e51f-403a-ba09-55599047b7a1",
-  "versionCounter": 114,
+  "versionId": "7c081329-0353-45e2-87cb-6ebdc260f769",
+  "activeVersionId": "7c081329-0353-45e2-87cb-6ebdc260f769",
+  "versionCounter": 117,
   "triggerCount": 1,
   "shared": [
     {
@@ -618,9 +619,9 @@
   ],
   "tags": [],
   "activeVersion": {
-    "updatedAt": "2026-05-13T20:30:34.192Z",
-    "createdAt": "2026-05-13T20:30:34.192Z",
-    "versionId": "8c42e108-e51f-403a-ba09-55599047b7a1",
+    "updatedAt": "2026-05-13T21:10:28.749Z",
+    "createdAt": "2026-05-13T21:10:28.749Z",
+    "versionId": "7c081329-0353-45e2-87cb-6ebdc260f769",
     "workflowId": "fonuRTyqepxdyIdf",
     "nodes": [
       {
@@ -803,6 +804,7 @@
             "cachedResultUrl": "https://backend.blotato.com/v2/accounts/11109"
           },
           "postContentText": "={{ $('Prepare').item.json.linkedin_post || '' }}",
+          "postContentMediaUrls": "={{ $('Prepare').item.json.effective_image_url }}",
           "options": {}
         },
         "id": "p0000001-0001-4000-8000-00000000000a",
@@ -1168,10 +1170,10 @@
     "autosaved": false,
     "workflowPublishHistory": [
       {
-        "createdAt": "2026-05-13T20:30:34.341Z",
-        "id": 967,
+        "createdAt": "2026-05-13T21:10:28.896Z",
+        "id": 968,
         "workflowId": "fonuRTyqepxdyIdf",
-        "versionId": "8c42e108-e51f-403a-ba09-55599047b7a1",
+        "versionId": "7c081329-0353-45e2-87cb-6ebdc260f769",
         "event": "activated",
         "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d"
       }


### PR DESCRIPTION
## Summary

- **fonuRTyqepxdyIdf** (GHL Marketing: Publisher): adds one parameter to `LinkedIn Post (Blotato)` —
  ```
  "postContentMediaUrls": "={{ $('Prepare').item.json.effective_image_url }}"
  ```
  Exact mirror of the `IG Post (Blotato)` expression on the same workflow. Closes Bug 2 from `/tmp/marketing_image_audit_20260513.md` for the GHL pipeline. (Crete pipeline carries the same gap on FB+LI plus an upstream Image Router gate — separate Slice 4.)

## PUT verification

| Workflow | PUT | updatedAt | availableInMCP | Verify |
|---|---|---|---|---|
| fonuRTyqepxdyIdf | HTTP 200 | 2026-05-13T21:10:28.744Z | true (in `settings`) | `LinkedIn Post (Blotato).parameters.postContentMediaUrls` matches IG's expression byte-for-byte |

Diff (functional content, excluding version metadata):

```diff
       "postContentText": "={{ $('Prepare').item.json.linkedin_post || '' }}",
+      "postContentMediaUrls": "={{ $('Prepare').item.json.effective_image_url }}",
       "options": {}
```

One line added. Mirrored once in `nodes` + once in the `activeVersion.nodes` GET-response mirror = the two `+` chunks visible in the disk diff.

## Brief-conflicts surfaced

- Workflow `updatedAt` was within the last 24h (Slice 2 PUT at `2026-05-13T20:30:34.190Z`). Confirmed via `git log` that this is the predecessor session (Slice 2 / PR #10), not parallel activity. Proceeded.
- Live workflow had zero non-position drift vs disk (Slice 2 refresh was current). Slice 2's Compute Final `error.description` promotion is preserved post-Slice-3 PUT (verified by static substring check).

## Out of scope (deferred / preserved)

- `LI Guard Check` + `LI Guard Apply` + `Skip LinkedIn?` 4h Blotato rate-limiter chain — preserved verbatim
- LinkedIn account credential (`accountId.value: "11109"`) — unchanged
- Facebook node — already wired correctly (Graph `/photos` with `url`)
- IG node — already wired correctly
- Compute Final (Slice 2 territory) — untouched
- Crete pipeline — Slice 4
- Approval Handler regenerate path — Slice 5 (per `/tmp/regenerate_wipe_audit_20260513.md`)

## Security gate (all green)

- [x] No hardcoded credentials added (single expression reference)
- [x] No new webhooks / endpoints
- [x] No RLS / schema changes
- [x] No financial features touched
- [x] `.env` perms unchanged at 600 on both QClaw + n8n hosts (neither file written)
- [x] `settings.availableInMCP: true` confirmed via re-GET
- [x] No stack traces or secrets exposed
- [x] Blotato credential reference unchanged

## Test plan

- [ ] Wait for next Publisher execution (manual `/post-now` from dashboard OR next scheduled approval). Confirm LinkedIn post appears with image attached on linkedin.com/in/tysonvenables. If the 4h Blotato guard short-circuits LinkedIn, that's the rate-limiter doing its job — wait or test from a different account.
- [ ] Verify by reviewing the n8n execution log: `LinkedIn Post (Blotato).parameters.postContentMediaUrls` should resolve to the same URL as the IG node's media URL for that draft.
- [ ] Confirm no regression on FB (still `/photos` with `url`) or IG (Blotato `postContentMediaUrls` resolves identically).
