### PR TITLE
Revert prompt dump instrumentation (PR #16) + build log entry

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -9780,3 +9780,101 @@ Pending Tyson post-merge:
   audit-log entries are reaching 30-cap (was 50) without errors.
 
 End of session 2026-05-14 memory drop hotfix.
+
+## [2026-05-14] Prompt dump diagnostic — landed, ran, reverted
+
+One cohesive entry covering the temporary instrumentation episode that
+followed the memory-drop hotfix. Build log entry was deliberately
+deferred from the PR #16 commit (per Brief 5) so the full add → ran →
+verdicted → reverted arc lands in one block.
+
+### Trigger
+
+The memory-drop hotfix (PR #15, H1+H2+H3) merged and deployed earlier
+on 2026-05-14. Verification repro: `/session` reset → "tell me about
+Content Studio Workflow B" → 5 turns of unrelated topics → "what was
+that workflow ID again?". Pre-hotfix, this consistently dropped the
+Workflow B reference. Post-hotfix, the first two repro runs **failed**
+in a different way: Charlie confidently answered "Workflow A
+(Qf39NEOEgz2W0uls)" instead of "Workflow B (qeE2hCSFoB6fU926)",
+asserting "Based on the recent context in my prompt, the last workflow
+we were discussing was Workflow A..." — confident answer, not a
+"lost context" acknowledgement.
+
+Three hypotheses to disambiguate:
+
+- **H5a** — history isn't reaching the prompt at runtime (hotfix in
+  code but something strips downstream).
+- **H5b** — history reaches the prompt but Workflow B reference is
+  buried under Charlie's own long outputs (salience failure).
+- **H5c** — Workflow B reference is present and prominent; Charlie is
+  ignoring it (model-behaviour limit or prompt-instruction gap).
+
+### Instrumentation (PR #16, commit `1a73ec0`)
+
+Single-file change in `src/agents/registry.js:_processNonReflex`,
+gated on `process.env.QCLAW_PROMPT_DUMP === '1'`. When set, wrote one
+file per non-reflex turn to `/tmp/charlie_prompt_dump_<iso>.txt` at
+mode 0600 containing the full assembled system prompt, the resolved
+truncated history (role + channel + timestamp + full content per
+entry), and the user message. When unset, zero I/O, zero behaviour
+change. Workstation smoke (`/tmp/dump-smoke.mjs`) verified both halves
+of the gate. Build log entry deferred to this commit so the whole
+episode lands in one cohesive block.
+
+### Investigation
+
+Tyson merged PR #16, added `QCLAW_PROMPT_DUMP=1` to
+`~/.quantumclaw/.env`, `pm2 reload quantumclaw`, then ran 3 consecutive
+7-turn repros. **All three answered correctly** — Workflow B
+(qeE2hCSFoB6fU926) held through 5 intervening topic turns each time.
+Combined with the 2 pre-instrumentation failures, the symptom is
+2 / 5 = 40% — intermittent, not deterministic.
+
+H5a is rejected by the 3 successful runs (history reaches the prompt
+fine). H5b vs H5c can't be disambiguated from successful-run dumps
+alone — they'd need a failure-case dump to compare against. Since the
+hotfix is holding empirically and the residual symptom is
+probabilistic, deferring the H5b/c distinction to a future
+re-occurrence is the right call.
+
+### Revert (this commit)
+
+Instrumentation removed via `git revert 1a73ec0`. `src/agents/registry.js`
+is now identical to its post-PR-#15 state (verified empty diff against
+`121b5ef`). No residual `QCLAW_PROMPT_DUMP` / `charlie_prompt_dump`
+references anywhere in `src/`. Full test suite: 660 passed, 1
+pre-existing probes workstation failure unchanged.
+
+### Followup (verbatim, per brief)
+
+> **Intermittent context salience** (observed 2026-05-14, hotfix-era).
+> Twice observed Charlie answering "Workflow A" when "Workflow B" was
+> the session's opening reference, after 5 turns of intervening topics.
+> Three subsequent identical-sequence re-runs all answered correctly.
+> Hypothesis: probabilistic salience failure under recency bias from
+> Charlie's own long outputs. If pattern re-emerges, instrument with
+> `QCLAW_PROMPT_DUMP=1` and capture failure-case dump. Not currently
+> blocking.
+
+### PR #15 hotfix status
+
+- H1 channel/userId filter at `src/agents/registry.js:_processNonReflex`
+  — in place, verified.
+- H2 `historyLimit = 24` + `MAX_CONTEXT_CHARS = 300000` — in place,
+  verified.
+- H3 Layer 4 fold-in (`bootstrap.recent.audit_log` +
+  `bootstrap.recent.memory` in `_buildSystemPrompt`) — in place,
+  verified.
+- No regressions introduced by the prompt-dump revert.
+
+### Post-merge for Tyson
+
+- `ssh qclaw`, remove the `QCLAW_PROMPT_DUMP` line from
+  `~/.quantumclaw/.env`, `sudo pm2 reload quantumclaw`.
+- `sudo rm /tmp/charlie_prompt_dump_*.txt` (cleanup the captured dumps
+  — the 3 successful runs + any earlier files).
+- Confirm: send Charlie a normal Telegram message, no new dump file
+  should land in `/tmp/`.
+
+End of session 2026-05-14 prompt-dump diagnostic episode.

--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -5,7 +5,7 @@
  * Default agent is "echo" — the primary assistant.
  */
 
-import { readdirSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { readdirSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { log } from '../core/logger.js';
 import { parseSkill, skillToTools, executeSkillTool } from './skill-parser.js';
@@ -322,36 +322,6 @@ export class Agent {
       userId: context?.userId,
     });
     const truncatedHistory = this._truncateHistory(fullHistory, availableForHistory);
-
-    // ─── Temporary diagnostic instrumentation (2026-05-14) ─────────────
-    // REVERT post-investigation. Gated entirely behind QCLAW_PROMPT_DUMP=1.
-    // When unset, this block performs zero I/O and has zero behaviour
-    // impact. Captures the full assembled prompt + resolved truncated
-    // history + user message to /tmp/charlie_prompt_dump_<iso>.txt at
-    // mode 0600, one file per turn. Used to disambiguate H5a/b/c after
-    // the PR #15 memory-drop hotfix verification failed twice.
-    if (process.env.QCLAW_PROMPT_DUMP === '1') {
-      try {
-        const now = new Date();
-        const isoTs = now.toISOString();
-        const fileTs = isoTs.replace(/[:.]/g, '-');
-        const dumpPath = `/tmp/charlie_prompt_dump_${fileTs}.txt`;
-        const header = `=== PROMPT DUMP ${isoTs} userId=${context?.userId ?? 'null'} agent=${this.name} channel=${context?.channel ?? 'unknown'} historyLength=${truncatedHistory.length} ===\n\n`;
-        const promptBlock = `--- SYSTEM PROMPT (${systemPrompt.length} chars) ---\n${systemPrompt}\n\n`;
-        const historyBlock = `--- HISTORY (${truncatedHistory.length} entries, resolved after _truncateHistory) ---\n`
-          + truncatedHistory.map((h, i) =>
-              `[${i}] ${h.role}${h.channel ? ` @${h.channel}` : ''}${h.timestamp ? ` ${h.timestamp}` : ''}:\n${h.content || ''}`
-            ).join('\n\n')
-          + (truncatedHistory.length === 0 ? '(empty)' : '')
-          + '\n\n';
-        const userBlock = `--- USER MESSAGE (${textMessage.length} chars) ---\n${textMessage}\n`;
-        writeFileSync(dumpPath, header + promptBlock + historyBlock + userBlock, { mode: 0o600 });
-        log.debug(`prompt-dump: wrote ${dumpPath}`);
-      } catch (err) {
-        log.warn(`prompt-dump: write failed: ${err.message}`);
-      }
-    }
-    // ─── End diagnostic instrumentation ────────────────────────────────
 
     // Build user message — multimodal if images provided
     let userContent;


### PR DESCRIPTION
## Summary

Reverts PR #16 (commit `1a73ec0`) — the temporary prompt-dump instrumentation. Diagnostic complete: the PR #15 memory-drop hotfix is holding correctly across 3 consecutive 7-turn repros run after the instrumentation landed. The two pre-instrumentation failures are recharacterised as probabilistic salience variance and captured as a non-blocking followup.

## Commits

| | |
|---|---|
| `44d911e` | **revert(registry): remove prompt dump instrumentation (1a73ec0)** — single file, `src/agents/registry.js` restored to its post-PR-#15 state. Verified empty diff against `121b5ef`. |
| `f50c7c7` | **docs(build-log): prompt dump diagnostic episode end-to-end** — single cohesive `QCLAW_BUILD_LOG.md` entry covering add → ran → verdicted → reverted, with the intermittent-salience followup captured verbatim per brief. |

## Acceptance criteria check

- [x] `src/agents/registry.js` back to its post-PR-#15 state in `_processNonReflex` (verified: `git diff 121b5ef -- src/agents/registry.js` is empty).
- [x] Zero grep hits for `QCLAW_PROMPT_DUMP` across `src/` (also `charlie_prompt_dump`).
- [x] Full test suite passes: 660 passed, 1 pre-existing `probes.test.js` workstation failure unchanged from main.
- [x] Build log entry lands the full diagnostic episode in one cohesive block, including the verbatim followup.

## Test plan

- [ ] Tyson merges this PR (base: `tysonven/QClaw:main`).
- [ ] `ssh qclaw`, remove the `QCLAW_PROMPT_DUMP` line from `~/.quantumclaw/.env`, `sudo pm2 reload quantumclaw`.
- [ ] `sudo rm /tmp/charlie_prompt_dump_*.txt` (cleanup the 3 successful-run dumps and any earlier files).
- [ ] Confirm in Telegram: send Charlie a normal message — no new dump file should land in `/tmp/`.
- [ ] Optional: re-run a 7-turn repro (no env flag set) to confirm the hotfix is still holding on the reverted code path.

## PR #15 hotfix status (unchanged by this revert)

- **H1** channel/userId filter at `src/agents/registry.js:_processNonReflex` — in place.
- **H2** `historyLimit = 24` + `MAX_CONTEXT_CHARS = 300000` — in place.
- **H3** Layer 4 fold-in (`bootstrap.recent.audit_log` + `bootstrap.recent.memory` in `_buildSystemPrompt`) — in place.

## Followup captured (verbatim per brief, lives in `QCLAW_BUILD_LOG.md`)

> **Intermittent context salience** (observed 2026-05-14, hotfix-era). Twice observed Charlie answering "Workflow A" when "Workflow B" was the session's opening reference, after 5 turns of intervening topics. Three subsequent identical-sequence re-runs all answered correctly. Hypothesis: probabilistic salience failure under recency bias from Charlie's own long outputs. If pattern re-emerges, instrument with `QCLAW_PROMPT_DUMP=1` and capture failure-case dump. Not currently blocking.

## Out of scope

- Slice 3a — next dispatch, ready post-revert.
- Any structural fix for the salience problem — deferred per followup.