### PR TITLE
Memory drop hotfix — H1 + H2 + H3 (2026-05-12 context-loss diagnostic)

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -9612,3 +9612,171 @@ endpoint) will exercise all four paths end-to-end. Expected behaviour:
   `Awo65rdSe5BvDHtC`.
 - `N8N_WORKFLOW_INDEX.md` line 248 — original Bug (b) note on
   empty-Draft-ID Telegram pattern (same shape now fixed here).
+
+## [2026-05-14] Memory drop hotfix — H1 + H2 + H3
+
+Branch `cc/memory-drop-hotfix-20260514-1043`. Audit grounding:
+`/tmp/memory_drop_diagnostic_audit.md` (Brief 1 deliverable). Closes
+three findings in one PR: H1 cross-channel contamination in history
+fetch, H2 history-trim cap too tight, H3 dead Layer 4 wiring.
+
+Bug-fix dispatch, not a design change — `CHARLIE_OVERHAUL.md` untouched.
+
+### What changed (this PR)
+
+Three commits on the branch, one per finding, all mine:
+
+- `3e77853` — **H1.** `src/agents/registry.js:_processNonReflex` now passes
+  `{ channel: context?.channel, userId: context?.userId }` into
+  `memory.getHistory()`. Pre-fix it was an unfiltered agent-level fetch,
+  so heartbeat / CLI / dashboard writes could displace Telegram-
+  conversation messages out of the history window — the proximate cause
+  of the 2026-05-12 symptom. `src/core/heartbeat.js:_askLearnQuestion`
+  gained an explanatory comment marking its unfiltered getHistory call
+  as intentional cross-channel (auto-learn fires outside any user
+  context). `src/dashboard/server.js:751` was already correct (passes
+  channel + userId from req.query). New test file
+  `tests/registry-history-isolation.test.js` (10 checks): asserts the
+  channel + userId filter contract — no CLI / dashboard leakage into
+  Telegram, no other-user leakage on the same channel, undefined-options
+  parity with the unfiltered heartbeat case, limit honoured under
+  filter. `package.json` chains the new file as the 13th test.
+
+- `9f4c325` — **H2.** `src/agents/registry.js:_processNonReflex` — two
+  constants raised:
+  - `historyLimit`: flattened from `knowledgeContext.length > 100 ? 8 : 20`
+    to a flat `24`. The prior ternary was a band-aid for prompt bloat
+    under heavy KnowledgeStore content; `_truncateHistory` immediately
+    below is the actual char-budget ceiling, making the message-count
+    cap redundant. The diagnostic confirmed the 8-message effective cap
+    (4 user-assistant turns) was the proximate cause of the symptom.
+  - `MAX_CONTEXT_CHARS`: `100000` → `300000`. Charlie calls Claude
+    (typically Opus 4.x, 200k-token context ≈ ~800k chars). 300k chars
+    ≈ ~75k tokens — ~38% of the smallest standard Claude 4 context,
+    leaving ~125k tokens of headroom for the response and tool
+    round-trips.
+  - Both constants carry rationale comments pointing at the 2026-05-14
+    audit so the reasoning survives the next someone-doesn't-recall-this
+    moment.
+
+- (this commit) — **H3.** `src/agents/bootstrap.js:_layer4Recent` —
+  audit-log cap lowered from `50` → `30` to match `recent.memory`'s
+  `limit:30`. `src/agents/registry.js:_buildSystemPrompt` —
+  `bootstrap.recent.audit_log` and `bootstrap.recent.memory` are now
+  threaded into the prompt, in order `probes → audit_log → memory`,
+  each with a labelled section header naming the entry count.
+  Pre-fix, both were populated by bootstrap but never reached
+  `_buildSystemPrompt` — dead Layer 4 wiring. Charlie's prompt now
+  carries the last 30 audit-log entries (timestamp, agent/action,
+  detail truncated to 80 chars) and the last 30 conversation-memory
+  entries (timestamp, [channel], role, content truncated to 120 chars).
+  Plus this build log entry.
+
+### Doc updates (in this PR)
+
+- `QCLAW_BUILD_LOG.md` — this entry.
+- `CHARLIE_OVERHAUL.md` — **deliberately unchanged.** This is a bug
+  fix, not an architectural surface change.
+- `LOCATIONS.md` — **deliberately unchanged.** All files and code paths
+  are already documented; no new locations.
+
+### What verified
+
+**Individual test files (npm test `&&` chain still shorts on the
+pre-existing probes.test.js workstation failure documented in Slice 2c
+followups — unaffected by this hotfix):**
+
+- `tests/smoke.test.js` → 24 passed, 0 failed
+- `tests/agent-mutex.test.js` → 7 passed, 0 failed
+- `tests/approval-parser-handler.test.js` → 29 passed, 0 failed
+- `tests/approval-gate-notifier.test.js` → 13 passed, 0 failed
+- `tests/approvals.test.js` → 13 passed, 0 failed
+- `tests/bootstrap.test.js` → 32 passed, 0 failed
+- `tests/probes.test.js` → 28 passed, **1 pre-existing failure**
+  (workstation-only `pm2_processes: failure carries error string`)
+- `tests/identity-canonicalization.test.js` → 10 passed, 0 failed
+- `tests/skill-frontmatter.test.js` → 249 passed, 0 failed
+- `tests/cli-skill-list.test.js` → 59 passed, 0 failed
+- `tests/skill-router.test.js` → 134 passed, 0 failed
+- `tests/skill-loader.test.js` → 52 passed, 0 failed
+- `tests/registry-history-isolation.test.js` → **10 passed**, 0 failed
+
+**Total: 660 passed, 1 pre-existing failure** (probes.test.js
+unchanged from main). Net hotfix additions: +10 test assertions
+(H1 isolation contract).
+
+**H3 prompt-assembly smoke test (workstation, `/tmp/h3-smoke.mjs`):**
+- Built a synthetic bootstrap with two memory entries (Telegram channel,
+  user+assistant pair referencing "Workflow Qf39") and one audit_log
+  entry (`charlie/completion: Trace requested for Qf39`).
+- Called `agent._buildSystemPrompt(...)` directly.
+- Verified the rendered prompt contains:
+  - `## Recent activity (audit log, last 1)` section
+  - `## Recent context (conversation memory, last 2)` section
+  - The audit entry detail `charlie/completion: Trace requested for Qf39`
+  - The memory entry content `Which workflow are we tracing?`
+  - Section ordering: probes → audit_log → memory.
+
+### 7 Pillars + security gate
+
+- Frontend: n/a — no UI changes.
+- Backend: no new endpoints. `getHistory` filter passthrough is an
+  internal contract change; signature unchanged (third arg already
+  existed). Inputs validated upstream (channel and userId originate
+  from Telegram / dashboard / req.query, all already checked at their
+  entry points).
+- Databases: no schema changes. `conversations` table already had
+  `channel` and `user_id` columns and the relevant indexes
+  (`idx_conv_thread (agent, channel, user_id)`).
+- Authentication: no auth changes.
+- Payments/Financial: n/a.
+- Security: no new credentials. The fold-in puts conversation memory
+  entries into the system prompt — same data Charlie already had
+  via `getHistory`, just under a different label. No privilege
+  escalation. Memory entries truncated at 120 chars per line, audit
+  entries at 80 chars — bounded prompt growth.
+- Infrastructure: no PM2 changes by Claude Code. Tyson reloads
+  `quantumclaw` post-merge so registry / bootstrap pick up the new
+  constants and the H3 fold-in.
+
+### Out of scope
+
+**Logs at `/tmp/bootstrap_2026-05-12_window.log` et al. still not
+present.** The H1 cache-eviction sub-mechanism remains unverified.
+Code-evidence for H1 + H2 was strong enough to act without them per
+the audit and the brief. If the logs arrive later and surface a
+distinct cache-eviction pattern, that's a separate follow-up.
+
+**Slice 3a** — tool surface overhaul (audit T7 primary). Queued
+separately.
+
+**Cognee entities/relationships population** — Phase 5+ work.
+
+### Followups (this dispatch)
+
+| Priority | Item | Source |
+|----------|------|--------|
+| LOW | `tests/probes.test.js` — `pm2_processes: failure carries error string` env-guard. Pre-existing on main; carried over from Slice 2c followup table unchanged. | this / 2c |
+| INFO | Prompt-budget impact of H3 fold-in: ~30 audit lines × ~100 chars ≈ ~3 KB plus ~30 memory lines × ~140 chars ≈ ~4 KB. ~7 KB of system-prompt growth per message inside the bootstrap cache window. Well within the new 300k char-budget. Monitor `bootstrap.log` after first hot bootstrap to confirm `total_chars` stays bounded. | this |
+| INFO | `historyLimit` is now flat 24 regardless of knowledge size. If the char-budget guard ever needs to drop messages because knowledge content is genuinely massive, the symptom would manifest as truncated-conversation behaviour with no other obvious cause. Add a `log.warn` when `_truncateHistory` cuts messages so silent drops become observable. Not in this hotfix scope. | this |
+| INFO | H1 channel/userId filter relies on `context.channel` being set by upstream callers. Confirmed live at `src/channels/manager.js:434` (Telegram, sets `channel: 'telegram', userId: ctx.from.id`). Dashboard path (`src/dashboard/server.js`) sets it too. CLI and heartbeat intentionally don't (cross-channel reads still work via the falsy-options path). If a new entry point is added later, it must pass channel/userId or accept cross-channel behavior — worth surfacing in `LOCATIONS.md` if a third Telegram-like entry point lands. | this |
+
+### Verified live
+
+Pending Tyson post-merge:
+- [ ] `pm2 reload quantumclaw` — required for this hotfix (registry +
+  bootstrap modules changed).
+- [ ] Spot-check Charlie's next Telegram message: the system prompt
+  (visible via `/bootstrap-status` log or by sending a non-trivial
+  message and checking `tail -3 ~/.quantumclaw/skill-load.log` plus
+  any prompt log) should show the new `## Recent activity` and
+  `## Recent context` sections.
+- [ ] Repro test for the original symptom: deliberately exceed 4
+  user-assistant turns in a Telegram conversation about a specific
+  workflow, then ask a context-dependent follow-up that doesn't
+  re-reference the workflow. Pre-fix this would force the loss;
+  post-fix Charlie should retain the reference.
+- [ ] Optional: tail `~/.quantumclaw/audit.jsonl` and confirm
+  audit-log entries are reaching 30-cap (was 50) without errors.
+
+End of session 2026-05-14 memory drop hotfix.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "diagnose": "node src/cli/index.js diagnose",
     "chat": "node src/cli/index.js chat",
     "dashboard": "node src/dashboard/server.js",
-    "test": "node tests/smoke.test.js && node tests/agent-mutex.test.js && node tests/approval-parser-handler.test.js && node tests/approval-gate-notifier.test.js && node tests/approvals.test.js && node tests/bootstrap.test.js && node tests/probes.test.js && node tests/identity-canonicalization.test.js && node tests/skill-frontmatter.test.js && node tests/cli-skill-list.test.js && node tests/skill-router.test.js && node tests/skill-loader.test.js",
+    "test": "node tests/smoke.test.js && node tests/agent-mutex.test.js && node tests/approval-parser-handler.test.js && node tests/approval-gate-notifier.test.js && node tests/approvals.test.js && node tests/bootstrap.test.js && node tests/probes.test.js && node tests/identity-canonicalization.test.js && node tests/skill-frontmatter.test.js && node tests/cli-skill-list.test.js && node tests/skill-router.test.js && node tests/skill-loader.test.js && node tests/registry-history-isolation.test.js",
     "lint": "eslint src/"
   },
   "engines": {

--- a/src/agents/bootstrap.js
+++ b/src/agents/bootstrap.js
@@ -317,10 +317,13 @@ async function _layer4Recent(services, warnings) {
   }
 
   // Audit log: AuditLog.recent(limit) returns last N entries (newest first).
+  // H3 fix (2026-05-14): cap at 30 to match recent.memory's limit (line ~305).
+  // Layer 4 is now wired into _buildSystemPrompt; symmetric caps keep the
+  // prompt budget predictable. Audit ref: /tmp/memory_drop_diagnostic_audit.md.
   let audit_log = { source: 'unavailable', entries: [] };
   if (services?.audit && typeof services.audit.recent === 'function') {
     try {
-      const entries = services.audit.recent(50);
+      const entries = services.audit.recent(30);
       const source = services.audit.db ? 'sqlite' : 'jsonl';
       audit_log = { source, entries };
     } catch (err) {

--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -524,6 +524,27 @@ You exist to make your human's life easier and their business more profitable. Y
         const probeLines = bootstrap.probes.map(p => `- ${p.ok ? '✓' : '✗'} ${p.name} (${p.latency_ms}ms)${p.error ? ` — ${p.error}` : ''}`).join('\n');
         parts.push(`\n## Live probes (session bootstrap)\n${probeLines}`);
       }
+      // H3 fix (2026-05-14): Layer 4 fold-in. recent.audit_log + recent.memory
+      // were populated by bootstrap but never reached the prompt — closes the
+      // dead wiring. Both are capped at 30 entries at the bootstrap source.
+      // Audit ref: /tmp/memory_drop_diagnostic_audit.md.
+      if (bootstrap.recent?.audit_log?.entries?.length) {
+        const auditLines = bootstrap.recent.audit_log.entries.map(e => {
+          const ts = (e.timestamp || '').slice(0, 19);
+          const detail = (e.detail || '').replace(/\s+/g, ' ').slice(0, 80);
+          return `- ${ts} ${e.agent}/${e.action}${detail ? `: ${detail}` : ''}`;
+        }).join('\n');
+        parts.push(`\n## Recent activity (audit log, last ${bootstrap.recent.audit_log.entries.length})\n${auditLines}`);
+      }
+      if (bootstrap.recent?.memory?.entries?.length) {
+        const memLines = bootstrap.recent.memory.entries.map(e => {
+          const ts = (e.timestamp || '').slice(0, 19);
+          const ch = e.channel || 'unknown';
+          const content = (e.content || '').replace(/\s+/g, ' ').slice(0, 120);
+          return `- ${ts} [${ch}] ${e.role}: ${content}`;
+        }).join('\n');
+        parts.push(`\n## Recent context (conversation memory, last ${bootstrap.recent.memory.entries.length})\n${memLines}`);
+      }
     }
 
     // Add agent identity (AGEX AID)

--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -297,12 +297,22 @@ export class Agent {
       context?.userId
     );
 
-    const MAX_CONTEXT_CHARS = 100000;
+    // H2 fix (2026-05-14): char-budget raised 100k → 300k. Charlie calls
+    // Claude (typically Opus 4.x, 200k-token context ≈ ~800k chars).
+    // 300k chars ≈ ~75k tokens — leaves ~125k tokens of model headroom
+    // for the response and tool round-trips. _truncateHistory below is
+    // the real ceiling on what reaches the model.
+    const MAX_CONTEXT_CHARS = 300000;
     const systemChars = systemPrompt.length;
     const messageChars = textMessage.length;
     const availableForHistory = MAX_CONTEXT_CHARS - systemChars - messageChars;
 
-    const historyLimit = knowledgeContext.length > 100 ? 8 : 20;
+    // H2 fix (2026-05-14): flat 24 (was `knowledgeContext.length > 100 ? 8 : 20`).
+    // The prior ternary was a band-aid for prompt-bloat under heavy knowledge;
+    // _truncateHistory(availableForHistory) is the actual char-budget ceiling,
+    // making the message-count cap redundant. 8-message cap (4 turns) was
+    // confirmed too tight by the 2026-05-12 context-loss diagnostic.
+    const historyLimit = 24;
     // H1 fix (2026-05-14): scope history to the (channel, userId) of the
     // current message so heartbeat / CLI / dashboard writes can't pollute
     // the Telegram conversation a user is mid-flight in. Pre-fix this was

--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -303,7 +303,14 @@ export class Agent {
     const availableForHistory = MAX_CONTEXT_CHARS - systemChars - messageChars;
 
     const historyLimit = knowledgeContext.length > 100 ? 8 : 20;
-    const fullHistory = memory.getHistory(this.name, historyLimit);
+    // H1 fix (2026-05-14): scope history to the (channel, userId) of the
+    // current message so heartbeat / CLI / dashboard writes can't pollute
+    // the Telegram conversation a user is mid-flight in. Pre-fix this was
+    // an unfiltered agent-level fetch; see /tmp/memory_drop_diagnostic_audit.md.
+    const fullHistory = memory.getHistory(this.name, historyLimit, {
+      channel: context?.channel,
+      userId: context?.userId,
+    });
     const truncatedHistory = this._truncateHistory(fullHistory, availableForHistory);
 
     // Build user message — multimodal if images provided

--- a/src/core/heartbeat.js
+++ b/src/core/heartbeat.js
@@ -332,6 +332,12 @@ export class Heartbeat {
     // Pick a question — contextual if we have recent memory, random otherwise
     let question;
     try {
+      // Intentionally unfiltered (cross-channel). Auto-learn fires
+      // outside any specific user/channel context — its job is to
+      // surface a contextual question from whatever Charlie has been
+      // talking about recently across the whole agent surface. The
+      // H1 channel/userId filter at registry.js:_processNonReflex
+      // does not apply here. (Audit ref: /tmp/memory_drop_diagnostic_audit.md)
       const recent = this.memory.getHistory(agent.name, 10);
       const recentText = recent.map(m => m.content).join(' ').slice(0, 500);
 

--- a/tests/registry-history-isolation.test.js
+++ b/tests/registry-history-isolation.test.js
@@ -1,0 +1,101 @@
+/**
+ * History isolation tests — H1 hotfix, 2026-05-14.
+ *
+ * Run: node tests/registry-history-isolation.test.js
+ *
+ * Locks in the channel + userId filter contract that
+ * src/agents/registry.js _processNonReflex now relies on. Before this
+ * fix, getHistory(agent, limit) returned the agent's most recent N
+ * messages across all channels — so heartbeat / CLI / dashboard writes
+ * could pollute a live Telegram conversation. The fix passes
+ * { channel: context?.channel, userId: context?.userId } at
+ * src/agents/registry.js:306.
+ *
+ * These tests exercise the underlying memory.getHistory filter path
+ * (JSON-store fallback, same filter logic as the SQL path) to ensure
+ * the contract holds.
+ *
+ * Audit ref: /tmp/memory_drop_diagnostic_audit.md
+ */
+
+import { MemoryManager } from '../src/memory/manager.js';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+let passed = 0;
+let failed = 0;
+function check(label, cond, detail = '') {
+  if (cond) { console.log(`  ✓ ${label}`); passed++; }
+  else { console.error(`  ✗ ${label}${detail ? ' — ' + detail : ''}`); failed++; }
+}
+
+const tmp = mkdtempSync(join(tmpdir(), 'qclaw-history-iso-'));
+
+// Construct a minimal MemoryManager backed by the JSON store. We skip
+// the full connect() path (SQLite native module / Cognee / vector init)
+// because we're testing the getHistory filter contract only.
+const memory = new MemoryManager({ _dir: tmp }, {});
+memory._jsonStore = { conversations: [], context: {} };
+memory._jsonStorePath = join(tmp, 'memory.json');
+memory._saveJsonStore = () => {}; // no-op for test
+
+// Seed conversations across channels and users.
+memory.addMessage('charlie', 'user',      'cli-msg-1',   { channel: 'cli',       userId: 'X' });
+memory.addMessage('charlie', 'user',      'tg-msg-1',    { channel: 'telegram',  userId: 'X' });
+memory.addMessage('charlie', 'assistant', 'tg-reply-1',  { channel: 'telegram',  userId: 'X' });
+memory.addMessage('charlie', 'user',      'cli-msg-2',   { channel: 'cli',       userId: 'Y' });
+memory.addMessage('charlie', 'user',      'tg-msg-2',    { channel: 'telegram',  userId: 'X' });
+memory.addMessage('charlie', 'user',      'dash-msg-1',  { channel: 'dashboard', userId: 'X' });
+
+// ─── Channel + userId filter (the H1 fix contract) ─────────────────────
+const tgX = memory.getHistory('charlie', 20, { channel: 'telegram', userId: 'X' });
+check('channel+userId filter returns only matching channel',
+  tgX.length === 3 && tgX.every(m => m.channel === 'telegram'),
+  `got: ${tgX.map(m => `${m.channel}:${m.userId}`).join(', ')}`);
+check('channel+userId filter returns only matching userId',
+  tgX.every(m => m.userId === 'X'));
+check('channel+userId filter does NOT leak CLI entries with same userId',
+  !tgX.some(m => m.channel === 'cli'));
+check('channel+userId filter does NOT leak dashboard entries with same userId',
+  !tgX.some(m => m.channel === 'dashboard'));
+check('channel+userId filter does NOT leak other-user entries on same channel',
+  !tgX.some(m => m.userId === 'Y'));
+
+// ─── Channel-only filter (multi-user scenario) ─────────────────────────
+const allTg = memory.getHistory('charlie', 20, { channel: 'telegram' });
+check('channel-only filter returns all matching channel across users',
+  allTg.length === 3 && allTg.every(m => m.channel === 'telegram'),
+  `got: ${allTg.map(m => `${m.channel}:${m.userId}`).join(', ')}`);
+
+// ─── userId-only filter (legacy callers that don't track channel) ──────
+const allX = memory.getHistory('charlie', 20, { userId: 'X' });
+check('userId-only filter returns all matching userId across channels',
+  allX.length === 5 && allX.every(m => m.userId === 'X'),
+  `got: ${allX.map(m => `${m.channel}:${m.userId}`).join(', ')}`);
+
+// ─── Unfiltered call (heartbeat / auto-learn legitimate cross-channel) ──
+const all = memory.getHistory('charlie', 20);
+check('unfiltered call returns all agent messages (cross-channel)',
+  all.length === 6, `got ${all.length} messages`);
+
+// ─── Undefined-vs-missing options (heartbeat pattern parity) ───────────
+// registry.js passes { channel: context?.channel, userId: context?.userId }
+// where both keys are PRESENT but their values may be undefined for
+// non-Telegram callers. Filter behaviour must match the unfiltered case.
+const undefBoth = memory.getHistory('charlie', 20, { channel: undefined, userId: undefined });
+check('undefined channel + undefined userId behaves like unfiltered',
+  undefBoth.length === 6,
+  `got ${undefBoth.length}; expected 6 (parity with unfiltered)`);
+
+// ─── Limit honoured under filter ───────────────────────────────────────
+const tgLimited = memory.getHistory('charlie', 2, { channel: 'telegram', userId: 'X' });
+check('limit honoured alongside filter',
+  tgLimited.length === 2 && tgLimited.every(m => m.channel === 'telegram'),
+  `got ${tgLimited.length}`);
+
+// ─── Cleanup ───────────────────────────────────────────────────────────
+rmSync(tmp, { recursive: true, force: true });
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Three findings from the 2026-05-12 mid-conversation context-loss diagnostic (`/tmp/memory_drop_diagnostic_audit.md`), closed in one PR. Bug fix, not a design change — `CHARLIE_OVERHAUL.md` deliberately untouched.

- **H1 — cross-channel contamination.** [src/agents/registry.js:_processNonReflex](src/agents/registry.js) now passes `{ channel: context?.channel, userId: context?.userId }` to `memory.getHistory()`. Pre-fix, heartbeat / CLI / dashboard writes could displace Telegram-conversation messages out of the history window.
- **H2 — history-trim too tight.** `historyLimit` flattened from `knowledgeContext.length > 100 ? 8 : 20` to a flat `24`; `MAX_CONTEXT_CHARS` raised `100000 → 300000`. The diagnostic confirmed the effective 8-message cap (4 user-assistant turns) was the proximate cause of the symptom.
- **H3 — dead Layer 4 wiring.** [bootstrap.js:_layer4Recent](src/agents/bootstrap.js) audit cap lowered `50 → 30` to match `recent.memory`'s existing `limit:30`. [registry.js:_buildSystemPrompt](src/agents/registry.js) now renders `bootstrap.recent.audit_log` and `bootstrap.recent.memory` in the prompt, after the live-probes block (order: probes → audit_log → memory).

## Commits

| | |
|---|---|
| `3e77853` | fix(memory): H1 scope getHistory by channel + userId in registry |
| `9f4c325` | fix(memory): H2 raise history limit to 24 and char budget to 300k |
| `121b5ef` | fix(memory): H3 wire bootstrap Layer 4 into Charlie's prompt |

## Test plan

- [ ] Each test file run individually (npm test `&&` chain shorts on pre-existing probes.test.js workstation failure carried from Slice 2c):
  - smoke 24/24, agent-mutex 7/7, approval-parser-handler 29/29, approval-gate-notifier 13/13, approvals 13/13, bootstrap 32/32
  - probes 28/29 (`pm2_processes: failure carries error string` — workstation-only, pre-existing, unchanged from main)
  - identity-canonicalization 10/10, skill-frontmatter 249/249, cli-skill-list 59/59, skill-router 134/134, skill-loader 52/52
  - **registry-history-isolation 10/10 (new)**
- [ ] Workstation smoke test (`/tmp/h3-smoke.mjs`) — synthetic bootstrap renders both new sections with correct ordering and truncated content.
- [ ] **Tyson post-merge:** `pm2 reload quantumclaw` required (registry + bootstrap modules changed).
- [ ] Spot-check Charlie's next Telegram message — prompt should now include `## Recent activity (audit log, last N)` and `## Recent context (conversation memory, last N)` sections.
- [ ] **Repro test for the original symptom:** exceed 4 user-assistant turns in a Telegram conversation about a specific workflow, then ask a context-dependent follow-up that doesn't re-reference the workflow. Pre-fix this would force the loss; post-fix Charlie should retain the reference.

## Acceptance criteria check

- [x] All `getHistory` call sites either pass an explicit filter or carry an explicit cross-channel-justifying comment ([src/index.js:175](src/index.js#L175) stub, [src/core/heartbeat.js:335](src/core/heartbeat.js#L335) annotated, [src/agents/registry.js:306](src/agents/registry.js#L306) filtered, [src/dashboard/server.js:751](src/dashboard/server.js#L751) already correct).
- [x] `historyLimit` and `_truncateHistory` budget both reflect new values with rationale comments pointing at the audit.
- [x] `_buildSystemPrompt` embeds `bootstrap.recent.memory` AND `bootstrap.recent.audit_log`; smoke test confirms both sections render.
- [x] New test `tests/registry-history-isolation.test.js` asserts the channel + userId filter contract — 10 passing checks.

## Out of scope (per brief)

- Logs at `/tmp/bootstrap_2026-05-12_window.log` et al. — still not present; H1 cache-eviction sub-mechanism remains unverified but acted-on per the audit.
- Slice 3a (tool surface overhaul, audit T7) — separate dispatch queued.
- Cognee entities/relationships population — Phase 5+.

## Followups

| Priority | Item |
|----------|------|
| LOW | `tests/probes.test.js` `pm2_processes: failure carries error string` env-guard. Pre-existing, carried from Slice 2c. |
| INFO | Prompt-budget impact of H3 fold-in ≈ 7 KB per message inside bootstrap cache window. Comfortable within new 300k char budget. Monitor `bootstrap.log` `total_chars`. |
| INFO | Add `log.warn` in `_truncateHistory` when it drops messages, so silent prompt-budget cuts become observable. Not in this hotfix scope. |
| INFO | H1 filter assumes upstream callers set `context.channel` / `context.userId`. If a new Telegram-like entry point lands, document in `LOCATIONS.md`. |