### PR TITLE
Diag: one-shot prompt dump gated on QCLAW_PROMPT_DUMP=1 (TEMP — revert post-investigation)

### DIFF
--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -5,7 +5,7 @@
  * Default agent is "echo" — the primary assistant.
  */
 
-import { readdirSync, existsSync, readFileSync } from 'fs';
+import { readdirSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { log } from '../core/logger.js';
 import { parseSkill, skillToTools, executeSkillTool } from './skill-parser.js';
@@ -322,6 +322,36 @@ export class Agent {
       userId: context?.userId,
     });
     const truncatedHistory = this._truncateHistory(fullHistory, availableForHistory);
+
+    // ─── Temporary diagnostic instrumentation (2026-05-14) ─────────────
+    // REVERT post-investigation. Gated entirely behind QCLAW_PROMPT_DUMP=1.
+    // When unset, this block performs zero I/O and has zero behaviour
+    // impact. Captures the full assembled prompt + resolved truncated
+    // history + user message to /tmp/charlie_prompt_dump_<iso>.txt at
+    // mode 0600, one file per turn. Used to disambiguate H5a/b/c after
+    // the PR #15 memory-drop hotfix verification failed twice.
+    if (process.env.QCLAW_PROMPT_DUMP === '1') {
+      try {
+        const now = new Date();
+        const isoTs = now.toISOString();
+        const fileTs = isoTs.replace(/[:.]/g, '-');
+        const dumpPath = `/tmp/charlie_prompt_dump_${fileTs}.txt`;
+        const header = `=== PROMPT DUMP ${isoTs} userId=${context?.userId ?? 'null'} agent=${this.name} channel=${context?.channel ?? 'unknown'} historyLength=${truncatedHistory.length} ===\n\n`;
+        const promptBlock = `--- SYSTEM PROMPT (${systemPrompt.length} chars) ---\n${systemPrompt}\n\n`;
+        const historyBlock = `--- HISTORY (${truncatedHistory.length} entries, resolved after _truncateHistory) ---\n`
+          + truncatedHistory.map((h, i) =>
+              `[${i}] ${h.role}${h.channel ? ` @${h.channel}` : ''}${h.timestamp ? ` ${h.timestamp}` : ''}:\n${h.content || ''}`
+            ).join('\n\n')
+          + (truncatedHistory.length === 0 ? '(empty)' : '')
+          + '\n\n';
+        const userBlock = `--- USER MESSAGE (${textMessage.length} chars) ---\n${textMessage}\n`;
+        writeFileSync(dumpPath, header + promptBlock + historyBlock + userBlock, { mode: 0o600 });
+        log.debug(`prompt-dump: wrote ${dumpPath}`);
+      } catch (err) {
+        log.warn(`prompt-dump: write failed: ${err.message}`);
+      }
+    }
+    // ─── End diagnostic instrumentation ────────────────────────────────
 
     // Build user message — multimodal if images provided
     let userContent;


### PR DESCRIPTION
## Summary

**TEMPORARY DIAGNOSTIC INSTRUMENTATION — to be reverted post-investigation.**

Adds a per-turn prompt dump in `src/agents/registry.js:_processNonReflex` to disambiguate the post-PR-#15 repro failure. After the memory-drop hotfix (H1+H2+H3) merged and deployed, the 7-turn repro test was run twice. Both times Charlie confidently asserted Workflow A as the discussion subject when Workflow B was the actual reference 5 turns earlier. Three hypotheses to disambiguate via prompt content inspection:

- **H5a** — History isn't reaching the prompt at runtime (hotfix in code but something strips downstream).
- **H5b** — History reaches the prompt but Workflow B reference is buried under long Charlie outputs (salience failure).
- **H5c** — Workflow B reference is present and prominent; Charlie is ignoring it (model-behaviour limit or prompt-instruction gap).

## What the dump captures

When `QCLAW_PROMPT_DUMP=1` is set in env, each non-reflex turn writes one file at `/tmp/charlie_prompt_dump_<iso-ts>.txt` (mode 0600):

```
=== PROMPT DUMP <iso ts> userId=<id> agent=<name> channel=<channel> historyLength=<N> ===

--- SYSTEM PROMPT (<chars> chars) ---
<full assembled system prompt>

--- HISTORY (<N> entries, resolved after _truncateHistory) ---
[0] <role> @<channel> <ts>:
<full content>

[1] <role> @<channel> <ts>:
<full content>
...

--- USER MESSAGE (<chars> chars) ---
<full text>
```

When the flag is unset, the block performs zero I/O and has zero behaviour impact. The prompt itself is unchanged.

## Placement note

The brief specified "exit of `_buildSystemPrompt`" but `historyLength after _truncateHistory` is only available downstream in `_processNonReflex` (line 324). Dump placement is one block lower so `systemPrompt`, `truncatedHistory`, and `textMessage` are all in scope. Intent preserved: captures the full prompt + history + user message as a single per-turn artifact.

## Test plan

1. Tyson merges this PR (base: `tysonven/QClaw:main`, single commit `1a73ec0`).
2. `ssh qclaw`, add `QCLAW_PROMPT_DUMP=1` to `~/.quantumclaw/.env`, `pm2 reload quantumclaw`.
3. In Telegram, run the 7-turn repro:
   - `/session` reset
   - "tell me about Content Studio Workflow B"
   - 5 turns of unrelated topics
   - "what was that workflow ID again?"
4. `ls /tmp/charlie_prompt_dump_*.txt` — expect **7 files** (one per non-reflex turn). If `/session` triggers any reflex paths, those won't dump (only non-reflex turns hit `_processNonReflex`).
5. `scp qclaw:/tmp/charlie_prompt_dump_*.txt /tmp/` to Mac.
6. Remove `QCLAW_PROMPT_DUMP` from `.env`, `pm2 reload quantumclaw`.
7. Hand off the dump files to Claude (chat) for H5a/b/c analysis.

## Acceptance criteria check

- [x] Single commit, single file changed (`src/agents/registry.js`).
- [x] Dump fires only when env flag set; default off; zero behaviour change when unset (workstation smoke confirmed).
- [x] Dump captures full system prompt, full history array (with role + channel + timestamp + content per entry), and user message.
- [x] File path predictable (`/tmp/charlie_prompt_dump_<iso>.txt`) for scp.

## Verification

**Workstation smoke (`/tmp/dump-smoke.mjs`):**
- flag unset → 0 dump files (no behaviour change confirmed)
- flag set → 1 dump file per `process()` call, mode 0600
- 9 shape assertions all pass: header carries userId/agent/channel/historyLength; SYSTEM PROMPT / HISTORY / USER MESSAGE sections all present; history entries render with role @channel timestamp + full content.

**Full test suite:** 660 passed, 1 pre-existing probes workstation failure (`pm2_processes: failure carries error string` — unchanged from main, carried in Slice 2c followup table).

## Followups

| Priority | Item |
|----------|------|
| **REQUIRED** | **REVERT after diagnostic complete** — this is instrumentation only, not for permanent use. The revert commit should add the formal `QCLAW_BUILD_LOG.md` entry covering the full diagnostic episode (one cohesive block: instrumentation added → dumps collected → hypothesis verdicted → instrumentation reverted). |
| LOW | If the diagnostic outcome motivates permanent prompt observability, that's a separate Phase 5+ design decision — would likely live in a dedicated module, not inline in `_processNonReflex`. |
| INFO | `tests/probes.test.js` `pm2_processes: failure carries error string` env-guard — pre-existing, carried from Slice 2c. |