### PR TITLE
fix(ghl-marketing): preserve image_url + cap hashtags + fix Draft ID in regenerate path (Slice 5)

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -9467,3 +9467,148 @@ investigation when it resumes.
   `Validate Media` first appeared with IG-only scope, plus the
   `publish_attempts` / `last_error` / `last_attempt_at` columns this
   slice's failure path now also exercises for FB+LI rows).
+
+## 2026-05-13 — Slice 5: GHL regenerate fixes (image_url forward + Cap Hashtags + Telegram Draft ID)
+
+Per `/tmp/regenerate_wipe_audit_20260513.md` (Slice 1.5). Bundled three
+defects on the same workflow — image_url wipe (W2), Cap Hashtags bypass,
+empty-Draft-ID Telegram bug — into a single PUT. Both trigger tracks
+(Telegram-feedback via `Route Action` and Dashboard-webhook via
+`Parse Dashboard Input`) converge at `Normalize Trigger` and share the
+downstream chain, so all three fixes apply to both paths in one PR.
+
+**Branch:** `cc/slice5-ghl-regenerate-fixes-20260513` (created from `main`
+@ `77cfbb5`, after Slice 4 PR #13 merged).
+
+### Workflow touched
+
+**`ptHK2TZq5XppKOOg` — GHL Marketing: Approval Handler (19 → 20 nodes,
+3 nodes modified + 1 added + connections rewired)**
+
+- **`Parse Regenerated` (Code) — modified.** Now extracts `imageUrl` from
+  `Fetch Original Draft` data using the same array-or-object unwrap
+  pattern already used for `postType` (Supabase returns arrays from
+  `?select=*`), and emits `image_url: imageUrl ?? null` alongside the
+  existing `post_type` / `status` / `draftId` fields. Closes Slice 1.5
+  failure shape W2 (Option F1 — carry original's image forward).
+- **`Cap Hashtags` (Code) — added.** Byte-for-byte mirror of Slice 2's
+  `Awo65rdSe5BvDHtC > Cap Hashtags` node. `MAX_HASHTAGS = 5`. Same
+  `/#\w+/g` replace, same whitespace cleanup, same pass-through for
+  empty/missing/≤5 captions, same `_hashtag_cap_applied` metadata
+  (stripped before persistence by Save New Draft's field whitelist).
+  Inserted between `Parse Regenerated` and `Save New Draft`. Comment
+  notes the pattern source.
+- **`Save New Draft` (HTTP POST) — modified.** Appended
+  `image_url: $json.image_url` to the JSON body's field whitelist. No
+  other fields changed; `hooks_used: [$json.instagram_hook_text]` and
+  the existing 10 copy fields are byte-identical.
+- **`Send Revised to Telegram` — modified.** Single text-template
+  substitution: `Draft ID: {{ $json[0].id }}` → `Draft ID: {{ $json.id }}`.
+  Fixes Slice 1.5 side-finding #1 (Supabase `Prefer: return=representation`
+  emits an array of one which n8n unwraps to an object at the next
+  node, so `$json[0].id` is undefined → renders as empty).
+
+### Connection rewiring
+
+Before: `Regenerate Content (Claude) → Parse Regenerated → Save New Draft → Send Revised to Telegram → Heartbeat: Success (Revise)`
+
+After: `Regenerate Content (Claude) → Parse Regenerated → Cap Hashtags → Save New Draft → Send Revised to Telegram → Heartbeat: Success (Revise)`
+
+Only the segment between `Parse Regenerated` and `Save New Draft` was
+re-wired. The Telegram trigger path (`Route Action → Normalize Trigger →
+Save Feedback to Supabase → Fetch Original Draft → Regenerate Content
+(Claude)`) and the Dashboard webhook path
+(`Parse Dashboard Input → Normalize Trigger`) both feed into this same
+segment unchanged, so both tracks pick up all four fixes.
+
+### Track B coverage check (brief-conflict reflex)
+
+Per the brief: "If Track B has the same wipe pattern, surface it as a
+follow-up but don't fix in this dispatch." Reading the live connections:
+both `Route Action[1]` (Telegram-feedback branch) and
+`Parse Dashboard Input` converge at `Normalize Trigger`, which then
+feeds `Save Feedback to Supabase → Fetch Original Draft → Regenerate
+Content (Claude) → Parse Regenerated → ...`. The downstream chain is
+shared, so Track B is fixed by the same Slice 5 PUT. No follow-up needed.
+
+### PUT verification (live)
+
+- PUT `HTTP=200` @ `2026-05-13T21:34:58.551Z`.
+- Re-GET confirms:
+  - 20 nodes (was 19 — Cap Hashtags added).
+  - `Parse Regenerated.parameters.jsCode` contains `imageUrl ?? null`
+    (image_url forwarded).
+  - `Save New Draft.parameters.jsonBody` contains
+    `image_url: $json.image_url` (whitelist extended).
+  - `Send Revised to Telegram.parameters.text` contains `$json.id` and
+    no longer contains `$json[0].id`.
+  - `Cap Hashtags` node exists (type `n8n-nodes-base.code`,
+    `MAX_HASHTAGS = 5`).
+  - Connections: `Parse Regenerated → Cap Hashtags → Save New Draft`.
+  - `settings.availableInMCP=true`.
+
+### Smoke tests
+
+Per brief: live smoke optional, **skipped** because (a) a regen would
+burn a Claude API call + a Telegram message + insert a real
+`pending_approval` row, and (b) all four changes are statically
+verifiable from the post-PUT GET. Next natural regenerate (Tyson rejects
+any pending draft with feedback, or fires the dashboard regenerate
+endpoint) will exercise all four paths end-to-end. Expected behaviour:
+- New row's `image_url` matches the original draft's `image_url`
+  verbatim (NULL preserved as NULL, populated URL preserved as URL —
+  Slice 1.5 Option F1).
+- New row's `instagram_caption` has ≤5 hashtags (Cap Hashtags).
+- Telegram revised-draft message has `Draft ID: <uuid>` populated (no
+  longer empty).
+
+### Security gate
+
+- [x] No hardcoded credentials added — Cap Hashtags is pure JS logic,
+      Parse Regenerated / Save New Draft additions are field-reference
+      changes only, Send Revised to Telegram change is a 4-character
+      template substitution.
+- [x] No new webhooks (no webhook nodes added).
+- [x] No new endpoints (no new HTTP nodes; Save New Draft still POSTs
+      to the same Supabase REST URL).
+- [x] No RLS changes — `marketing_drafts` table is untouched
+      structurally.
+- [x] No financial features touched.
+- [x] `~/.quantumclaw/.env` and `/home/n8nadmin/n8n-project/.env` perms
+      unchanged at 600 — neither file written.
+- [x] `settings.availableInMCP=true` re-confirmed via post-PUT GET.
+- [x] No stack traces or secrets exposed — Cap Hashtags writes only
+      integer counts + ISO timestamp into `_hashtag_cap_applied`; that
+      field is stripped before persistence by Save New Draft's
+      whitelist; Parse Regenerated still throws raw error messages only
+      for "Failed to parse" (existing behaviour, not changed).
+- [x] Credential references unchanged — Supabase anon-key headers,
+      Anthropic credential, Telegram bot chat id, errorWorkflow refs
+      all untouched.
+
+### Out of scope (deferred)
+
+- Crete Content Regenerate (`KKjw893zwzHwv1o6`) — clean per Slice 1.5
+  verdict (sparse PATCH preserves `media_url`).
+- Bot identity split between `flowstatesads_bot` and `@tyson_quantumbot`
+  — separate dispatch (per `N8N_WORKFLOW_INDEX.md` cluster note).
+- Heartbeat / errorWorkflow wiring on the regenerate path — cluster-wide
+  backlog.
+- Content Generator's `Send to Telegram` has the SAME `{{ $json[0].id }}`
+  bug as the regenerate path fixed here — `Awo65rdSe5BvDHtC > Send to
+  Telegram > text` contains `Draft ID: <code>{{ $json[0].id }}</code>`.
+  Sanity-checked in this session but explicitly out of scope per
+  dispatch ("Don't touch Content Generator"). Filed as a trivial
+  follow-up dispatch — same one-character fix (`$json.id`), same
+  workflow class, single-PUT.
+
+### References
+
+- `/tmp/regenerate_wipe_audit_20260513.md` — Slice 1.5 verdict (W2 +
+  side-findings #1 + #2).
+- `/tmp/marketing_image_audit_20260513.md` — original audit that flagged
+  `f442f66a` as the regenerated row with NULL image_url.
+- Slice 2 (PR #10) — Cap Hashtags pattern source on
+  `Awo65rdSe5BvDHtC`.
+- `N8N_WORKFLOW_INDEX.md` line 248 — original Bug (b) note on
+  empty-Draft-ID Telegram pattern (same shape now fixed here).

--- a/n8n-workflows/ptHK2TZq5XppKOOg-ghl-marketing-approval-handler.json
+++ b/n8n-workflows/ptHK2TZq5XppKOOg-ghl-marketing-approval-handler.json
@@ -1,7 +1,11 @@
 {
+  "updatedAt": "2026-05-13T21:34:58.551Z",
+  "createdAt": "2026-04-13T12:06:00.352Z",
   "id": "ptHK2TZq5XppKOOg",
   "name": "GHL Marketing: Approval Handler",
   "description": null,
+  "active": true,
+  "isArchived": false,
   "nodes": [
     {
       "parameters": {
@@ -345,7 +349,7 @@
     },
     {
       "parameters": {
-        "jsCode": "const response = $input.first().json;\nconst content = response.content?.[0]?.text;\nif (!content) throw new Error('No content in Claude response');\n\nlet parsed;\ntry {\n  const cleaned = content.replace(/```json\\n?/g, '').replace(/```\\n?/g, '').trim();\n  parsed = JSON.parse(cleaned);\n} catch (e) {\n  throw new Error('Failed to parse: ' + e.message);\n}\n\nconst originalDraft = $('Fetch Original Draft').first().json;\nconst postType = Array.isArray(originalDraft) ? originalDraft[0]?.post_type : originalDraft?.post_type;\nconst draftId = $('Normalize Trigger').first().json.draftId;\n\nreturn [{\n  json: {\n    ...parsed,\n    post_type: postType || 'value-led',\n    status: 'pending_approval',\n    draftId\n  }\n}];"
+        "jsCode": "const response = $input.first().json;\nconst content = response.content?.[0]?.text;\nif (!content) throw new Error('No content in Claude response');\n\nlet parsed;\ntry {\n  const cleaned = content.replace(/```json\\n?/g, '').replace(/```\\n?/g, '').trim();\n  parsed = JSON.parse(cleaned);\n} catch (e) {\n  throw new Error('Failed to parse: ' + e.message);\n}\n\nconst originalDraft = $('Fetch Original Draft').first().json;\nconst postType = Array.isArray(originalDraft) ? originalDraft[0]?.post_type : originalDraft?.post_type;\nconst imageUrl = Array.isArray(originalDraft) ? originalDraft[0]?.image_url : originalDraft?.image_url;\nconst draftId = $('Normalize Trigger').first().json.draftId;\n\nreturn [{\n  json: {\n    ...parsed,\n    post_type: postType || 'value-led',\n    image_url: imageUrl ?? null,\n    status: 'pending_approval',\n    draftId\n  }\n}];"
       },
       "id": "b2000001-0001-4000-8000-000000000010",
       "name": "Parse Regenerated",
@@ -353,6 +357,19 @@
       "typeVersion": 2,
       "position": [
         1560,
+        500
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Cap IG hashtags to 5; defensive against AI drift.\n// Pattern source: Awo65rdSe5BvDHtC 'Cap Hashtags' (Slice 2). Mirrored here so the\n// regenerate path also enforces Bug 3 fix \u2014 otherwise Cap Hashtags is bypassed\n// every time a draft is regenerated through Approval Handler.\nconst MAX_HASHTAGS = 5;\nconst item = $input.first().json;\nconst caption = item.instagram_caption;\nif (typeof caption !== 'string' || !caption) {\n  return [{ json: item }];\n}\nlet count = 0;\nconst stripped = caption.replace(/#\\w+/g, (m) => (++count <= MAX_HASHTAGS ? m : ''));\nconst cleaned = stripped\n  .replace(/[ \\t]+/g, ' ')\n  .replace(/\\n[ \\t]+/g, '\\n')\n  .replace(/\\n{3,}/g, '\\n\\n')\n  .trim();\nreturn [{\n  json: {\n    ...item,\n    instagram_caption: cleaned,\n    _hashtag_cap_applied: { max: MAX_HASHTAGS, original_count: count, dropped: Math.max(0, count - MAX_HASHTAGS), at: new Date().toISOString() }\n  }\n}];"
+      },
+      "id": "b2000001-0001-4000-8000-000000000020",
+      "name": "Cap Hashtags",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1720,
         500
       ]
     },
@@ -383,7 +400,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ post_type: $json.post_type, status: 'pending_approval', facebook_post: $json.facebook_post, linkedin_post: $json.linkedin_post, instagram_caption: $json.instagram_caption, instagram_hook_text: $json.instagram_hook_text, ad_headline: $json.ad_headline, ad_body: $json.ad_body, ad_cta: $json.ad_cta, retargeting_copy: $json.retargeting_copy, hooks_used: [$json.instagram_hook_text] }) }}",
+        "jsonBody": "={{ JSON.stringify({ post_type: $json.post_type, status: 'pending_approval', facebook_post: $json.facebook_post, linkedin_post: $json.linkedin_post, instagram_caption: $json.instagram_caption, instagram_hook_text: $json.instagram_hook_text, ad_headline: $json.ad_headline, ad_body: $json.ad_body, ad_cta: $json.ad_cta, retargeting_copy: $json.retargeting_copy, hooks_used: [$json.instagram_hook_text], image_url: $json.image_url }) }}",
         "options": {
           "response": {
             "response": {
@@ -397,7 +414,7 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        1780,
+        1940,
         500
       ],
       "credentials": {
@@ -410,7 +427,7 @@
     {
       "parameters": {
         "chatId": "1375806243",
-        "text": "=Revised {{ $('Parse Regenerated').first().json.post_type }} draft ready.\n\n<b>FACEBOOK:</b>\n{{ $('Parse Regenerated').first().json.facebook_post }}\n\n<b>LINKEDIN:</b>\n{{ $('Parse Regenerated').first().json.linkedin_post }}\n\n<b>INSTAGRAM:</b>\n{{ $('Parse Regenerated').first().json.instagram_caption }}\nHook: {{ $('Parse Regenerated').first().json.instagram_hook_text }}\n\n<b>PAID AD:</b>\nHeadline: {{ $('Parse Regenerated').first().json.ad_headline }}\nBody: {{ $('Parse Regenerated').first().json.ad_body }}\nCTA: {{ $('Parse Regenerated').first().json.ad_cta }}\n\n<b>RETARGETING:</b>\n{{ $('Parse Regenerated').first().json.retargeting_copy }}\n\nReply \"go\" to approve and schedule.\nReply with feedback to regenerate.\nDraft ID: {{ $json[0].id }}",
+        "text": "=Revised {{ $('Parse Regenerated').first().json.post_type }} draft ready.\n\n<b>FACEBOOK:</b>\n{{ $('Parse Regenerated').first().json.facebook_post }}\n\n<b>LINKEDIN:</b>\n{{ $('Parse Regenerated').first().json.linkedin_post }}\n\n<b>INSTAGRAM:</b>\n{{ $('Parse Regenerated').first().json.instagram_caption }}\nHook: {{ $('Parse Regenerated').first().json.instagram_hook_text }}\n\n<b>PAID AD:</b>\nHeadline: {{ $('Parse Regenerated').first().json.ad_headline }}\nBody: {{ $('Parse Regenerated').first().json.ad_body }}\nCTA: {{ $('Parse Regenerated').first().json.ad_cta }}\n\n<b>RETARGETING:</b>\n{{ $('Parse Regenerated').first().json.retargeting_copy }}\n\nReply \"go\" to approve and schedule.\nReply with feedback to regenerate.\nDraft ID: {{ $json.id }}",
         "additionalFields": {
           "parse_mode": "HTML"
         }
@@ -420,7 +437,7 @@
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
       "position": [
-        2000,
+        2160,
         500
       ],
       "credentials": {
@@ -558,7 +575,7 @@
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
       "position": [
-        2250,
+        2410,
         500
       ],
       "credentials": {
@@ -680,7 +697,7 @@
       "main": [
         [
           {
-            "node": "Save New Draft",
+            "node": "Cap Hashtags",
             "type": "main",
             "index": 0
           }
@@ -767,11 +784,899 @@
           }
         ]
       ]
+    },
+    "Cap Hashtags": {
+      "main": [
+        [
+          {
+            "node": "Save New Draft",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
   "settings": {
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": true
+  },
+  "staticData": null,
+  "meta": null,
+  "pinData": null,
+  "versionId": "90039c1b-37b2-477f-9a21-8c951f12a1be",
+  "activeVersionId": "90039c1b-37b2-477f-9a21-8c951f12a1be",
+  "versionCounter": 58,
+  "triggerCount": 2,
+  "shared": [
+    {
+      "updatedAt": "2026-04-13T12:06:00.352Z",
+      "createdAt": "2026-04-13T12:06:00.352Z",
+      "role": "workflow:owner",
+      "workflowId": "ptHK2TZq5XppKOOg",
+      "projectId": "KwpTDWcFWL3DfyW3",
+      "project": {
+        "updatedAt": "2026-04-08T20:28:08.726Z",
+        "createdAt": "2025-06-06T11:27:14.830Z",
+        "id": "KwpTDWcFWL3DfyW3",
+        "name": "Tyson Venables <tysonvenables@protonmail.com>",
+        "type": "personal",
+        "icon": null,
+        "description": null,
+        "creatorId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+        "projectRelations": [
+          {
+            "updatedAt": "2025-06-06T11:27:14.830Z",
+            "createdAt": "2025-06-06T11:27:14.830Z",
+            "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+            "projectId": "KwpTDWcFWL3DfyW3",
+            "user": {
+              "updatedAt": "2026-05-13T02:04:11.362Z",
+              "createdAt": "2025-06-06T11:27:13.858Z",
+              "id": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+              "email": "tysonvenables@protonmail.com",
+              "firstName": "Tyson",
+              "lastName": "Venables",
+              "personalizationAnswers": {
+                "version": "v4",
+                "personalization_survey_submitted_at": "2025-06-06T11:42:52.454Z",
+                "personalization_survey_n8n_version": "1.95.3",
+                "companySize": "<20",
+                "companyType": "saas",
+                "role": "business-owner",
+                "reportedSource": "friend"
+              },
+              "settings": {
+                "userActivated": true,
+                "easyAIWorkflowOnboarded": true,
+                "firstSuccessfulWorkflowId": "WVXrFCjb8wO7RWRX",
+                "userActivatedAt": 1751062185356,
+                "npsSurvey": {
+                  "responded": true,
+                  "lastShownAt": 1769430963515
+                }
+              },
+              "disabled": false,
+              "mfaEnabled": false,
+              "lastActiveAt": "2026-05-13",
+              "isPending": false
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "tags": [],
+  "activeVersion": {
+    "updatedAt": "2026-05-13T21:34:58.556Z",
+    "createdAt": "2026-05-13T21:34:58.556Z",
+    "versionId": "90039c1b-37b2-477f-9a21-8c951f12a1be",
+    "workflowId": "ptHK2TZq5XppKOOg",
+    "nodes": [
+      {
+        "parameters": {
+          "updates": [
+            "message"
+          ],
+          "additionalFields": {}
+        },
+        "id": "b2000001-0001-4000-8000-000000000001",
+        "name": "Telegram Trigger",
+        "type": "n8n-nodes-base.telegramTrigger",
+        "typeVersion": 1.1,
+        "position": [
+          200,
+          300
+        ],
+        "webhookId": "ghl-approval-trigger",
+        "credentials": {
+          "telegramApi": {
+            "id": "UR6xX8CchGBKaP3h",
+            "name": "Flow States Ads Bot"
+          }
+        }
+      },
+      {
+        "parameters": {
+          "jsCode": "const msg = $input.first().json.message;\nconst chatId = msg?.chat?.id;\n\nif (chatId !== 1375806243) {\n  return [{ json: { action: 'ignore', reason: 'Wrong chat ID: ' + chatId } }];\n}\n\nconst text = (msg.text || '').toLowerCase().trim();\nconst replyTo = msg.reply_to_message?.text || '';\n\nconst draftIdMatch = replyTo.match(/Draft ID:\\s*([a-f0-9-]+)/);\nconst draftId = draftIdMatch ? draftIdMatch[1] : null;\n\nif (!draftId) {\n  return [{ json: { action: 'ignore', reason: 'Not a reply to a draft message' } }];\n}\n\nconst isApproval = ['go', 'approved', 'approve'].includes(text);\n\nreturn [{\n  json: {\n    action: isApproval ? 'approve' : 'feedback',\n    draftId,\n    feedback: isApproval ? null : msg.text\n  }\n}];"
+        },
+        "id": "b2000001-0001-4000-8000-000000000002",
+        "name": "Parse Reply",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          420,
+          300
+        ]
+      },
+      {
+        "parameters": {
+          "rules": {
+            "values": [
+              {
+                "conditions": {
+                  "options": {
+                    "caseSensitive": false,
+                    "leftValue": "",
+                    "typeValidation": "strict"
+                  },
+                  "conditions": [
+                    {
+                      "leftValue": "={{ $json.action }}",
+                      "rightValue": "approve",
+                      "operator": {
+                        "type": "string",
+                        "operation": "equals"
+                      }
+                    }
+                  ],
+                  "combinator": "and"
+                },
+                "renameOutput": true,
+                "outputKey": "approve"
+              },
+              {
+                "conditions": {
+                  "options": {
+                    "caseSensitive": false,
+                    "leftValue": "",
+                    "typeValidation": "strict"
+                  },
+                  "conditions": [
+                    {
+                      "leftValue": "={{ $json.action }}",
+                      "rightValue": "feedback",
+                      "operator": {
+                        "type": "string",
+                        "operation": "equals"
+                      }
+                    }
+                  ],
+                  "combinator": "and"
+                },
+                "renameOutput": true,
+                "outputKey": "feedback"
+              },
+              {
+                "conditions": {
+                  "options": {
+                    "caseSensitive": false,
+                    "leftValue": "",
+                    "typeValidation": "strict"
+                  },
+                  "conditions": [
+                    {
+                      "leftValue": "={{ $json.action }}",
+                      "rightValue": "ignore",
+                      "operator": {
+                        "type": "string",
+                        "operation": "equals"
+                      }
+                    }
+                  ],
+                  "combinator": "and"
+                },
+                "renameOutput": true,
+                "outputKey": "ignore"
+              }
+            ]
+          },
+          "options": {}
+        },
+        "id": "b2000001-0001-4000-8000-000000000003",
+        "name": "Route Action",
+        "type": "n8n-nodes-base.switch",
+        "typeVersion": 3.2,
+        "position": [
+          640,
+          300
+        ]
+      },
+      {
+        "parameters": {
+          "method": "PATCH",
+          "url": "=https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts?id=eq.{{ $('Parse Reply').first().json.draftId }}",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ status: 'approved', updated_at: new Date().toISOString() }) }}",
+          "options": {}
+        },
+        "id": "b2000001-0001-4000-8000-000000000004",
+        "name": "Approve in Supabase",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          900,
+          100
+        ],
+        "credentials": {
+          "httpHeaderAuth": {
+            "id": "Nd2uuX5t9KEwbQPv",
+            "name": "Supabase FSC"
+          }
+        }
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "https://webhook.flowos.tech/webhook/ghl-marketing-publish",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ draftId: $('Parse Reply').first().json.draftId }) }}",
+          "options": {
+            "timeout": 10000
+          }
+        },
+        "id": "b2000001-0001-4000-8000-000000000005",
+        "name": "Trigger Publisher",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1120,
+          100
+        ]
+      },
+      {
+        "parameters": {
+          "chatId": "1375806243",
+          "text": "Approved. Scheduling posts now.",
+          "additionalFields": {
+            "parse_mode": "HTML"
+          }
+        },
+        "id": "b2000001-0001-4000-8000-000000000006",
+        "name": "Confirm Approval",
+        "type": "n8n-nodes-base.telegram",
+        "typeVersion": 1.2,
+        "position": [
+          1340,
+          100
+        ],
+        "credentials": {
+          "telegramApi": {
+            "id": "UR6xX8CchGBKaP3h",
+            "name": "Flow States Ads Bot"
+          }
+        }
+      },
+      {
+        "parameters": {
+          "method": "PATCH",
+          "url": "=https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts?id=eq.{{ $('Normalize Trigger').first().json.draftId }}",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ status: 'rejected', feedback: $('Normalize Trigger').first().json.feedback, updated_at: new Date().toISOString() }) }}",
+          "options": {}
+        },
+        "id": "b2000001-0001-4000-8000-000000000007",
+        "name": "Save Feedback to Supabase",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          900,
+          500
+        ],
+        "credentials": {
+          "httpHeaderAuth": {
+            "id": "Nd2uuX5t9KEwbQPv",
+            "name": "Supabase FSC"
+          }
+        },
+        "alwaysOutputData": true
+      },
+      {
+        "parameters": {
+          "method": "GET",
+          "url": "=https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts?id=eq.{{ $('Normalize Trigger').first().json.draftId }}&select=*",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+              }
+            ]
+          },
+          "options": {
+            "response": {
+              "response": {
+                "responseFormat": "json"
+              }
+            }
+          }
+        },
+        "id": "b2000001-0001-4000-8000-000000000008",
+        "name": "Fetch Original Draft",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1120,
+          500
+        ],
+        "credentials": {
+          "httpHeaderAuth": {
+            "id": "Nd2uuX5t9KEwbQPv",
+            "name": "Supabase FSC"
+          }
+        },
+        "alwaysOutputData": true
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "https://api.anthropic.com/v1/messages",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "anthropic-version",
+                "value": "2023-06-01"
+              },
+              {
+                "name": "content-type",
+                "value": "application/json"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ model: 'claude-sonnet-4-20250514', max_tokens: 2000, system: \"You are a marketing copywriter for GHL Support Specialist. Product: AI-powered 24/7 support for GoHighLevel users. URL: support.flowos.tech/ghl/landing. Price: $29/month or $290/year. Founders Offer: first 50 members get 3 months free with code GHLPOWER50. Tone: Direct, practical, slightly irreverent. Speak like a GHL power user. No corporate language. Short sentences. No em dashes. No hashtags in body copy. Never say: game-changer, revolutionary, unlock your potential. Use specific GHL terms: workflows, automations, pipelines, funnels, SaaS mode, merge fields, calendars, triggers, actions.\", messages: [{ role: 'user', content: 'Generate a ' + ($input.first().json[0]?.post_type || 'value-led') + ' organic post for GHL Support Specialist. The previous draft was rejected. Feedback: ' + ($('Normalize Trigger').first().json.feedback ?? $('Normalize Trigger').first().json.feedback) + '. Generate a new version addressing this feedback. Provide output as JSON with these exact keys: facebook_post (plain text, no hashtags, 100-200 words), linkedin_post (plain text, no hashtags, 80-150 words), instagram_caption (with hashtag block at end, 60-120 words before hashtags), instagram_hook_text (5-8 words, overlay text for image), ad_headline (under 10 words), ad_body (80-120 words, includes pain point + solution + Founders Offer + URL with UTMs: support.flowos.tech/ghl/landing?utm_source=facebook&utm_medium=paid_social&utm_campaign=founders_offer), ad_cta (3-4 words for button text), retargeting_copy (60-100 words, acknowledges they visited, restates value, urgency). Return ONLY valid JSON. No markdown fences. No explanation.' }] }) }}",
+          "options": {
+            "response": {
+              "response": {
+                "responseFormat": "json"
+              }
+            }
+          },
+          "authentication": "genericCredentialType",
+          "genericAuthType": "httpHeaderAuth"
+        },
+        "id": "b2000001-0001-4000-8000-000000000009",
+        "name": "Regenerate Content (Claude)",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1340,
+          500
+        ],
+        "credentials": {
+          "httpHeaderAuth": {
+            "id": "V9YcuDfp9lqydyDH",
+            "name": "Anthropic Header Auth"
+          }
+        }
+      },
+      {
+        "parameters": {
+          "jsCode": "const response = $input.first().json;\nconst content = response.content?.[0]?.text;\nif (!content) throw new Error('No content in Claude response');\n\nlet parsed;\ntry {\n  const cleaned = content.replace(/```json\\n?/g, '').replace(/```\\n?/g, '').trim();\n  parsed = JSON.parse(cleaned);\n} catch (e) {\n  throw new Error('Failed to parse: ' + e.message);\n}\n\nconst originalDraft = $('Fetch Original Draft').first().json;\nconst postType = Array.isArray(originalDraft) ? originalDraft[0]?.post_type : originalDraft?.post_type;\nconst imageUrl = Array.isArray(originalDraft) ? originalDraft[0]?.image_url : originalDraft?.image_url;\nconst draftId = $('Normalize Trigger').first().json.draftId;\n\nreturn [{\n  json: {\n    ...parsed,\n    post_type: postType || 'value-led',\n    image_url: imageUrl ?? null,\n    status: 'pending_approval',\n    draftId\n  }\n}];"
+        },
+        "id": "b2000001-0001-4000-8000-000000000010",
+        "name": "Parse Regenerated",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          1560,
+          500
+        ]
+      },
+      {
+        "parameters": {
+          "jsCode": "// Cap IG hashtags to 5; defensive against AI drift.\n// Pattern source: Awo65rdSe5BvDHtC 'Cap Hashtags' (Slice 2). Mirrored here so the\n// regenerate path also enforces Bug 3 fix \u2014 otherwise Cap Hashtags is bypassed\n// every time a draft is regenerated through Approval Handler.\nconst MAX_HASHTAGS = 5;\nconst item = $input.first().json;\nconst caption = item.instagram_caption;\nif (typeof caption !== 'string' || !caption) {\n  return [{ json: item }];\n}\nlet count = 0;\nconst stripped = caption.replace(/#\\w+/g, (m) => (++count <= MAX_HASHTAGS ? m : ''));\nconst cleaned = stripped\n  .replace(/[ \\t]+/g, ' ')\n  .replace(/\\n[ \\t]+/g, '\\n')\n  .replace(/\\n{3,}/g, '\\n\\n')\n  .trim();\nreturn [{\n  json: {\n    ...item,\n    instagram_caption: cleaned,\n    _hashtag_cap_applied: { max: MAX_HASHTAGS, original_count: count, dropped: Math.max(0, count - MAX_HASHTAGS), at: new Date().toISOString() }\n  }\n}];"
+        },
+        "id": "b2000001-0001-4000-8000-000000000020",
+        "name": "Cap Hashtags",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          1720,
+          500
+        ]
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "apikey",
+                "value": "={{$env.SUPABASE_ANON_KEY}}"
+              },
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "name": "Prefer",
+                "value": "return=representation"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ post_type: $json.post_type, status: 'pending_approval', facebook_post: $json.facebook_post, linkedin_post: $json.linkedin_post, instagram_caption: $json.instagram_caption, instagram_hook_text: $json.instagram_hook_text, ad_headline: $json.ad_headline, ad_body: $json.ad_body, ad_cta: $json.ad_cta, retargeting_copy: $json.retargeting_copy, hooks_used: [$json.instagram_hook_text], image_url: $json.image_url }) }}",
+          "options": {
+            "response": {
+              "response": {
+                "responseFormat": "json"
+              }
+            }
+          }
+        },
+        "id": "b2000001-0001-4000-8000-000000000011",
+        "name": "Save New Draft",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1940,
+          500
+        ],
+        "credentials": {
+          "httpHeaderAuth": {
+            "id": "Nd2uuX5t9KEwbQPv",
+            "name": "Supabase FSC"
+          }
+        }
+      },
+      {
+        "parameters": {
+          "chatId": "1375806243",
+          "text": "=Revised {{ $('Parse Regenerated').first().json.post_type }} draft ready.\n\n<b>FACEBOOK:</b>\n{{ $('Parse Regenerated').first().json.facebook_post }}\n\n<b>LINKEDIN:</b>\n{{ $('Parse Regenerated').first().json.linkedin_post }}\n\n<b>INSTAGRAM:</b>\n{{ $('Parse Regenerated').first().json.instagram_caption }}\nHook: {{ $('Parse Regenerated').first().json.instagram_hook_text }}\n\n<b>PAID AD:</b>\nHeadline: {{ $('Parse Regenerated').first().json.ad_headline }}\nBody: {{ $('Parse Regenerated').first().json.ad_body }}\nCTA: {{ $('Parse Regenerated').first().json.ad_cta }}\n\n<b>RETARGETING:</b>\n{{ $('Parse Regenerated').first().json.retargeting_copy }}\n\nReply \"go\" to approve and schedule.\nReply with feedback to regenerate.\nDraft ID: {{ $json.id }}",
+          "additionalFields": {
+            "parse_mode": "HTML"
+          }
+        },
+        "id": "b2000001-0001-4000-8000-000000000012",
+        "name": "Send Revised to Telegram",
+        "type": "n8n-nodes-base.telegram",
+        "typeVersion": 1.2,
+        "position": [
+          2160,
+          500
+        ],
+        "credentials": {
+          "telegramApi": {
+            "id": "UR6xX8CchGBKaP3h",
+            "name": "Flow States Ads Bot"
+          }
+        }
+      },
+      {
+        "parameters": {
+          "httpMethod": "POST",
+          "path": "ghl-marketing-regenerate",
+          "responseMode": "onReceived",
+          "options": {}
+        },
+        "id": "b2000001-0001-4000-8000-00000000000d",
+        "name": "Dashboard Regenerate Webhook",
+        "type": "n8n-nodes-base.webhook",
+        "typeVersion": 2,
+        "position": [
+          200,
+          700
+        ],
+        "webhookId": "ghl-marketing-regenerate"
+      },
+      {
+        "parameters": {
+          "jsCode": "const body = $input.first().json.body || $input.first().json;\nconst draftId = body.draftId || body.draft_id;\nconst feedback = body.feedback || '';\nif (!draftId) throw new Error('draftId required');\nreturn [{ json: { action: 'feedback', draftId, feedback } }];"
+        },
+        "id": "b2000001-0001-4000-8000-00000000000e",
+        "name": "Parse Dashboard Input",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          420,
+          700
+        ]
+      },
+      {
+        "parameters": {
+          "jsCode": "const j = $input.first().json;\nreturn [{ json: { draftId: j.draftId, feedback: j.feedback || null, action: 'feedback' } }];"
+        },
+        "id": "b2000001-0001-4000-8000-00000000000f",
+        "name": "Normalize Trigger",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          770,
+          500
+        ]
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'started'::text, 'GHL Marketing: Approval Handler'::text, '{{ $execution.id }}'::text);",
+          "options": {}
+        },
+        "name": "Heartbeat: Start (Telegram)",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          400,
+          300
+        ],
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true,
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "aff6f38e-a643-42ab-8dd4-c00377224936"
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'started'::text, 'GHL Marketing: Approval Handler'::text, '{{ $execution.id }}'::text);",
+          "options": {}
+        },
+        "name": "Heartbeat: Start (Dashboard)",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          400,
+          700
+        ],
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true,
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "092b9bf2-910f-4870-bae4-f0b630bb5955"
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'success'::text, 'GHL Marketing: Approval Handler'::text, '{{ $execution.id }}'::text);",
+          "options": {}
+        },
+        "name": "Heartbeat: Success (Approve)",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          1590,
+          100
+        ],
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true,
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "4401a818-ec4e-4ca0-8d36-7e8301b23bea"
+      },
+      {
+        "parameters": {
+          "operation": "executeQuery",
+          "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'success'::text, 'GHL Marketing: Approval Handler'::text, '{{ $execution.id }}'::text);",
+          "options": {}
+        },
+        "name": "Heartbeat: Success (Revise)",
+        "type": "n8n-nodes-base.postgres",
+        "typeVersion": 2.6,
+        "position": [
+          2410,
+          500
+        ],
+        "credentials": {
+          "postgres": {
+            "id": "qGUxEHfEZkZGdAcZ",
+            "name": "Supabase Postgres DB"
+          }
+        },
+        "continueOnFail": true,
+        "retryOnFail": true,
+        "maxTries": 2,
+        "waitBetweenTries": 2000,
+        "id": "da20b06e-da0b-488e-b2c1-de001762bd04"
+      }
+    ],
+    "connections": {
+      "Telegram Trigger": {
+        "main": [
+          [
+            {
+              "node": "Parse Reply",
+              "type": "main",
+              "index": 0
+            },
+            {
+              "node": "Heartbeat: Start (Telegram)",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Parse Reply": {
+        "main": [
+          [
+            {
+              "node": "Route Action",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Route Action": {
+        "main": [
+          [
+            {
+              "node": "Approve in Supabase",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Normalize Trigger",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          []
+        ]
+      },
+      "Approve in Supabase": {
+        "main": [
+          [
+            {
+              "node": "Trigger Publisher",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Trigger Publisher": {
+        "main": [
+          [
+            {
+              "node": "Confirm Approval",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Save Feedback to Supabase": {
+        "main": [
+          [
+            {
+              "node": "Fetch Original Draft",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Fetch Original Draft": {
+        "main": [
+          [
+            {
+              "node": "Regenerate Content (Claude)",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Regenerate Content (Claude)": {
+        "main": [
+          [
+            {
+              "node": "Parse Regenerated",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Parse Regenerated": {
+        "main": [
+          [
+            {
+              "node": "Cap Hashtags",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Save New Draft": {
+        "main": [
+          [
+            {
+              "node": "Send Revised to Telegram",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Dashboard Regenerate Webhook": {
+        "main": [
+          [
+            {
+              "node": "Parse Dashboard Input",
+              "type": "main",
+              "index": 0
+            },
+            {
+              "node": "Heartbeat: Start (Dashboard)",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Parse Dashboard Input": {
+        "main": [
+          [
+            {
+              "node": "Normalize Trigger",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Normalize Trigger": {
+        "main": [
+          [
+            {
+              "node": "Save Feedback to Supabase",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Heartbeat: Start (Telegram)": {
+        "main": [
+          []
+        ]
+      },
+      "Heartbeat: Start (Dashboard)": {
+        "main": [
+          []
+        ]
+      },
+      "Confirm Approval": {
+        "main": [
+          [
+            {
+              "node": "Heartbeat: Success (Approve)",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Send Revised to Telegram": {
+        "main": [
+          [
+            {
+              "node": "Heartbeat: Success (Revise)",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Cap Hashtags": {
+        "main": [
+          [
+            {
+              "node": "Save New Draft",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      }
+    },
+    "authors": "Tyson Venables",
+    "name": null,
+    "description": null,
+    "autosaved": false,
+    "workflowPublishHistory": [
+      {
+        "createdAt": "2026-05-13T21:34:59.527Z",
+        "id": 971,
+        "workflowId": "ptHK2TZq5XppKOOg",
+        "versionId": "90039c1b-37b2-477f-9a21-8c951f12a1be",
+        "event": "activated",
+        "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Three bundled defects on the same workflow (`ptHK2TZq5XppKOOg` — GHL Marketing: Approval Handler), single PUT. Closes the regenerate-path findings from `/tmp/regenerate_wipe_audit_20260513.md` plus the related Cap-Hashtags-bypass and empty-Draft-ID side-findings from the same audit.

| Change | Node | What changed |
|---|---|---|
| 1 | `Parse Regenerated` (modified) | Forwards `image_url` from `Fetch Original Draft` using the same array-or-object unwrap pattern as `post_type` (Supabase `?select=*` returns arrays). Closes Slice 1.5 failure shape **W2**. |
| 2 | `Cap Hashtags` (new Code node) | Byte-for-byte mirror of Slice 2's `Awo65rdSe5BvDHtC > Cap Hashtags` (`MAX_HASHTAGS = 5`, `/#\w+/g` replace, whitespace cleanup, pass-through for ≤5). Inserted between `Parse Regenerated` and `Save New Draft`. Closes Bug 3 reappearance on every regenerate. |
| 3 | `Save New Draft` (modified) | Appended `image_url: $json.image_url` to JSON body whitelist. Other 11 fields byte-identical. |
| 4 | `Send Revised to Telegram` (modified) | One-line fix: `Draft ID: {{ $json[0].id }}` → `Draft ID: {{ $json.id }}`. Supabase POST with `Prefer: return=representation` returns a 1-item array; n8n unwraps it to an object at the next node, so `$json[0].id` was undefined. |

## Track A + Track B coverage

Both trigger paths feed into the same patched chain via `Normalize Trigger`:

```
Telegram trigger:        Telegram Trigger → Parse Reply → Route Action → Normalize Trigger ─┐
Dashboard webhook:       Dashboard Regenerate Webhook → Parse Dashboard Input ──────────────┤
                                                                                            ↓
                                                                                Normalize Trigger
                                                                                            ↓
                  Save Feedback to Supabase → Fetch Original Draft → Regenerate Content (Claude)
                                                                                            ↓
                                            Parse Regenerated → Cap Hashtags → Save New Draft → Send Revised to Telegram
```

So Track B is fixed by the same Slice 5 PUT — no follow-up dispatch needed.

## PUT verification

| Field | Value |
|---|---|
| PUT response | HTTP 200 |
| `updatedAt` | 2026-05-13T21:34:58.551Z |
| Node count | 20 (was 19) |
| `settings.availableInMCP` | true |
| `Parse Regenerated.jsCode` contains `imageUrl ?? null` | ✓ |
| `Cap Hashtags` exists (`MAX_HASHTAGS = 5`) | ✓ |
| Connections `Parse Regenerated → Cap Hashtags → Save New Draft` | ✓ |
| `Save New Draft.jsonBody` contains `image_url: $json.image_url` | ✓ |
| `Send Revised to Telegram.text` uses `$json.id` (not `$json[0].id`) | ✓ |

## Brief-conflicts surfaced

- Live workflow had **zero non-position drift** vs disk. Last `updatedAt` was 2026-05-05 (8 days ago, no parallel session). Brief-conflict reflex items 1–4 NOT triggered.
- Sanity-checked: Slice 2's `Cap Hashtags` on `Awo65rdSe5BvDHtC` is still present (mirror reference intact).
- Sanity-checked: Slice 1.5's failure-shape W2 still held against live (`Save New Draft.jsonBody` lacked `image_url` before this PUT).
- **Side-finding surfaced (out of scope for this PR):** the Content Generator's `Send to Telegram` on `Awo65rdSe5BvDHtC` has the SAME `{{ $json[0].id }}` empty-Draft-ID bug — exactly mirrors the bug fixed here on the Approval Handler. Same 4-character fix would close it. Filed as a trivial follow-up dispatch (the dispatch explicitly scoped Slice 5 to `ptHK2TZq5XppKOOg` only).

## Smoke tests

Per brief: live smoke optional. **Skipped** — a regen would burn a Claude API call + a Telegram message + a real `pending_approval` row. All four changes are statically verifiable from the post-PUT GET (above table). Next natural regenerate (Tyson rejects any pending draft with feedback, or fires the dashboard regenerate endpoint) will exercise all four paths end-to-end. Expected:

- New row's `image_url` = original draft's `image_url` (NULL preserved as NULL, populated URL preserved as URL).
- New row's `instagram_caption` has ≤5 hashtags.
- Telegram revised-draft message shows `Draft ID: <uuid>` populated.

## Security gate (all green)

- [x] No hardcoded credentials added (logic-only changes + field-reference additions)
- [x] No new webhooks / endpoints
- [x] No RLS / schema changes
- [x] No financial features touched
- [x] `.env` perms unchanged at 600 on QClaw + n8n hosts (neither file written)
- [x] `settings.availableInMCP: true` confirmed via re-GET
- [x] No stack traces or secrets exposed (Cap Hashtags `_hashtag_cap_applied` carries integer counts + ISO timestamp only, stripped before persistence by Save New Draft whitelist)
- [x] Credential references unchanged (Supabase anon-key, Anthropic, Telegram bot chat id, errorWorkflow refs)

## Out of scope (deferred)

- Crete Content Regenerate (`KKjw893zwzHwv1o6`) — clean per Slice 1.5 verdict
- Bot identity split (`flowstatesads_bot` vs `@tyson_quantumbot`) — separate dispatch
- Heartbeat / errorWorkflow on regenerate path — cluster-wide backlog
- Content Generator `Send to Telegram` same Draft ID bug — trivial follow-up
- `KKjw893zwzHwv1o6` mirror to disk — backlog

## Test plan

- [ ] On the next pending GHL marketing draft that has a non-NULL `image_url`, click reject-with-feedback in the dashboard (or reply with feedback in Telegram). Confirm in Supabase that the resulting new row's `image_url` matches the original's (instead of NULL).
- [ ] On the next regenerate of any draft, confirm the Telegram revised-draft message shows `Draft ID: <uuid>` populated.
- [ ] Spot-check the regenerated row's `instagram_caption` for ≤5 hashtags.
- [ ] Verify no regression: original (rejected) draft's row should still have its original `image_url` intact (`Save Feedback to Supabase` PATCH is sparse — confirmed by Slice 1.5 row pair).
