### PR TITLE
fix(crete): wire media URL across all platforms + extend validation (Slice 4)

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -9293,3 +9293,177 @@ failure.
 - Slice 2 (PR #10, merged `c482013...d63e855`) — predecessor on this
   workflow (Compute Final `error.description` promotion).
 - Memory: `project_n8n_qclaw_topology.md` (PUT body shape).
+
+## 2026-05-13 — Slice 4: Crete Bug 2 fix (Generator + Publisher media wiring + Validate Media expansion)
+
+Per `/tmp/marketing_image_audit_20260513.md` Bug 2 verdict for the Crete
+pipeline. Two-layer fix: the Generator's `Image Router` previously
+early-returned for any non-Instagram row (FB and LinkedIn rows arrived at
+the Publisher with `media_url=NULL`); the Publisher's `Facebook Post` and
+`LinkedIn Post (Blotato)` nodes had no media-field wiring even if a
+`media_url` were present. Closes the wiring gap end-to-end for Crete.
+
+**Branch:** `cc/slice4-crete-media-wiring-20260513` (created from `main` @
+`18c500e`, after Slice 3 PR #12 merged).
+
+### Workflows touched (both via PUT through `https://webhook.flowos.tech/api/v1`)
+
+**`tnvXFYvODL1PrhJa` — Crete - Content Generator (19 → 19 nodes, 1 node modified)**
+
+- **`Image Router` Code node rewritten.** Pre-Slice-4: `if (!isInstagram)
+  return row` skipped image generation for FB/LinkedIn. Post-Slice-4:
+  `NEEDS_IMAGE = ['instagram','facebook','linkedin']` opens the gate to
+  all three; non-supported platforms (e.g. `'other'`) still pass through
+  untouched. Default `imageType` is `'text_card'` for all supported
+  platforms (matches IG's pre-Slice-4 default); `'photo'` branch
+  preserved verbatim for any row whose calendar slot explicitly sets
+  `image_type='photo'`. The downstream chain (`Generate Text Card` →
+  `Merge Image URL` → `Insert to Supabase`, plus the
+  `Photo Fallback` → `Fetch Photo Library` → `Select Random Photo`
+  failure branch added Apr 30) is platform-agnostic and required no
+  changes — confirmed by static read.
+
+**`zXKBjp3yjW2oR2Mj` — Crete - Content Publish (27 → 27 nodes, 3 nodes modified)**
+
+- **`LinkedIn Post (Blotato)`** — added one parameter:
+  `postContentMediaUrls: "={{ $('Extract Item').item.json.media_url }}"`.
+  Byte-for-byte mirror of the IG node's expression on the same workflow,
+  same pattern as Slice 3 used on the GHL Publisher. Account 11109
+  (Tyson Venables LinkedIn) unchanged.
+- **`Facebook Post`** — endpoint changed from Graph `/feed` to `/photos`
+  (mirror of GHL Publisher's FB pattern from the Apr 27 morning
+  hardening). Body changed from `{message, access_token}` to
+  `{url, caption, access_token}` with `url: $json.media_url` and
+  `caption: $json.body`. Env vars unchanged: still uses Crete-side
+  `META_PAGE_ID` / `META_PAGE_ACCESS_TOKEN` (NOT GHL's `FLOWOS_META_*`
+  vars — confirmed by static read before edit, the two business units
+  have separate Meta page credentials per `LOCATIONS.md`).
+- **`Validate Media`** — `NEEDS_MEDIA = ['instagram','facebook','linkedin']`
+  expanded from instagram-only. `_failure_reason` now dynamic:
+  `'missing_media_for_' + platform`. So a LinkedIn row arriving with
+  `media_url=NULL` post-Slice-4 will be marked
+  `status='failed', last_error='missing_media_for_linkedin'` via the
+  existing `Mark Failed (Validation)` PATCH — same audit trail the
+  Apr 30 hardening built for IG.
+
+### PUT verification (live)
+
+- **tnvXFYvODL1PrhJa:** PUT `HTTP=200` @ `2026-05-13T21:20:10.940Z`.
+  Static post-PUT GET: no `if (!isInstagram)` early-return, supports
+  FB+LI+IG, default `imageType='text_card'`, photo+text-card branches
+  preserved, non-supported-platform passthrough preserved.
+  `settings.availableInMCP=true`.
+- **zXKBjp3yjW2oR2Mj:** PUT `HTTP=200` @ `2026-05-13T21:21:00.887Z`.
+  Static post-PUT GET: Validate Media covers all three platforms with
+  dynamic `_failure_reason`; FB Post endpoint is `/photos` with `url` +
+  `caption` body, Crete `META_PAGE_ID` + `META_PAGE_ACCESS_TOKEN` env
+  refs preserved; LI Post has `postContentMediaUrls` matching IG's
+  exact expression; IG node unchanged.
+  `settings.availableInMCP=true`.
+- Both workflows' `Heartbeat: Start` / `Heartbeat: Success` /
+  `errorWorkflow: 7kpNnMtnuDWXgWcX` settings preserved.
+
+### Smoke tests
+
+Per brief: live smoke is optional. **Static-only validation used.**
+Generator next runs at 08:00 UTC daily (effective ~11:00 UTC per the
+NY-timezone observation in `N8N_WORKFLOW_INDEX.md`) — when it does, any
+FB or LinkedIn calendar slot will hit the new image branch. Publisher's
+next webhook fire will hit the new Validate Media + FB `/photos` + LI
+`postContentMediaUrls` paths. Skipping the live-trigger smoke because:
+1. Generator live-trigger would burn Claude API + dashboard text-card
+   endpoint quota + insert a real `pending_review` row.
+2. Publisher live-trigger would publish to real FB/LinkedIn accounts
+   (no synthetic-row option available without first inserting one).
+3. The GHL Publisher FB `/photos` pattern this dispatch mirrors is
+   already proven against Meta (every successful GHL publish since Apr
+   27 PM uses it). Switching Crete's env vars (`META_PAGE_ID` →
+   different page id) doesn't change the API surface or auth pattern.
+
+### Queue backfill — Option D (no-op, queue was empty at audit time)
+
+Per brief's pause-point query, read-only check on
+`crete_content_queue` for rows with `platform IN ('facebook','linkedin')
+AND media_url IS NULL AND status IN ('pending_review','approved')`:
+**0 rows.** Full queue state at audit time: 43 published, 3 archived,
+1 failed (the May 2 Apr-30-hardening IG validation artifact). No active
+`pending_review` or `approved` rows at all across the entire queue —
+nothing to remediate by any option.
+
+Of the 43 `published` rows, 27 are FB/LinkedIn with `media_url=NULL`
+(text-only posts that already shipped). Per dispatch's "Republishing
+already-`published` rows" exclusion, out of scope for this slice.
+Tyson is aware. They are not re-published by Slice 4 and remain
+historical.
+
+Tyson decision (received): proceed to commit/PR; log this as Option D.
+
+### Text-card endpoint load increase note
+
+Removing the IG-only gate roughly 3× the dashboard text-card endpoint's
+load (currently IG-only daily → IG+FB+LI daily). At Crete's published
+cadence (~43 rows over ~5 weeks ≈ ~8/week ≈ ~3 per platform per week),
+the post-Slice-4 daily peak is ~3 generator calls per cron tick instead
+of ~1. Not a blocker; the endpoint already serves IG fine, and there's
+slack for 3× given the Apr 21 root-cause work was about reliability not
+throughput. Filed as informational for the Apr 30 unresolved-text-card
+investigation when it resumes.
+
+### Security gate
+
+- [x] No hardcoded credentials added — Generator changes are
+      logic-only in `Image Router`; Publisher changes mirror existing
+      env-var references (`META_PAGE_ID`, `META_PAGE_ACCESS_TOKEN`,
+      `SUPABASE_ANON_KEY`) — no new secrets introduced.
+- [x] No new webhooks (no webhook nodes added).
+- [x] No new endpoints (FB Post endpoint changed from `/feed` to
+      `/photos` on Graph v19 — same host, same auth scope
+      `pages_manage_posts`, same access token).
+- [x] No RLS changes (no schema or policy touched).
+- [x] No financial features touched.
+- [x] `~/.quantumclaw/.env` and `/home/n8nadmin/n8n-project/.env` perms
+      unchanged at 600 — neither file written.
+- [x] `settings.availableInMCP=true` confirmed via re-GET on both
+      workflows.
+- [x] No stack traces or secrets exposed — `Validate Media`'s
+      `_failure_reason` is a static literal prefix concatenated with
+      lowercased `platform`; no inputs reflected, no error fields
+      leaked. `Mark Failed (Validation)` PATCH already used dynamic
+      `_failure_reason` pre-Slice-4 (Apr 30 hardening), so the dynamic
+      string now flows through correctly without further changes.
+- [x] Credential references unchanged — Blotato LinkedIn `accountId.value:
+      "11109"`, Blotato IG `accountId.value: "43178"`, Supabase FSC
+      credential `Nd2uuX5t9KEwbQPv` (where attached), error workflow
+      `7kpNnMtnuDWXgWcX` (pending rename) all untouched.
+- [x] FB Graph endpoint change uses same auth pattern as the GHL
+      Publisher FB node — no new permission surface.
+
+### Out of scope (deferred)
+
+- Approval Handler regenerate path on GHL (`ptHK2TZq5XppKOOg`) — Slice 5
+  per `/tmp/regenerate_wipe_audit_20260513.md`.
+- Crete - Content Regenerate workflow (`KKjw893zwzHwv1o6`) — not affected
+  per Slice 1.5 (sparse PATCH preserves `media_url`); also not yet
+  mirrored to disk (backlog).
+- Heartbeat / errorWorkflow rename across Crete cluster ("Trading - Error
+  Handler" → "Shared Error Handler") — separate dispatch.
+- Text-card endpoint root-cause investigation (Apr 30 unresolved).
+- Republishing the 27 historical FB/LinkedIn text-only `published` rows.
+- Per-platform image styling differences (square vs landscape) —
+  `Generate Text Card` currently produces a single shape; suitable as-is
+  for all three platforms (FB and LinkedIn accept square 1:1).
+
+### References
+
+- `/tmp/marketing_image_audit_20260513.md` — Bug 2 verdict (Crete entry).
+- `/tmp/regenerate_wipe_audit_20260513.md` — Slice 1.5 verdict confirming
+  Crete regenerate doesn't wipe `media_url`.
+- Slice 2 (PR #10) — Cap Hashtags + Compute Final on GHL.
+- Slice 3 (PR #12) — LinkedIn media wiring on GHL Publisher (pattern
+  source for the LI fix this dispatch).
+- Apr 27 PM build log — GHL Publisher FB `/photos` migration (pattern
+  source for the FB fix this dispatch).
+- Apr 30 build log — Crete publishing pipeline hardening (where
+  `Validate Media` first appeared with IG-only scope, plus the
+  `publish_attempts` / `last_error` / `last_attempt_at` columns this
+  slice's failure path now also exercises for FB+LI rows).

--- a/n8n-workflows/tnvXFYvODL1PrhJa-crete-content-generator.json
+++ b/n8n-workflows/tnvXFYvODL1PrhJa-crete-content-generator.json
@@ -1,7 +1,11 @@
 {
+  "updatedAt": "2026-05-13T21:20:10.940Z",
+  "createdAt": "2026-04-11T07:17:27.368Z",
   "id": "tnvXFYvODL1PrhJa",
   "name": "Crete - Content Generator",
   "description": null,
+  "active": true,
+  "isArchived": false,
   "nodes": [
     {
       "parameters": {
@@ -184,7 +188,7 @@
     {
       "parameters": {
         "mode": "runOnceForEachItem",
-        "jsCode": "const row = $input.item.json;\nconst isInstagram = (row.platform || '').toLowerCase() === 'instagram';\nconst imageType = row.image_type || (isInstagram ? 'text_card' : null);\n\nif (!isInstagram) {\n  return row;\n}\n\nif (imageType === 'photo') {\n  return { ...row, _needsPhoto: true, _photoTheme: row.image_theme || '' };\n}\n\nconst style = row.image_style || 'quote';\nconst body = row.body || '';\nconst sentences = body.match(/[^.!?]+[.!?]+/g) || [body.slice(0, 200)];\n\nlet apiBody;\nif (style === 'editorial') {\n  apiBody = {\n    style: 'editorial',\n    headline: (sentences[0] || '').trim().slice(0, 200),\n    body: (sentences[1] || '').trim().slice(0, 300)\n  };\n} else {\n  const quoteText = sentences.slice(0, 2).join(' ').trim().slice(0, 400);\n  apiBody = { style: 'quote', text: quoteText };\n}\n\nreturn { ...row, _needsImage: true, _apiBody: apiBody };"
+        "jsCode": "// Route row to image generation based on platform + image_type.\n// Pre-Slice-4: early-returned for any non-Instagram row (FB/LinkedIn rows got media_url=null).\n// Slice 4: open to Instagram + Facebook + LinkedIn. Rows on other platforms still pass through\n// untouched (no _needsImage / _needsPhoto flags \u2192 straight to Insert with media_url=null per Build Row).\nconst row = $input.item.json;\nconst platform = (row.platform || '').toLowerCase();\nconst NEEDS_IMAGE = ['instagram', 'facebook', 'linkedin'];\n\nif (!NEEDS_IMAGE.includes(platform)) {\n  return row;\n}\n\nconst imageType = row.image_type || 'text_card';\n\nif (imageType === 'photo') {\n  return { ...row, _needsPhoto: true, _photoTheme: row.image_theme || '' };\n}\n\nconst style = row.image_style || 'quote';\nconst body = row.body || '';\nconst sentences = body.match(/[^.!?]+[.!?]+/g) || [body.slice(0, 200)];\n\nlet apiBody;\nif (style === 'editorial') {\n  apiBody = {\n    style: 'editorial',\n    headline: (sentences[0] || '').trim().slice(0, 200),\n    body: (sentences[1] || '').trim().slice(0, 300)\n  };\n} else {\n  const quoteText = sentences.slice(0, 2).join(' ').trim().slice(0, 400);\n  apiBody = { style: 'quote', text: quoteText };\n}\n\nreturn { ...row, _needsImage: true, _apiBody: apiBody };"
       },
       "id": "c1a2b3d4-e5f6-7890-abcd-100000000001",
       "name": "Image Router",
@@ -633,5 +637,721 @@
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": true,
     "errorWorkflow": "7kpNnMtnuDWXgWcX"
+  },
+  "staticData": {
+    "node:Schedule 08:00 UTC": {
+      "recurrenceRules": []
+    }
+  },
+  "meta": null,
+  "pinData": {},
+  "versionId": "45672940-47df-4448-a6ae-74276b5c9e8d",
+  "activeVersionId": "45672940-47df-4448-a6ae-74276b5c9e8d",
+  "versionCounter": 97,
+  "triggerCount": 1,
+  "shared": [
+    {
+      "updatedAt": "2026-04-11T07:17:27.368Z",
+      "createdAt": "2026-04-11T07:17:27.368Z",
+      "role": "workflow:owner",
+      "workflowId": "tnvXFYvODL1PrhJa",
+      "projectId": "KwpTDWcFWL3DfyW3",
+      "project": {
+        "updatedAt": "2026-04-08T20:28:08.726Z",
+        "createdAt": "2025-06-06T11:27:14.830Z",
+        "id": "KwpTDWcFWL3DfyW3",
+        "name": "Tyson Venables <tysonvenables@protonmail.com>",
+        "type": "personal",
+        "icon": null,
+        "description": null,
+        "creatorId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+        "projectRelations": [
+          {
+            "updatedAt": "2025-06-06T11:27:14.830Z",
+            "createdAt": "2025-06-06T11:27:14.830Z",
+            "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+            "projectId": "KwpTDWcFWL3DfyW3",
+            "user": {
+              "updatedAt": "2026-05-13T02:04:11.362Z",
+              "createdAt": "2025-06-06T11:27:13.858Z",
+              "id": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+              "email": "tysonvenables@protonmail.com",
+              "firstName": "Tyson",
+              "lastName": "Venables",
+              "personalizationAnswers": {
+                "version": "v4",
+                "personalization_survey_submitted_at": "2025-06-06T11:42:52.454Z",
+                "personalization_survey_n8n_version": "1.95.3",
+                "companySize": "<20",
+                "companyType": "saas",
+                "role": "business-owner",
+                "reportedSource": "friend"
+              },
+              "settings": {
+                "userActivated": true,
+                "easyAIWorkflowOnboarded": true,
+                "firstSuccessfulWorkflowId": "WVXrFCjb8wO7RWRX",
+                "userActivatedAt": 1751062185356,
+                "npsSurvey": {
+                  "responded": true,
+                  "lastShownAt": 1769430963515
+                }
+              },
+              "disabled": false,
+              "mfaEnabled": false,
+              "lastActiveAt": "2026-05-13",
+              "isPending": false
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "tags": [],
+  "activeVersion": {
+    "updatedAt": "2026-05-13T21:20:10.942Z",
+    "createdAt": "2026-05-13T21:20:10.942Z",
+    "versionId": "45672940-47df-4448-a6ae-74276b5c9e8d",
+    "workflowId": "tnvXFYvODL1PrhJa",
+    "nodes": [
+      {
+        "parameters": {
+          "rule": {
+            "interval": [
+              {
+                "field": "cronExpression",
+                "expression": "0 0 8 * * *"
+              }
+            ]
+          }
+        },
+        "id": "bc5648e4-001e-49f7-bf95-3df0136a34dc",
+        "name": "Schedule 08:00 UTC",
+        "type": "n8n-nodes-base.scheduleTrigger",
+        "typeVersion": 1.2,
+        "position": [
+          -256,
+          320
+        ]
+      },
+      {
+        "parameters": {
+          "url": "https://media.creteprojects.com/content-calendar.json",
+          "options": {
+            "response": {
+              "response": {
+                "responseFormat": "json"
+              }
+            }
+          }
+        },
+        "id": "883e223c-a069-41a0-9921-5d7d3f8e72e2",
+        "name": "Fetch Calendar",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          -32,
+          320
+        ]
+      },
+      {
+        "parameters": {
+          "jsCode": "// Return slots whose date is today or tomorrow (UTC)\nconst calendar = $input.first().json;\nconst slots = (calendar.content_slots || []);\nconst today = new Date();\nconst t = today.toISOString().slice(0, 10);\nconst tomorrow = new Date(today.getTime() + 86400000).toISOString().slice(0, 10);\nconst due = slots.filter(s => s.date === t || s.date === tomorrow);\nif (due.length === 0) {\n  return [];  // empty output halts downstream\n}\nreturn due.map(s => ({ json: s }));\n"
+        },
+        "id": "939788ca-5df1-480e-b72e-9fede4237837",
+        "name": "Filter Due Slots",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          176,
+          320
+        ]
+      },
+      {
+        "parameters": {
+          "mode": "runOnceForEachItem",
+          "jsCode": "const SYSTEM_PROMPT = \"You are the content engine for Crete Projects (creteprojects.com) \\u2014 a premium land, property, and wellness development in Crete, Greece. Three interconnected pillars: Agricultural Land (regenerative agroforestry, biodynamic farming, olives/herbs/citrus/honey, workshops, agro-tourism), Village Restoration (traditional Cretan stone buildings restored to premium private accommodation for worldschooling families, 2-8 week stays), Health & Wellness (gym, cold plunge, sauna, physiotherapy, yoga, pilates, breathwork, visiting practitioners). Target: medium-to-high income location-independent families, entrepreneurs, investors. NOT a commune or budget destination. Voice: premium but not pretentious, direct, confident, grounded. No cliches, no \\\"live your best life\\\" fluff. British English. No hashtags on LinkedIn or Facebook. Instagram posts may include up to 5 relevant hashtags at the end of the post, separated from the main text by a blank line. No em dashes. Every piece needs a clear CTA (register at creteprojects.com, reply, share). Currently in Foundation phase \\u2014 be honest about the stage. Never fabricate milestones.\";\nconst slot = $input.item.json;\nconst userPrompt = [\n  'Generate a ' + slot.content_type + ' for ' + slot.platform + '.',\n  'Theme: ' + (slot.theme || 'general'),\n  'Brief: ' + (slot.brief || ''),\n  'CTA: ' + (slot.cta || 'register at creteprojects.com'),\n  'Content mix: ' + (slot.content_mix || 'mixed'),\n  '',\n  'Return ONLY the post body text. No markdown headers, no commentary, no JSON wrapper.'\n].join('\\n');\nreturn {\n  slot_id: slot.id,\n  image_type: slot.image_type || null,\n  image_style: slot.image_style || null,\n  image_theme: slot.image_theme || null,\n  scheduled_for: slot.date,\n  content_type: slot.content_type,\n  platform: slot.platform,\n  theme: slot.theme || null,\n  cta: slot.cta || null,\n  system_prompt: SYSTEM_PROMPT,\n  user_prompt: userPrompt\n};"
+        },
+        "id": "0dd3fa32-155b-4b14-b1ef-e9380d7cf24f",
+        "name": "Build Prompt",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          400,
+          320
+        ]
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "https://api.anthropic.com/v1/messages",
+          "authentication": "genericCredentialType",
+          "genericAuthType": "httpHeaderAuth",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "anthropic-version",
+                "value": "2023-06-01"
+              },
+              {
+                "name": "content-type",
+                "value": "application/json"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 1000,\n  \"system\": {{ JSON.stringify($json.system_prompt) }},\n  \"messages\": [\n    { \"role\": \"user\", \"content\": {{ JSON.stringify($json.user_prompt) }} }\n  ]\n}",
+          "options": {}
+        },
+        "id": "65e13592-ccb4-4404-bef6-a1d44dfb9b10",
+        "name": "Claude API",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          624,
+          320
+        ],
+        "credentials": {
+          "httpHeaderAuth": {
+            "id": "V9YcuDfp9lqydyDH",
+            "name": "Anthropic Header Auth"
+          }
+        }
+      },
+      {
+        "parameters": {
+          "mode": "runOnceForEachItem",
+          "jsCode": "const resp = $input.item.json;\nconst text = (resp.content || []).map(b => b.text || '').join('\\n').trim();\nif (!text) throw new Error('Claude returned empty content');\nconst cleanText = text.replace(/\\*\\*([^*]+)\\*\\*/g, '$1').replace(/\\*([^*]+)\\*/g, '$1').replace(/^#+\\s+/gm, '').replace(/^[-*]\\s+/gm, '').replace(/`([^`]+)`/g, '$1');\nconst ctx = $('Build Prompt').item.json;\n\n// Strip or limit hashtags based on platform\nlet finalText = cleanText;\nconst platform = ctx.platform || '';\nif (platform === 'linkedin' || platform === 'facebook') {\n  // Remove all hashtags from LinkedIn and Facebook\n  finalText = cleanText.replace(/\\n*#\\S+/g, '').trim();\n} else if (platform === 'instagram') {\n  // Keep max 5 hashtags on Instagram\n  const hashtagRegex = /#\\S+/g;\n  const allTags = cleanText.match(hashtagRegex) || [];\n  if (allTags.length > 5) {\n    // Remove all hashtags first, then append only first 5\n    const bodyWithoutTags = cleanText.replace(/\\n*#\\S+/g, '').trim();\n    finalText = bodyWithoutTags + '\\n\\n' + allTags.slice(0, 5).join(' ');\n  }\n}\n\nconst firstLine = cleanText.split('\\n').map(s => s.trim()).find(Boolean) || '';\nconst title = firstLine.length > 80 ? firstLine.slice(0, 77) + '...'\n                                     : (firstLine || ((ctx.theme || 'Crete') + ' - ' + ctx.platform));\nreturn {\n  status: 'pending_review',\n  content_type: ctx.content_type,\n  platform: ctx.platform,\n  title,\n  body: finalText,\n  cta: ctx.cta,\n  theme: ctx.theme,\n  scheduled_for: ctx.scheduled_for,\n  generation_prompt: ctx.user_prompt,\n  metadata: { slot_id: ctx.slot_id, generated_by: 'crete-content-generator' },\n  image_type: ctx.image_type || null,\n  image_style: ctx.image_style || null,\n  image_theme: ctx.image_theme || null,\n  media_url: null\n};"
+        },
+        "id": "a504a9a0-332e-4e8c-b40d-5ddf8a031cb8",
+        "name": "Build Row",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          816,
+          320
+        ]
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "https://fdabygmromuqtysitodp.supabase.co/rest/v1/crete_content_queue",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "name": "Prefer",
+                "value": "return=representation"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify($json) }}",
+          "options": {}
+        },
+        "id": "54557176-453e-4b8d-818e-decb049638e8",
+        "name": "Insert to Supabase",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          3136,
+          432
+        ]
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "=https://api.telegram.org/bot{{$env.TELEGRAM_BOT_TOKEN}}/sendMessage",
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={\n  \"chat_id\": 1375806243,\n  \"text\": \"\ud83c\udd95 New Crete content for review: {{ $('Build Row').item.json.title }} ({{ $('Build Row').item.json.content_type }}). Review at agentboardroom.flowos.tech\",\n}",
+          "options": {}
+        },
+        "id": "b826bc5d-bd77-4b56-82b7-9a6de17a2c09",
+        "name": "Telegram Notify",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          3344,
+          432
+        ],
+        "onError": "continueRegularOutput"
+      },
+      {
+        "parameters": {
+          "mode": "runOnceForEachItem",
+          "jsCode": "// Route row to image generation based on platform + image_type.\n// Pre-Slice-4: early-returned for any non-Instagram row (FB/LinkedIn rows got media_url=null).\n// Slice 4: open to Instagram + Facebook + LinkedIn. Rows on other platforms still pass through\n// untouched (no _needsImage / _needsPhoto flags \u2192 straight to Insert with media_url=null per Build Row).\nconst row = $input.item.json;\nconst platform = (row.platform || '').toLowerCase();\nconst NEEDS_IMAGE = ['instagram', 'facebook', 'linkedin'];\n\nif (!NEEDS_IMAGE.includes(platform)) {\n  return row;\n}\n\nconst imageType = row.image_type || 'text_card';\n\nif (imageType === 'photo') {\n  return { ...row, _needsPhoto: true, _photoTheme: row.image_theme || '' };\n}\n\nconst style = row.image_style || 'quote';\nconst body = row.body || '';\nconst sentences = body.match(/[^.!?]+[.!?]+/g) || [body.slice(0, 200)];\n\nlet apiBody;\nif (style === 'editorial') {\n  apiBody = {\n    style: 'editorial',\n    headline: (sentences[0] || '').trim().slice(0, 200),\n    body: (sentences[1] || '').trim().slice(0, 300)\n  };\n} else {\n  const quoteText = sentences.slice(0, 2).join(' ').trim().slice(0, 400);\n  apiBody = { style: 'quote', text: quoteText };\n}\n\nreturn { ...row, _needsImage: true, _apiBody: apiBody };"
+        },
+        "id": "c1a2b3d4-e5f6-7890-abcd-100000000001",
+        "name": "Image Router",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          1040,
+          320
+        ]
+      },
+      {
+        "parameters": {
+          "conditions": {
+            "options": {
+              "caseSensitive": true,
+              "leftValue": "",
+              "typeValidation": "strict"
+            },
+            "conditions": [
+              {
+                "leftValue": "={{ $json._needsImage }}",
+                "rightValue": true,
+                "operator": {
+                  "type": "boolean",
+                  "operation": "true"
+                }
+              }
+            ],
+            "combinator": "and"
+          },
+          "options": {}
+        },
+        "id": "c1a2b3d4-e5f6-7890-abcd-100000000002",
+        "name": "Needs Image?",
+        "type": "n8n-nodes-base.if",
+        "typeVersion": 2.2,
+        "position": [
+          1248,
+          320
+        ]
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "=https://agentboardroom.flowos.tech/api/crete/generate-image?token={{$env.QCLAW_API_TOKEN}}",
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify($json._apiBody) }}",
+          "options": {
+            "timeout": 30000
+          }
+        },
+        "id": "c1a2b3d4-e5f6-7890-abcd-100000000003",
+        "name": "Generate Text Card",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1536,
+          144
+        ],
+        "retryOnFail": false,
+        "onError": "continueErrorOutput"
+      },
+      {
+        "parameters": {
+          "mode": "runOnceForEachItem",
+          "jsCode": "// Merge generator response into row. Throws loudly if generator failed.\nconst apiResp = $input.item.json;\nconst row = $('Image Router').item.json;\nif (apiResp && apiResp.url) {\n  const { _needsImage, _apiBody, ...cleanRow } = row;\n  cleanRow.media_url = apiResp.url;\n  cleanRow.metadata = { ...(row.metadata || {}), image_source: 'generator' };\n  return cleanRow;\n}\nthrow new Error(\n  'generate-image API returned no url for slot ' +\n  (row.metadata?.slot_id || row.title || 'unknown') +\n  '. Response: ' + JSON.stringify(apiResp || {}).slice(0, 500)\n);"
+        },
+        "id": "c1a2b3d4-e5f6-7890-abcd-100000000004",
+        "name": "Merge Image URL",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          2288,
+          208
+        ]
+      },
+      {
+        "parameters": {
+          "conditions": {
+            "options": {
+              "caseSensitive": true,
+              "leftValue": "",
+              "typeValidation": "strict"
+            },
+            "conditions": [
+              {
+                "leftValue": "={{ $json._needsPhoto }}",
+                "rightValue": true,
+                "operator": {
+                  "type": "boolean",
+                  "operation": "true"
+                }
+              }
+            ],
+            "combinator": "and"
+          },
+          "options": {}
+        },
+        "id": "c1a2b3d4-e5f6-7890-abcd-100000000005",
+        "name": "Needs Photo?",
+        "type": "n8n-nodes-base.if",
+        "typeVersion": 2.2,
+        "position": [
+          1552,
+          576
+        ]
+      },
+      {
+        "parameters": {
+          "url": "https://media.creteprojects.com/photos/library.json",
+          "options": {
+            "timeout": 15000
+          }
+        },
+        "id": "c1a2b3d4-e5f6-7890-abcd-100000000006",
+        "name": "Fetch Photo Library",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          2288,
+          384
+        ]
+      },
+      {
+        "parameters": {
+          "mode": "runOnceForEachItem",
+          "jsCode": "// Select a random photo from library, filtered by theme. Throws if none usable.\n// $input.item.json IS the photo-library response (contains photos[]); the actual row\n// context (title/body/platform/etc.) lives upstream. Two upstream paths feed here:\n//   - normal photo path: Image Router emitted {_needsPhoto:true,...}\n//   - text-card-failed fallback path: Photo Fallback emitted {_fallback_from_generator:true,...}\n// Use Photo Fallback's output if it ran, else Image Router. $() throws if a node\n// didn't run in this execution, so guard with try/catch.\nlet row;\ntry {\n  const fb = $('Photo Fallback').item.json;\n  row = (fb && fb._fallback_from_generator) ? fb : $('Image Router').item.json;\n} catch (e) {\n  row = $('Image Router').item.json;\n}\nconst photoLib = $('Fetch Photo Library').item.json;\nconst photos = photoLib?.photos || photoLib?.body?.photos || [];\nif (!Array.isArray(photos) || photos.length === 0) {\n  throw new Error('Photo library returned 0 photos. Theme=' + (row._photoTheme || row.image_theme || 'any'));\n}\nconst theme = (row._photoTheme || row.image_theme || row.theme || '').toLowerCase();\nlet pool = photos;\nif (theme) {\n  const themed = photos.filter(p => ((p.theme || '') + ' ' + ((p.tags || []).join(' '))).toLowerCase().includes(theme));\n  if (themed.length > 0) pool = themed;\n}\nconst selected = pool[Math.floor(Math.random() * pool.length)];\nif (!selected || !selected.public_url) {\n  throw new Error('Photo library returned no usable photo for theme: ' + (theme || 'any') + '. Library size: ' + photos.length);\n}\n// Strip ALL transient flags including _needsImage/_apiBody (set by Image Router on text-card path,\n// would leak through on the fallback path).\nconst { _needsPhoto, _photoTheme, _fallback_from_generator, _needsImage, _apiBody, ...cleanRow } = row;\ncleanRow.media_url = selected.public_url;\ncleanRow.metadata = { ...(row.metadata || {}), image_source: row._fallback_from_generator ? 'library_fallback' : 'library', photo_id: selected.id };\nreturn cleanRow;"
+        },
+        "id": "c1a2b3d4-e5f6-7890-abcd-100000000007",
+        "name": "Select Random Photo",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          2512,
+          384
+        ]
+      },
+      {
+        "parameters": {
+          "jsCode": "// Fallback when generate-image errors: queue photo path, mark fallback for downstream alert.\nconst row = $('Image Router').item.json;\nreturn {\n  ...row,\n  _needsPhoto: true,\n  _photoTheme: row.image_theme || row.theme || '',\n  _fallback_from_generator: true\n};"
+        },
+        "id": "c0000000-0000-0000-0000-000000000030",
+        "name": "Photo Fallback",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          1728,
+          256
+        ]
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "=https://api.telegram.org/bot{{$env.TELEGRAM_BOT_TOKEN}}/sendMessage",
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ chat_id: 1375806243, text: '\\u26A0\\uFE0F Image generator unavailable, fell back to stock photo for ' + ($(\\'Image Router\\').item.json.title || 'slot') }) }}",
+          "options": {
+            "timeout": 15000
+          }
+        },
+        "id": "c0000000-0000-0000-0000-000000000031",
+        "name": "Telegram Fallback Alert",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1904,
+          256
+        ],
+        "onError": "continueRegularOutput"
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'started'::text, 'Crete - Content Generator'::text, '{{ $execution.id }}'::text);",
+          "options": {}
+        },
+        "name": "Heartbeat: Start",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          -56,
+          320
+        ],
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true,
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "2a87b135-cb9a-481c-a34d-a84f7d476910"
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'success'::text, 'Crete - Content Generator'::text, '{{ $execution.id }}'::text);",
+          "options": {}
+        },
+        "name": "Heartbeat: Success",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          3594,
+          432
+        ],
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true,
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "1deffb07-ae1a-46d1-8017-685e8bbf8cf9"
+      }
+    ],
+    "connections": {
+      "Schedule 08:00 UTC": {
+        "main": [
+          [
+            {
+              "node": "Fetch Calendar",
+              "type": "main",
+              "index": 0
+            },
+            {
+              "node": "Heartbeat: Start",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Fetch Calendar": {
+        "main": [
+          [
+            {
+              "node": "Filter Due Slots",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Filter Due Slots": {
+        "main": [
+          [
+            {
+              "node": "Build Prompt",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Build Prompt": {
+        "main": [
+          [
+            {
+              "node": "Claude API",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Claude API": {
+        "main": [
+          [
+            {
+              "node": "Build Row",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Build Row": {
+        "main": [
+          [
+            {
+              "node": "Image Router",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Insert to Supabase": {
+        "main": [
+          [
+            {
+              "node": "Telegram Notify",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Image Router": {
+        "main": [
+          [
+            {
+              "node": "Needs Image?",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Needs Image?": {
+        "main": [
+          [
+            {
+              "node": "Generate Text Card",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Needs Photo?",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Generate Text Card": {
+        "main": [
+          [
+            {
+              "node": "Merge Image URL",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Photo Fallback",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Merge Image URL": {
+        "main": [
+          [
+            {
+              "node": "Insert to Supabase",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Needs Photo?": {
+        "main": [
+          [
+            {
+              "node": "Fetch Photo Library",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Insert to Supabase",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Fetch Photo Library": {
+        "main": [
+          [
+            {
+              "node": "Select Random Photo",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Select Random Photo": {
+        "main": [
+          [
+            {
+              "node": "Insert to Supabase",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Photo Fallback": {
+        "main": [
+          [
+            {
+              "node": "Telegram Fallback Alert",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Telegram Fallback Alert": {
+        "main": [
+          [
+            {
+              "node": "Fetch Photo Library",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Heartbeat: Start": {
+        "main": [
+          []
+        ]
+      },
+      "Telegram Notify": {
+        "main": [
+          [
+            {
+              "node": "Heartbeat: Success",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      }
+    },
+    "authors": "Tyson Venables",
+    "name": null,
+    "description": null,
+    "autosaved": false,
+    "workflowPublishHistory": [
+      {
+        "createdAt": "2026-05-13T21:20:11.110Z",
+        "id": 969,
+        "workflowId": "tnvXFYvODL1PrhJa",
+        "versionId": "45672940-47df-4448-a6ae-74276b5c9e8d",
+        "event": "activated",
+        "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d"
+      }
+    ]
   }
 }

--- a/n8n-workflows/zXKBjp3yjW2oR2Mj-crete-content-publish.json
+++ b/n8n-workflows/zXKBjp3yjW2oR2Mj-crete-content-publish.json
@@ -1,7 +1,11 @@
 {
+  "updatedAt": "2026-05-13T21:21:00.887Z",
+  "createdAt": "2026-04-11T07:11:36.400Z",
   "id": "zXKBjp3yjW2oR2Mj",
   "name": "Crete - Content Publish",
   "description": null,
+  "active": true,
+  "isArchived": false,
   "nodes": [
     {
       "parameters": {
@@ -160,10 +164,10 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "=https://graph.facebook.com/v19.0/{{$env.META_PAGE_ID}}/feed",
+        "url": "=https://graph.facebook.com/v19.0/{{$env.META_PAGE_ID}}/photos",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"message\": {{ JSON.stringify($json.body) }},\n  \"access_token\": \"{{$env.META_PAGE_ACCESS_TOKEN}}\"\n}",
+        "jsonBody": "={\n  \"url\": {{ JSON.stringify($json.media_url) }},\n  \"caption\": {{ JSON.stringify($json.body || \"\") }},\n  \"access_token\": \"{{$env.META_PAGE_ACCESS_TOKEN}}\"\n}",
         "options": {}
       },
       "id": "b1c2d3e4-f5a6-7890-abcd-ef1234567002",
@@ -361,6 +365,7 @@
           "cachedResultUrl": "https://backend.blotato.com/v2/accounts/11109"
         },
         "postContentText": "={{ $('Extract Item').item.json.body }}",
+        "postContentMediaUrls": "={{ $('Extract Item').item.json.media_url }}",
         "options": {}
       },
       "type": "@blotato/n8n-nodes-blotato.blotato",
@@ -453,7 +458,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Validate media_url is present for platforms that require it.\nconst item = $input.first().json;\nconst platform = (item.platform || '').toLowerCase();\nif (platform === 'instagram' && !item.media_url) {\n  return [{ json: { ...item, _validation_failed: true, _failure_reason: 'missing_media_for_instagram' } }];\n}\nreturn [{ json: { ...item, _validation_failed: false } }];"
+        "jsCode": "// Validate media_url is present for platforms that require it.\n// Slice 4: extended from instagram-only to instagram+facebook+linkedin.\n// Other platforms (e.g. 'other') bypass validation as before.\nconst item = $input.first().json;\nconst platform = (item.platform || '').toLowerCase();\nconst NEEDS_MEDIA = ['instagram', 'facebook', 'linkedin'];\nif (NEEDS_MEDIA.includes(platform) && !item.media_url) {\n  return [{ json: { ...item, _validation_failed: true, _failure_reason: 'missing_media_for_' + platform } }];\n}\nreturn [{ json: { ...item, _validation_failed: false } }];"
       },
       "id": "b0000000-0000-0000-0000-000000000020",
       "name": "Validate Media",
@@ -1099,5 +1104,1218 @@
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": true,
     "errorWorkflow": "7kpNnMtnuDWXgWcX"
+  },
+  "staticData": null,
+  "meta": null,
+  "pinData": {
+    "Webhook": [
+      {
+        "json": {
+          "headers": {
+            "host": "webhook.flowos.tech",
+            "user-agent": "axios/1.12.0",
+            "content-length": "53",
+            "accept": "application/json,text/html,application/xhtml+xml,application/xml,text/*;q=0.9, image/*;q=0.8, */*;q=0.7",
+            "accept-encoding": "gzip, br",
+            "cdn-loop": "cloudflare; loops=1",
+            "cf-connecting-ip": "157.230.216.158",
+            "cf-ipcountry": "US",
+            "cf-ray": "9f2e59e09cae2f06-EWR",
+            "cf-visitor": "{\"scheme\":\"https\"}",
+            "cf-warp-tag-id": "cea92e4d-bc65-4890-b7d7-f3ed9b35a652",
+            "connection": "keep-alive",
+            "content-type": "application/json",
+            "x-forwarded-for": "157.230.216.158",
+            "x-forwarded-proto": "https"
+          },
+          "params": {},
+          "query": {},
+          "body": {
+            "content_id": "c9e4332b-baa8-4b10-898a-6e847fb9e764"
+          },
+          "webhookUrl": "https://webhook.flowos.tech/webhook/crete-content-publish",
+          "executionMode": "production"
+        },
+        "pairedItem": {
+          "item": 0
+        }
+      }
+    ]
+  },
+  "versionId": "3fd76c15-4de1-4570-956a-0bbd4aa3de55",
+  "activeVersionId": "3fd76c15-4de1-4570-956a-0bbd4aa3de55",
+  "versionCounter": 84,
+  "triggerCount": 1,
+  "shared": [
+    {
+      "updatedAt": "2026-04-11T07:11:36.400Z",
+      "createdAt": "2026-04-11T07:11:36.400Z",
+      "role": "workflow:owner",
+      "workflowId": "zXKBjp3yjW2oR2Mj",
+      "projectId": "KwpTDWcFWL3DfyW3",
+      "project": {
+        "updatedAt": "2026-04-08T20:28:08.726Z",
+        "createdAt": "2025-06-06T11:27:14.830Z",
+        "id": "KwpTDWcFWL3DfyW3",
+        "name": "Tyson Venables <tysonvenables@protonmail.com>",
+        "type": "personal",
+        "icon": null,
+        "description": null,
+        "creatorId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+        "projectRelations": [
+          {
+            "updatedAt": "2025-06-06T11:27:14.830Z",
+            "createdAt": "2025-06-06T11:27:14.830Z",
+            "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+            "projectId": "KwpTDWcFWL3DfyW3",
+            "user": {
+              "updatedAt": "2026-05-13T02:04:11.362Z",
+              "createdAt": "2025-06-06T11:27:13.858Z",
+              "id": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+              "email": "tysonvenables@protonmail.com",
+              "firstName": "Tyson",
+              "lastName": "Venables",
+              "personalizationAnswers": {
+                "version": "v4",
+                "personalization_survey_submitted_at": "2025-06-06T11:42:52.454Z",
+                "personalization_survey_n8n_version": "1.95.3",
+                "companySize": "<20",
+                "companyType": "saas",
+                "role": "business-owner",
+                "reportedSource": "friend"
+              },
+              "settings": {
+                "userActivated": true,
+                "easyAIWorkflowOnboarded": true,
+                "firstSuccessfulWorkflowId": "WVXrFCjb8wO7RWRX",
+                "userActivatedAt": 1751062185356,
+                "npsSurvey": {
+                  "responded": true,
+                  "lastShownAt": 1769430963515
+                }
+              },
+              "disabled": false,
+              "mfaEnabled": false,
+              "lastActiveAt": "2026-05-13",
+              "isPending": false
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "tags": [],
+  "activeVersion": {
+    "updatedAt": "2026-05-13T21:21:00.895Z",
+    "createdAt": "2026-05-13T21:21:00.895Z",
+    "versionId": "3fd76c15-4de1-4570-956a-0bbd4aa3de55",
+    "workflowId": "zXKBjp3yjW2oR2Mj",
+    "nodes": [
+      {
+        "parameters": {
+          "httpMethod": "POST",
+          "path": "crete-content-publish",
+          "responseMode": "responseNode",
+          "options": {}
+        },
+        "id": "47d88f72-a27d-4277-ba0c-c9af0632b426",
+        "name": "Webhook",
+        "type": "n8n-nodes-base.webhook",
+        "typeVersion": 2,
+        "position": [
+          240,
+          304
+        ],
+        "webhookId": "crete-content-publish"
+      },
+      {
+        "parameters": {
+          "url": "=https://fdabygmromuqtysitodp.supabase.co/rest/v1/crete_content_queue?id=eq.{{ $json.body.content_id }}",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+              }
+            ]
+          },
+          "options": {}
+        },
+        "id": "03fa15d6-9459-4c19-91dd-252e315d566b",
+        "name": "Get Content",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          464,
+          304
+        ],
+        "credentials": {
+          "httpHeaderAuth": {
+            "id": "Nd2uuX5t9KEwbQPv",
+            "name": "Supabase FSC"
+          }
+        }
+      },
+      {
+        "parameters": {
+          "jsCode": "const data = $input.first().json;\nconst item = Array.isArray(data) ? data[0] : data;\nif (!item || !item.id) {\n  throw new Error('Content not found for id');\n}\nreturn [{ json: item }];\n"
+        },
+        "id": "4b9ad5c6-c765-41a1-82ab-4ecfad8dccfc",
+        "name": "Extract Item",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          688,
+          304
+        ]
+      },
+      {
+        "parameters": {
+          "rules": {
+            "values": [
+              {
+                "conditions": {
+                  "options": {
+                    "caseSensitive": true,
+                    "leftValue": "",
+                    "typeValidation": "strict",
+                    "version": 2
+                  },
+                  "conditions": [
+                    {
+                      "leftValue": "={{ $json.platform }}",
+                      "rightValue": "facebook",
+                      "operator": {
+                        "type": "string",
+                        "operation": "equals"
+                      },
+                      "id": "4e0a1a02-3384-4f5e-94ba-afff52d31f80"
+                    }
+                  ],
+                  "combinator": "and"
+                },
+                "renameOutput": true,
+                "outputKey": "Facebook"
+              },
+              {
+                "conditions": {
+                  "options": {
+                    "caseSensitive": true,
+                    "leftValue": "",
+                    "typeValidation": "strict",
+                    "version": 2
+                  },
+                  "conditions": [
+                    {
+                      "leftValue": "={{ $json.platform }}",
+                      "rightValue": "instagram",
+                      "operator": {
+                        "type": "string",
+                        "operation": "equals"
+                      },
+                      "id": "e2c7f198-4e76-48c5-88cd-c62859b20c60"
+                    }
+                  ],
+                  "combinator": "and"
+                },
+                "renameOutput": true,
+                "outputKey": "Instagram"
+              },
+              {
+                "conditions": {
+                  "options": {
+                    "caseSensitive": true,
+                    "leftValue": "",
+                    "typeValidation": "strict",
+                    "version": 2
+                  },
+                  "conditions": [
+                    {
+                      "leftValue": "={{ $json.platform }}",
+                      "rightValue": "linkedin",
+                      "operator": {
+                        "type": "string",
+                        "operation": "equals"
+                      },
+                      "id": "1adbdfd3-8c4e-41a9-97cd-559b30fb5092"
+                    }
+                  ],
+                  "combinator": "and"
+                },
+                "renameOutput": true,
+                "outputKey": "LinkedIn"
+              }
+            ]
+          },
+          "options": {
+            "fallbackOutput": "extra"
+          }
+        },
+        "id": "b1c2d3e4-f5a6-7890-abcd-ef1234567001",
+        "name": "Platform Switch",
+        "type": "n8n-nodes-base.switch",
+        "typeVersion": 3.2,
+        "position": [
+          912,
+          304
+        ]
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "=https://graph.facebook.com/v19.0/{{$env.META_PAGE_ID}}/photos",
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={\n  \"url\": {{ JSON.stringify($json.media_url) }},\n  \"caption\": {{ JSON.stringify($json.body || \"\") }},\n  \"access_token\": \"{{$env.META_PAGE_ACCESS_TOKEN}}\"\n}",
+          "options": {}
+        },
+        "id": "b1c2d3e4-f5a6-7890-abcd-ef1234567002",
+        "name": "Facebook Post",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1152,
+          112
+        ],
+        "onError": "continueErrorOutput",
+        "retryOnFail": false
+      },
+      {
+        "parameters": {
+          "assignments": {
+            "assignments": [
+              {
+                "id": "field-id",
+                "name": "id",
+                "type": "string",
+                "value": "={{ $('Extract Item').item.json.id }}"
+              },
+              {
+                "id": "field-title",
+                "name": "title",
+                "type": "string",
+                "value": "={{ $('Extract Item').item.json.title }}"
+              },
+              {
+                "id": "field-platform",
+                "name": "platform",
+                "type": "string",
+                "value": "={{ $('Extract Item').item.json.platform }}"
+              },
+              {
+                "id": "field-result",
+                "name": "publish_result",
+                "type": "string",
+                "value": "={{ JSON.stringify($json) }}"
+              }
+            ]
+          },
+          "options": {}
+        },
+        "id": "b1c2d3e4-f5a6-7890-abcd-ef1234567003",
+        "name": "FB Restore Fields",
+        "type": "n8n-nodes-base.set",
+        "typeVersion": 3.4,
+        "position": [
+          1360,
+          112
+        ]
+      },
+      {
+        "parameters": {
+          "assignments": {
+            "assignments": [
+              {
+                "id": "field-id",
+                "name": "id",
+                "type": "string",
+                "value": "={{ $('Extract Item').item.json.id }}"
+              },
+              {
+                "id": "field-title",
+                "name": "title",
+                "type": "string",
+                "value": "={{ $('Extract Item').item.json.title }}"
+              },
+              {
+                "id": "field-platform",
+                "name": "platform",
+                "type": "string",
+                "value": "={{ $('Extract Item').item.json.platform }}"
+              },
+              {
+                "id": "field-result",
+                "name": "publish_result",
+                "type": "string",
+                "value": "={{ JSON.stringify($json) }}"
+              }
+            ]
+          },
+          "options": {}
+        },
+        "id": "b1c2d3e4-f5a6-7890-abcd-ef1234567007",
+        "name": "IG Restore Fields",
+        "type": "n8n-nodes-base.set",
+        "typeVersion": 3.4,
+        "position": [
+          1808,
+          256
+        ]
+      },
+      {
+        "parameters": {
+          "jsCode": "const item = $input.first().json;\nconst platform = item.platform || 'unknown';\nconst reason = platform === 'linkedin' ? 'LinkedIn TODO - uses Blotato' : `Unsupported platform: ${platform}`;\nreturn [{ json: { ...item, publish_result: { skipped: true, reason } } }];\n"
+        },
+        "id": "b1c2d3e4-f5a6-7890-abcd-ef1234567009",
+        "name": "Other Platform Skip",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          1152,
+          752
+        ]
+      },
+      {
+        "parameters": {
+          "method": "PATCH",
+          "url": "=https://fdabygmromuqtysitodp.supabase.co/rest/v1/crete_content_queue?id=eq.{{ $json.id }}",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "name": "Prefer",
+                "value": "return=representation"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ status: 'published', published_at: new Date().toISOString(), publish_attempts: ($('Extract Item').item.json.publish_attempts || 0) + 1, last_attempt_at: new Date().toISOString() }) }}",
+          "options": {}
+        },
+        "id": "72594655-9378-488f-8eb7-40f0edf8aa2c",
+        "name": "Update Status",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          2032,
+          304
+        ],
+        "credentials": {
+          "httpHeaderAuth": {
+            "id": "Nd2uuX5t9KEwbQPv",
+            "name": "Supabase FSC"
+          }
+        }
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "=https://api.telegram.org/bot{{$env.TELEGRAM_BOT_TOKEN}}/sendMessage",
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={\n  \"chat_id\": 1375806243,\n  \"text\": \"\u2705 Published: {{ $('Extract Item').item.json.title }} to {{ $('Extract Item').item.json.platform }}\",\n  \"parse_mode\": \"Markdown\"\n}",
+          "options": {}
+        },
+        "id": "6550713c-3983-43bc-b876-fd1b0d573a56",
+        "name": "Telegram Notify",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          2240,
+          304
+        ]
+      },
+      {
+        "parameters": {
+          "respondWith": "json",
+          "responseBody": "={ \"success\": true, \"content_id\": \"{{ $('Extract Item').item.json.id }}\", \"status\": \"published\" }",
+          "options": {}
+        },
+        "id": "1fb3076b-01c2-4ba3-90a0-883910a65cc2",
+        "name": "Respond",
+        "type": "n8n-nodes-base.respondToWebhook",
+        "typeVersion": 1.1,
+        "position": [
+          2464,
+          304
+        ]
+      },
+      {
+        "parameters": {
+          "platform": "linkedin",
+          "accountId": {
+            "__rl": true,
+            "value": "11109",
+            "mode": "list",
+            "cachedResultName": "Tyson Venables",
+            "cachedResultUrl": "https://backend.blotato.com/v2/accounts/11109"
+          },
+          "postContentText": "={{ $('Extract Item').item.json.body }}",
+          "postContentMediaUrls": "={{ $('Extract Item').item.json.media_url }}",
+          "options": {}
+        },
+        "type": "@blotato/n8n-nodes-blotato.blotato",
+        "typeVersion": 2,
+        "position": [
+          1152,
+          560
+        ],
+        "id": "d1e2f3a4-b5c6-7890-abcd-200000000001",
+        "name": "LinkedIn Post (Blotato)",
+        "credentials": {
+          "blotatoApi": {
+            "id": "Bs2TEAOA9mVKfcR3",
+            "name": "Blotato account"
+          }
+        },
+        "onError": "continueErrorOutput",
+        "retryOnFail": false
+      },
+      {
+        "parameters": {
+          "assignments": {
+            "assignments": [
+              {
+                "id": "field-id",
+                "name": "id",
+                "type": "string",
+                "value": "={{ $('Extract Item').item.json.id }}"
+              },
+              {
+                "id": "field-title",
+                "name": "title",
+                "type": "string",
+                "value": "={{ $('Extract Item').item.json.title }}"
+              },
+              {
+                "id": "field-platform",
+                "name": "platform",
+                "type": "string",
+                "value": "={{ $('Extract Item').item.json.platform }}"
+              },
+              {
+                "id": "field-result",
+                "name": "publish_result",
+                "type": "string",
+                "value": "={{ JSON.stringify($json) }}"
+              }
+            ]
+          },
+          "options": {}
+        },
+        "id": "d1e2f3a4-b5c6-7890-abcd-200000000002",
+        "name": "LI Restore Fields",
+        "type": "n8n-nodes-base.set",
+        "typeVersion": 3.4,
+        "position": [
+          1376,
+          368
+        ]
+      },
+      {
+        "parameters": {
+          "accountId": {
+            "__rl": true,
+            "value": "43178",
+            "mode": "list",
+            "cachedResultName": "creteprojects",
+            "cachedResultUrl": "https://backend.blotato.com/v2/accounts/43178"
+          },
+          "postContentText": "={{ $('Extract Item').item.json.body }}",
+          "postContentMediaUrls": "={{ $('Extract Item').item.json.media_url }}",
+          "options": {}
+        },
+        "type": "@blotato/n8n-nodes-blotato.blotato",
+        "typeVersion": 2,
+        "position": [
+          1360,
+          304
+        ],
+        "id": "d1e2f3a4-b5c6-7890-abcd-200000000002",
+        "name": "Instagram Post (Blotato)",
+        "credentials": {
+          "blotatoApi": {
+            "id": "Bs2TEAOA9mVKfcR3",
+            "name": "Blotato account"
+          }
+        },
+        "onError": "continueErrorOutput",
+        "retryOnFail": false
+      },
+      {
+        "parameters": {
+          "jsCode": "// Validate media_url is present for platforms that require it.\n// Slice 4: extended from instagram-only to instagram+facebook+linkedin.\n// Other platforms (e.g. 'other') bypass validation as before.\nconst item = $input.first().json;\nconst platform = (item.platform || '').toLowerCase();\nconst NEEDS_MEDIA = ['instagram', 'facebook', 'linkedin'];\nif (NEEDS_MEDIA.includes(platform) && !item.media_url) {\n  return [{ json: { ...item, _validation_failed: true, _failure_reason: 'missing_media_for_' + platform } }];\n}\nreturn [{ json: { ...item, _validation_failed: false } }];"
+        },
+        "id": "b0000000-0000-0000-0000-000000000020",
+        "name": "Validate Media",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          780,
+          300
+        ]
+      },
+      {
+        "parameters": {
+          "conditions": {
+            "options": {
+              "caseSensitive": true,
+              "leftValue": "",
+              "typeValidation": "strict"
+            },
+            "conditions": [
+              {
+                "leftValue": "={{ $json._validation_failed }}",
+                "rightValue": true,
+                "operator": {
+                  "type": "boolean",
+                  "operation": "true"
+                }
+              }
+            ],
+            "combinator": "and"
+          }
+        },
+        "id": "b0000000-0000-0000-0000-000000000021",
+        "name": "Validation Failed?",
+        "type": "n8n-nodes-base.if",
+        "typeVersion": 2.2,
+        "position": [
+          960,
+          300
+        ]
+      },
+      {
+        "parameters": {
+          "method": "PATCH",
+          "url": "=https://fdabygmromuqtysitodp.supabase.co/rest/v1/crete_content_queue?id=eq.{{ $json.id }}",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "name": "Prefer",
+                "value": "return=minimal"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ status: 'failed', publish_attempts: ($json.publish_attempts || 0) + 1, last_error: $json._failure_reason, last_attempt_at: new Date().toISOString() }) }}",
+          "options": {
+            "timeout": 15000
+          }
+        },
+        "id": "b0000000-0000-0000-0000-000000000022",
+        "name": "Mark Failed (Validation)",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1180,
+          200
+        ],
+        "credentials": {
+          "httpHeaderAuth": {
+            "id": "Nd2uuX5t9KEwbQPv",
+            "name": "Supabase FSC"
+          }
+        },
+        "onError": "continueRegularOutput"
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "=https://api.telegram.org/bot{{$env.TELEGRAM_BOT_TOKEN}}/sendMessage",
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ chat_id: 1375806243, text: '\\u{1F6D1} Crete publish blocked \u2014 ' + ($(\\'Extract Item\\').item.json.title || $json.id) + ' | reason: ' + ($(\\'Extract Item\\').item.json._failure_reason || 'validation') + ' | id: ' + $(\\'Extract Item\\').item.json.id }) }}",
+          "options": {
+            "timeout": 15000
+          }
+        },
+        "id": "b0000000-0000-0000-0000-000000000023",
+        "name": "Telegram Validation Failed",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1380,
+          200
+        ],
+        "onError": "continueRegularOutput"
+      },
+      {
+        "parameters": {
+          "respondWith": "json",
+          "responseBody": "={{ JSON.stringify({ success: false, reason: $('Validate Media').item.json._failure_reason || 'validation_failed', content_id: $('Extract Item').item.json.id }) }}",
+          "options": {
+            "responseCode": 422
+          }
+        },
+        "id": "b0000000-0000-0000-0000-000000000024",
+        "name": "Respond Validation Failed",
+        "type": "n8n-nodes-base.respondToWebhook",
+        "typeVersion": 1.1,
+        "position": [
+          1580,
+          200
+        ]
+      },
+      {
+        "parameters": {
+          "jsCode": "// Build PATCH body for incrementing publish_attempts and capturing error.\nconst item = $('Extract Item').item.json;\nconst err = $input.first().json;\nconst attempts = (item.publish_attempts || 0) + 1;\nconst errMsg = (err.error?.message || (typeof err === 'string' ? err : JSON.stringify(err))).slice(0, 1000);\nreturn [{ json: {\n  id: item.id,\n  publish_attempts: attempts,\n  last_error: errMsg,\n  last_attempt_at: new Date().toISOString(),\n  status: attempts >= 3 ? 'failed' : 'approved',\n  _will_retry: attempts < 3\n} }];"
+        },
+        "id": "b0000000-0000-0000-0000-000000000025",
+        "name": "Increment Attempts",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          1180,
+          480
+        ]
+      },
+      {
+        "parameters": {
+          "method": "PATCH",
+          "url": "=https://fdabygmromuqtysitodp.supabase.co/rest/v1/crete_content_queue?id=eq.{{ $json.id }}",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "name": "Prefer",
+                "value": "return=minimal"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ publish_attempts: $json.publish_attempts, last_error: $json.last_error, last_attempt_at: $json.last_attempt_at, status: $json.status }) }}",
+          "options": {
+            "timeout": 15000
+          }
+        },
+        "id": "b0000000-0000-0000-0000-000000000026",
+        "name": "Patch Attempts",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1380,
+          480
+        ],
+        "credentials": {
+          "httpHeaderAuth": {
+            "id": "Nd2uuX5t9KEwbQPv",
+            "name": "Supabase FSC"
+          }
+        },
+        "onError": "continueRegularOutput"
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "=https://api.telegram.org/bot{{$env.TELEGRAM_BOT_TOKEN}}/sendMessage",
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ chat_id: 1375806243, text: ($json._will_retry ? '\\u26A0\\uFE0F Crete publish failed (will retry): ' : '\\u{1F6D1} Crete publish PERMANENTLY failed (3 attempts): ') + ($(\\'Extract Item\\').item.json.title || $json.id) + ' | ' + ($json.last_error || '').slice(0, 200) }) }}",
+          "options": {
+            "timeout": 15000
+          }
+        },
+        "id": "b0000000-0000-0000-0000-000000000027",
+        "name": "Telegram Publish Failed",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1580,
+          480
+        ],
+        "onError": "continueRegularOutput"
+      },
+      {
+        "parameters": {
+          "respondWith": "json",
+          "responseBody": "={{ JSON.stringify({ success: false, attempt: $json.publish_attempts, will_retry: $json._will_retry, content_id: $json.id, error: ($json.last_error || '').slice(0, 200) }) }}",
+          "options": {
+            "responseCode": 502
+          }
+        },
+        "id": "b0000000-0000-0000-0000-000000000028",
+        "name": "Respond Publish Failed",
+        "type": "n8n-nodes-base.respondToWebhook",
+        "typeVersion": 1.1,
+        "position": [
+          1780,
+          480
+        ]
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'started'::text, 'Crete - Content Publish'::text, '{{ $execution.id }}'::text);",
+          "options": {}
+        },
+        "name": "Heartbeat: Start",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          440,
+          304
+        ],
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true,
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "3f8f56e7-baa1-481d-b18f-026a130ce01f"
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'success'::text, 'Crete - Content Publish'::text, '{{ $execution.id }}'::text);",
+          "options": {}
+        },
+        "name": "Heartbeat: Success",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          2160,
+          300
+        ],
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true,
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "9116ed1b-53f6-4a5a-9963-e378385e7372"
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'error'::text, 'Crete - Content Publish'::text, '{{ $execution.id }}'::text, '{{ JSON.stringify({node:\"Validation\"}) }}'::jsonb);",
+          "options": {}
+        },
+        "name": "Heartbeat: Error (Validation)",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          1630,
+          200
+        ],
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true,
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "2c3f0713-eb30-4ccc-8436-37faa1ec11d5"
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'error'::text, 'Crete - Content Publish'::text, '{{ $execution.id }}'::text, '{{ JSON.stringify({node:\"Publish\"}) }}'::jsonb);",
+          "options": {}
+        },
+        "name": "Heartbeat: Error (Publish)",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          1830,
+          480
+        ],
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true,
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "115d67f6-5a38-455d-b82e-1dd28a6616d6"
+      }
+    ],
+    "connections": {
+      "Webhook": {
+        "main": [
+          [
+            {
+              "node": "Get Content",
+              "type": "main",
+              "index": 0
+            },
+            {
+              "node": "Heartbeat: Start",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Get Content": {
+        "main": [
+          [
+            {
+              "node": "Extract Item",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Extract Item": {
+        "main": [
+          [
+            {
+              "node": "Validate Media",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Platform Switch": {
+        "main": [
+          [
+            {
+              "node": "Facebook Post",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Instagram Post (Blotato)",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "LinkedIn Post (Blotato)",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Other Platform Skip",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Facebook Post": {
+        "main": [
+          [
+            {
+              "node": "FB Restore Fields",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Increment Attempts",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "FB Restore Fields": {
+        "main": [
+          [
+            {
+              "node": "Update Status",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "IG Restore Fields": {
+        "main": [
+          [
+            {
+              "node": "Update Status",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Other Platform Skip": {
+        "main": [
+          [
+            {
+              "node": "Update Status",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Update Status": {
+        "main": [
+          [
+            {
+              "node": "Telegram Notify",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Telegram Notify": {
+        "main": [
+          [
+            {
+              "node": "Heartbeat: Success",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "LinkedIn Post (Blotato)": {
+        "main": [
+          [
+            {
+              "node": "LI Restore Fields",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Increment Attempts",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "LI Restore Fields": {
+        "main": [
+          [
+            {
+              "node": "Update Status",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Instagram Post (Blotato)": {
+        "main": [
+          [
+            {
+              "node": "IG Restore Fields",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Increment Attempts",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Validate Media": {
+        "main": [
+          [
+            {
+              "node": "Validation Failed?",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Validation Failed?": {
+        "main": [
+          [
+            {
+              "node": "Mark Failed (Validation)",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Platform Switch",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Mark Failed (Validation)": {
+        "main": [
+          [
+            {
+              "node": "Telegram Validation Failed",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Telegram Validation Failed": {
+        "main": [
+          [
+            {
+              "node": "Heartbeat: Error (Validation)",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Increment Attempts": {
+        "main": [
+          [
+            {
+              "node": "Patch Attempts",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Patch Attempts": {
+        "main": [
+          [
+            {
+              "node": "Telegram Publish Failed",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Telegram Publish Failed": {
+        "main": [
+          [
+            {
+              "node": "Heartbeat: Error (Publish)",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Heartbeat: Start": {
+        "main": [
+          []
+        ]
+      },
+      "Heartbeat: Success": {
+        "main": [
+          [
+            {
+              "node": "Respond",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Heartbeat: Error (Validation)": {
+        "main": [
+          [
+            {
+              "node": "Respond Validation Failed",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Heartbeat: Error (Publish)": {
+        "main": [
+          [
+            {
+              "node": "Respond Publish Failed",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      }
+    },
+    "authors": "Tyson Venables",
+    "name": null,
+    "description": null,
+    "autosaved": false,
+    "workflowPublishHistory": [
+      {
+        "createdAt": "2026-05-13T21:21:01.435Z",
+        "id": 970,
+        "workflowId": "zXKBjp3yjW2oR2Mj",
+        "versionId": "3fd76c15-4de1-4570-956a-0bbd4aa3de55",
+        "event": "activated",
+        "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Two-workflow fix for Crete Bug 2 from `/tmp/marketing_image_audit_20260513.md`.

**`tnvXFYvODL1PrhJa` (Crete - Content Generator) — 1 node modified:**
- `Image Router` opened from IG-only to IG + Facebook + LinkedIn. Pre-Slice-4: `if (!isInstagram) return row` skipped image generation for FB/LinkedIn rows. Post-Slice-4: `NEEDS_IMAGE = ['instagram','facebook','linkedin']`. Default `imageType = 'text_card'` (matches IG's pre-Slice-4 default); `'photo'` branch and unsupported-platform passthrough preserved verbatim.

**`zXKBjp3yjW2oR2Mj` (Crete - Content Publish) — 3 nodes modified:**
- `LinkedIn Post (Blotato)`: added `postContentMediaUrls: "={{ $('Extract Item').item.json.media_url }}"` (byte-for-byte mirror of IG node's expression; same pattern as Slice 3 used on the GHL Publisher).
- `Facebook Post`: endpoint changed from Graph `/feed` to `/photos` (mirror of the Apr 27 PM GHL Publisher pattern). Body now `{url, caption, access_token}` with `url: $json.media_url`, `caption: $json.body`. Crete-side `META_PAGE_ID` and `META_PAGE_ACCESS_TOKEN` env refs preserved (Crete and GHL have separate Meta page credentials per `LOCATIONS.md`).
- `Validate Media`: `NEEDS_MEDIA` expanded from `['instagram']` to all three. Dynamic `_failure_reason = 'missing_media_for_' + platform`. Failure routes through the existing Apr 30 `Mark Failed (Validation)` PATCH path (same audit trail).

## PUT verification

| Workflow | PUT | updatedAt | availableInMCP | Verify |
|---|---|---|---|---|
| tnvXFYvODL1PrhJa | HTTP 200 | 2026-05-13T21:20:10.940Z | true (in `settings`) | No IG early-return; supports FB+LI+IG; defaults correct; photo branch + passthrough preserved |
| zXKBjp3yjW2oR2Mj | HTTP 200 | 2026-05-13T21:21:00.887Z | true (in `settings`) | Validate Media covers 3 platforms; FB `/photos` with `url`+`caption`; LI has `postContentMediaUrls`; IG unchanged |

## Queue backfill — Option D (no-op)

Per dispatch pause-point, read-only count on `crete_content_queue` for `platform IN ('facebook','linkedin') AND media_url IS NULL AND status IN ('pending_review','approved')`: **0 rows.**

Full queue at audit time: 43 published / 3 archived / 1 failed (the May 2 Apr-30 IG validation artifact). No active queue → none of Options A/B/C apply. Tyson confirmed Option D (no-op).

Of the 43 `published` rows, 27 are FB/LI with `media_url=NULL` — text-only posts that already shipped. Per dispatch's "Republishing already-`published` rows" exclusion, out of scope for this slice.

## Smoke tests

Static-only validation. No live trigger:
- Generator live-trigger would burn Claude API + text-card endpoint quota + insert a real `pending_review` row. Next 08:00 UTC cron (effective ~11:00 UTC per NY-timezone observation) is the natural smoke.
- Publisher live-trigger would publish to real FB/LinkedIn (no synthetic-row option without first inserting one).
- The GHL Publisher FB `/photos` pattern this dispatch mirrors is proven against Meta since Apr 27 PM. Switching Crete's env vars (`META_PAGE_ID` → different page id) doesn't change the API surface or auth pattern.

## Brief-conflicts surfaced

- Crete `Facebook Post` uses `META_PAGE_ID` + `META_PAGE_ACCESS_TOKEN` (NOT GHL's `FLOWOS_META_*`). Confirmed by static read before edit; env vars preserved unchanged.
- `Restore Fields` per-platform `set` nodes do not actively strip `media_url` (just don't include it in the new shape). `Update Status` downstream reads only `$('Extract Item').item.json.id` for the row patch, so `media_url` on the Supabase row is untouched throughout the publish chain. No preservation fix needed.
- `Generate Text Card` is platform-agnostic — confirmed by static read. No platform-specific styling difference required. Per-platform image dimensions (1:1 vs 1.91:1) could be a future enhancement, not in scope.

## Security gate (all green)

- [x] No hardcoded credentials added (env-var refs only)
- [x] No new webhooks / endpoints (FB endpoint change is same host, same auth scope)
- [x] No RLS / schema changes
- [x] No financial features touched
- [x] `.env` perms unchanged at 600 on both QClaw + n8n hosts
- [x] `settings.availableInMCP: true` confirmed via re-GET on both workflows
- [x] No stack traces or secrets exposed; `_failure_reason` is static literal prefix + lowercased platform
- [x] Credential references unchanged (Blotato 11109/43178, Supabase FSC, errorWorkflow 7kpNnMtnuDWXgWcX)
- [x] FB Graph endpoint change uses same auth pattern as GHL Publisher

## Out of scope (deferred / preserved)

- GHL Approval Handler regenerate path → Slice 5 (per `/tmp/regenerate_wipe_audit_20260513.md`)
- Crete Content Regenerate (`KKjw893zwzHwv1o6`) — not affected (sparse PATCH preserves `media_url`); also not yet mirrored to disk
- 27 historical FB/LI text-only `published` rows — explicit exclusion
- Crete cluster heartbeat / errorWorkflow rename
- Text-card endpoint root-cause (Apr 30 unresolved)

## Test plan

- [ ] Watch tomorrow's 08:00 UTC Generator cron tick. Confirm any FB or LinkedIn calendar slot produces a `pending_review` row with `media_url` populated.
- [ ] Confirm `metadata.image_source` is set on the new FB/LI rows (`'generator'` for text-card path, `'library'`/`'library_fallback'` for photo paths).
- [ ] When the Scheduled Publisher picks up the next approved FB or LI row, confirm Blotato/Graph fan-out succeeds with image attached on each platform.
- [ ] Negative test (optional): manually insert a synthetic LinkedIn row with `media_url=NULL` via SQL, fire the Publish webhook, confirm it's marked `status='failed'` with `last_error='missing_media_for_linkedin'`. (Mirror the Apr 30 IG validation test pattern.)
- [ ] Monitor text-card endpoint load — should roughly 3× from IG-only daily to IG+FB+LI daily. Filed for the Apr 30 unresolved-text-card investigation.
