### PR TITLE
Slice 3d.1: git verb safe.directory prepend (fix dubious-ownership post-Slice-3d)

### DIFF
--- a/CHARLIE_OVERHAUL.md
+++ b/CHARLIE_OVERHAUL.md
@@ -704,8 +704,39 @@ Deleted: `src/tools/shell-exec-allowlist.js`,
 `tests/approval-gate-shell-exec-parser.test.js`).
 Verification: `scripts/verify-shell-exec-parser.js`.
 
+**Slice 3d.1 — git verb safe.directory prepend — ✓ COMPLETE 2026-05-17.**
+Post-deploy smoke surfaced "dubious ownership" failures on `git status`
+/ `git log` through `shell_exec`. Root cause: `SAFE_ENV.GIT_CONFIG_GLOBAL
+=/dev/null` (set in Slice 3d Round 2 to neutralise user-level aliases
+in `/root/.gitconfig`) also disables `safe.directory` resolution from
+the same file — the spawned git refuses to operate on `/root/QClaw`
+because it can't see the safe.directory entry. The three-gate
+dangerous-git-config-key model in Slice 3d didn't anticipate this:
+`safe.directory` wasn't on the dangerous list because it isn't an
+attack surface — but it was needed for legitimate operation under the
+sanitised env.
+
+Fix (Tyson's Option A): generic `spawnArgvPrefix?: string[]` field on
+verb schemas. `git status` and `git log` get `['-c',
+'safe.directory=/root/QClaw']`. The spawn module inserts the prefix
+between the binary and the verb-stripped user argv. Per-invocation
+trust, no config-file dependency, SAFE_ENV unchanged
+(alias-neutralisation property from Slice 3d preserved).
+
+Adversarial property preserved: user-supplied `-c` is rejected at the
+parser layer in both positions. `git -c X log` → `unknown_verb` (the
+two-token verb prefix `git -c` isn't a known verb). `git log -c X` →
+`invalid_flag/flag_not_in_v1` (`-c` isn't in git log's allowedFlags).
+Six new adversarial assertions in `tests/shell-exec-schemas.test.js`
+§F.1; nine spawn-argv assertions in `tests/shell-exec-env-isolation
+.test.js` §B/§B.1/§B.2.
+
+Files: `src/tools/shell-exec-verb-schemas.js`,
+`src/tools/shell-exec-spawn.js`, `tests/shell-exec-env-isolation.test.js`,
+`tests/shell-exec-schemas.test.js`.
+
 **Slice 3 family closure (2026-05-16):** 3a + 3b + 3b.1 + 3c + 3c.1 +
-3d all ✓ COMPLETE.
+3d all ✓ COMPLETE. Slice 3d.1 (2026-05-17) — post-merge fix — ✓ COMPLETE.
 
 Code-round adversarial review pending after Unit 3 push.
 

--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -11578,3 +11578,147 @@ fixture helper. The lesson: pre-PR verification on Tyson's Mac is
 necessary but not sufficient — every code change that touches
 filesystem paths in tests needs explicit non-root / no-/root validation
 before declaring ready-for-review.
+
+## 2026-05-17 — Slice 3d.1 — git verb safe.directory prepend (fix dubious-ownership post-Slice-3d)
+
+### Failure
+
+Post-deploy smoke after Slice 3d merge (PR #25, commit f79523a). Through
+Telegram → executor → shell_exec → spawnWithCaps, git verbs (`git
+status`, `git log`) fail with "dubious ownership". `sudo git -C
+/root/QClaw log` works fine as root on the qclaw host;
+`sudo git config --global --get-all safe.directory` returns
+`/root/QClaw`. Only the sanitised-env spawn path through shell_exec is
+blocked.
+
+Verbatim from Tyson's post-deploy report:
+
+```
+git verbs (git status, git log) fail with "dubious ownership"
+through shell_exec
+- sudo git -C /root/QClaw log works fine as root
+- sudo git config --global --get-all safe.directory returns
+  /root/QClaw
+- the repo is fully accessible — only shell_exec's sanitised env
+  path is blocked
+```
+
+### Root cause
+
+`SAFE_ENV.GIT_CONFIG_GLOBAL=/dev/null` (set in Slice 3d Round-2 to
+neutralise user-level aliases in `/root/.gitconfig` — see
+`src/tools/shell-exec-verb-schemas.js` line 36) ALSO disables
+`safe.directory` resolution from `/root/.gitconfig`. The same single
+env-var setting controls two unrelated behaviours:
+
+  - alias-neutralisation (the property Slice 3d wanted)
+  - safe.directory resolution (the property git needs for legitimate
+    cross-uid ownership of /root/QClaw — Charlie runs as a non-root
+    user under PM2, the repo is owned by root)
+
+Slice 3d's three-gate dangerous-git-config-key model
+(DANGEROUS_GIT_CONFIG_EXACT_KEYS / LEAVES / SECTIONS) caught attack
+surfaces but did not catch defensive surfaces — `safe.directory`
+wasn't on any dangerous list because it isn't an attack key, but it
+was needed for git to operate at all under the sanitised env.
+
+### Fix (Option A — Tyson's decision)
+
+Add a generic `spawnArgvPrefix?: string[]` field to the verb schemas
+(`src/tools/shell-exec-verb-schemas.js`). For `git status` and `git log`,
+the prefix is `['-c', 'safe.directory=/root/QClaw']`. The spawn module
+(`src/tools/shell-exec-spawn.js`) reads the schema's `spawnArgvPrefix`
+and inserts it BETWEEN argv[0] (the binary) and argv.slice(1) (the
+verb-stripped user argv). Per-invocation safe.directory trust, no
+config-file dependency.
+
+SAFE_ENV is NOT modified — `GIT_CONFIG_GLOBAL=/dev/null` stays. The
+alias-neutralisation property from Slice 3d is preserved (the spawned
+git still does not read /root/.gitconfig). Only the single needed
+safe.directory key is re-injected per-invocation.
+
+### Adversarial property preserved
+
+User-supplied `-c` MUST NOT be accepted at any layer. Same flag-injection
+concern from Slice 3d Round 1. Verified by ad-hoc probe
+(`/tmp/slice3d1_adhoc.js`):
+
+```
+[git -c alias.log=evil log] command='git -c alias.log=evil log'
+           result={"ok":false,"error":"unknown_verb","reason":"verb_not_in_v1","detail":{"verb":"git -c"}}
+[git -c safe.directory=/x log] command='git -c safe.directory=/x log'
+           result={"ok":false,"error":"unknown_verb","reason":"verb_not_in_v1","detail":{"verb":"git -c"}}
+[git -c http.sslVerify=false status] command='git -c http.sslVerify=false status'
+           result={"ok":false,"error":"unknown_verb","reason":"verb_not_in_v1","detail":{"verb":"git -c"}}
+[git log -c X] command='git log -c X'
+           result={"ok":false,"error":"invalid_flag","reason":"flag_not_in_v1","detail":{"token":"-c","verb":"git log"}}
+[git log -c user.name=foo] command='git log -c user.name=foo'
+           result={"ok":false,"error":"invalid_flag","reason":"flag_not_in_v1","detail":{"token":"-c","verb":"git log"}}
+```
+
+Two structural protections:
+  - `git -c X log` → parser dispatch tries the two-token verb prefix
+    `git -c` → `unknown_verb/verb_not_in_v1` (no such verb in
+    VERB_SCHEMAS). The `-c` token cannot reach the subcommand from
+    the git-level position.
+  - `git log -c X` → `-c` is not in `git log`'s allowedFlags → 
+    `invalid_flag/flag_not_in_v1`.
+
+The structural invariant: user input → parse → schema validate → spawn
+prepends its own flags AFTER validation. User input never contains `-c`
+in any accepted form, so the prefix can ONLY come from the schema's
+spawnArgvPrefix array.
+
+### Spawn argv verified
+
+```
+[git log] command='git log -n 5 --oneline'
+           bin=/usr/bin/git
+           argv=["-c","safe.directory=/root/QClaw","log","-n","5","--oneline"]
+[git status] command='git status'
+           bin=/usr/bin/git
+           argv=["-c","safe.directory=/root/QClaw","status"]
+[ls (no args)] command='ls'
+           bin=/bin/ls
+           argv=[]
+```
+
+Non-git verbs (ls, cat, pm2) do NOT receive a spawnArgvPrefix —
+schema-absent, argv passthrough is unchanged.
+
+### Local verification (post-fix)
+
+```
+shell-exec-parser.test.js:                64 passed, 0 failed
+shell-exec-schemas.test.js:               66 passed, 0 failed   (+6 adversarial -c assertions)
+shell-exec-path-resolve.test.js:          46 passed, 0 failed
+shell-exec-env-isolation.test.js:         34 passed, 0 failed   (+9 spawnArgvPrefix assertions)
+shell-exec-git-config-safety.test.js:     22 passed, 0 failed
+approval-gate-shell-exec-parser.test.js:  81 passed, 0 failed
+shell-exec-spawn-limits.test.js:          12 passed, 0 failed
+verify-shell-exec-parser.js:              47 passed, 0 failed
+```
+
+Tyson's required assertion (`argv[1] === '-c'` and `argv[2] ===
+'safe.directory=/root/QClaw'` for any git invocation) implemented in
+`tests/shell-exec-env-isolation.test.js` §B and §B.1, captured at the
+spawn boundary via the node:test `mock.method(child_process, 'spawn',
+…)` spy.
+
+### Files changed
+
+- `src/tools/shell-exec-verb-schemas.js` — `spawnArgvPrefix` field
+  added to `git status` and `git log` schemas
+- `src/tools/shell-exec-spawn.js` — imports VERB_SCHEMAS, reads
+  schema.spawnArgvPrefix, prepends to spawn argv (between binary and
+  argv.slice(1))
+- `tests/shell-exec-env-isolation.test.js` — existing argv-slice
+  assertion updated for the new prefix; +B.1 git status spawn argv;
+  +B.2 non-git verbs do NOT receive prefix
+- `tests/shell-exec-schemas.test.js` — +§F.1 Slice 3d.1 adversarial
+  battery: 6 user-supplied `-c` rejection assertions
+
+### Post-deploy smoke (1 step)
+
+`show me recent git log` through Telegram should return log output
+(not dubious-ownership). Tyson's responsibility post-merge.

--- a/src/tools/shell-exec-spawn.js
+++ b/src/tools/shell-exec-spawn.js
@@ -22,6 +22,7 @@ import {
   SPAWN_TIMEOUT_MS,
   MAX_OUTPUT_BYTES,
   VERB_BINARY,
+  VERB_SCHEMAS,
 } from './shell-exec-verb-schemas.js';
 
 function decodeOutput(buf) {
@@ -54,6 +55,33 @@ export async function spawnWithCaps(validated) {
     };
   }
 
+  // Slice 3d.1 — schema-level spawnArgvPrefix.
+  //
+  // Some verbs need a binary-level option prepended that users must
+  // NEVER be able to inject themselves. Today: `git status` and
+  // `git log` need `-c safe.directory=/root/QClaw` because SAFE_ENV's
+  // GIT_CONFIG_GLOBAL=/dev/null disables safe.directory resolution
+  // from /root/.gitconfig (the same setting that neutralises user
+  // aliases — both properties live in the same file).
+  //
+  // The prefix is read from VERB_SCHEMAS[schemaKey].spawnArgvPrefix
+  // and inserted BETWEEN the binary and the verb-stripped argv. The
+  // parser/schema never accepts `-c` from user input (not in any
+  // allowed-flags list, and `git -c X log` rejects at dispatch as
+  // unknown_verb because `git -c` isn't a two-token verb prefix).
+  // The structural property: user input → parse → schema validate →
+  // spawn prepends its own flags AFTER validation. User cannot
+  // inject their own `-c`.
+  const schema = VERB_SCHEMAS[validated.schemaKey] || {};
+  const spawnArgvPrefix = Array.isArray(schema.spawnArgvPrefix)
+    ? schema.spawnArgvPrefix
+    : [];
+  // Strip argv[0] (the binary verb, e.g. 'git') — the subcommand and
+  // any positional/flag tokens remain in argv.slice(1). For `git
+  // status`/`git log`, the prefix is inserted BEFORE the subcommand
+  // so the spawned process sees `git -c safe.directory=... status`.
+  const spawnArgs = [...spawnArgvPrefix, ...argv.slice(1)];
+
   const startedAt = Date.now();
   // Build SAFE_ENV — make a fresh object (don't pass the frozen one to
   // spawn so Node can't mutate; also so the spy can deep-equal).
@@ -66,7 +94,7 @@ export async function spawnWithCaps(validated) {
       // mock.method(child_process, 'spawn', …) can intercept. A
       // top-level `import { spawn }` would snapshot the binding and
       // dodge the spy.
-      child = child_process.spawn(binary, argv.slice(1), {
+      child = child_process.spawn(binary, spawnArgs, {
         shell: false,
         cwd: ALLOWED_CWD,
         env,

--- a/src/tools/shell-exec-verb-schemas.js
+++ b/src/tools/shell-exec-verb-schemas.js
@@ -365,6 +365,17 @@ export const VERB_SCHEMAS = Object.freeze({
     allowedFlags: [],
     positional: { min: 0, max: 0 },
     maxArgvLength: 2,
+    // Slice 3d.1 — `safe.directory` prepend. SAFE_ENV sets
+    // GIT_CONFIG_GLOBAL=/dev/null (to neutralise user-level aliases
+    // in /root/.gitconfig), which also disables safe.directory
+    // resolution from /root/.gitconfig. Per-invocation `-c
+    // safe.directory=/root/QClaw` re-grants ownership trust for the
+    // single spawned git WITHOUT re-enabling /root/.gitconfig (so
+    // the alias-neutralisation property from Slice 3d is preserved).
+    // The parser does NOT accept `-c` from users (see git log flag
+    // list — it's not in allowedFlags, and `git -c X log` rejects as
+    // unknown_verb at dispatch). The prefix is spawn-side only.
+    spawnArgvPrefix: ['-c', 'safe.directory=/root/QClaw'],
   },
   'git log': {
     allowedFlags: [
@@ -386,6 +397,8 @@ export const VERB_SCHEMAS = Object.freeze({
     ],
     positional: { min: 0, max: 0 },
     maxArgvLength: 7,
+    // Slice 3d.1 — see `git status` note above.
+    spawnArgvPrefix: ['-c', 'safe.directory=/root/QClaw'],
   },
   'pm2 list': {
     allowedFlags: [],

--- a/tests/shell-exec-env-isolation.test.js
+++ b/tests/shell-exec-env-isolation.test.js
@@ -118,7 +118,7 @@ async function runEnvShapeTest() {
 }
 
 async function runArgvSliceTest() {
-  console.log('\n=== B. argv passed to spawn excludes the verb token ===');
+  console.log('\n=== B. argv passed to spawn excludes argv[0] and prepends schema spawnArgvPrefix (Slice 3d.1) ===');
   const captured = {};
   const spy = setupSpy(captured);
   try {
@@ -126,7 +126,65 @@ async function runArgvSliceTest() {
     check('parses', validated.ok);
     await spawnWithCaps(validated);
     check('bin = /usr/bin/git', captured.bin === '/usr/bin/git');
-    check("argv === ['log','--oneline','-n','5']", JSON.stringify(captured.argv) === JSON.stringify(['log', '--oneline', '-n', '5']));
+    // Slice 3d.1 — schema-level spawnArgvPrefix prepends
+    // `-c safe.directory=/root/QClaw` for git verbs (works around
+    // GIT_CONFIG_GLOBAL=/dev/null neutralising safe.directory from
+    // /root/.gitconfig along with the user aliases).
+    const expectedArgv = ['-c', 'safe.directory=/root/QClaw', 'log', '--oneline', '-n', '5'];
+    check(
+      `argv === ${JSON.stringify(expectedArgv)}`,
+      JSON.stringify(captured.argv) === JSON.stringify(expectedArgv),
+      captured.argv,
+    );
+    // Tyson's required structural assertion: argv[1]/argv[2] are
+    // the prepended safe.directory tokens for any git invocation.
+    check("argv[0] === '-c' (prepend, position 0)", captured.argv[0] === '-c');
+    check("argv[1] === 'safe.directory=/root/QClaw' (prepend, position 1)", captured.argv[1] === 'safe.directory=/root/QClaw');
+  } finally {
+    spy.mock.restore();
+  }
+}
+
+async function runGitStatusSpawnArgvTest() {
+  console.log('\n=== B.1 git status spawn argv includes safe.directory prepend (Slice 3d.1) ===');
+  const captured = {};
+  const spy = setupSpy(captured);
+  try {
+    const validated = parseAndValidate('git status');
+    check('parses', validated.ok);
+    await spawnWithCaps(validated);
+    check('bin = /usr/bin/git', captured.bin === '/usr/bin/git');
+    const expectedArgv = ['-c', 'safe.directory=/root/QClaw', 'status'];
+    check(
+      `argv === ${JSON.stringify(expectedArgv)}`,
+      JSON.stringify(captured.argv) === JSON.stringify(expectedArgv),
+      captured.argv,
+    );
+    check("argv[0] === '-c'", captured.argv[0] === '-c');
+    check("argv[1] === 'safe.directory=/root/QClaw'", captured.argv[1] === 'safe.directory=/root/QClaw');
+  } finally {
+    spy.mock.restore();
+  }
+}
+
+async function runNonGitNoPrefixTest() {
+  console.log('\n=== B.2 non-git verbs do NOT receive spawnArgvPrefix (Slice 3d.1) ===');
+  const captured = {};
+  const spy = setupSpy(captured);
+  try {
+    // Synthesise a validated `ls` (no fixture realpath needed —
+    // schema has no spawnArgvPrefix, so spawn argv should be
+    // exactly argv.slice(1)).
+    const validated = {
+      ok: true,
+      argv: ['ls'],
+      schemaKey: 'ls',
+      verbTokens: 1,
+      resolvedPaths: new Map(),
+    };
+    await spawnWithCaps(validated);
+    check('bin = /bin/ls', captured.bin === '/bin/ls');
+    check("argv === [] (no prefix for ls)", JSON.stringify(captured.argv) === JSON.stringify([]), captured.argv);
   } finally {
     spy.mock.restore();
   }
@@ -159,6 +217,8 @@ async function runResolvedPathsSubstitutionTest() {
   try {
     await runEnvShapeTest();
     await runArgvSliceTest();
+    await runGitStatusSpawnArgvTest();
+    await runNonGitNoPrefixTest();
     await runResolvedPathsSubstitutionTest();
     console.log(`\n=== shell-exec-env-isolation.test.js: ${passed} passed, ${failed} failed ===\n`);
     if (failed > 0) process.exit(1);

--- a/tests/shell-exec-schemas.test.js
+++ b/tests/shell-exec-schemas.test.js
@@ -149,6 +149,24 @@ rej('git log --format=anything (forbidden)', 'git log --format=raw', 'invalid_fl
 rej('git log --output=/tmp/x', 'git log --output=/tmp/x', 'invalid_flag');
 rej('git log -c user.name=foo', 'git log -c user.name=foo', 'invalid_flag');
 
+// Slice 3d.1 — adversarial. The schema prepends `-c
+// safe.directory=/root/QClaw` to the spawn argv for git verbs, so we
+// must verify the parser refuses to accept any user-supplied `-c`
+// (neither at git-level nor as a git log flag). This is the same
+// flag-injection concern from Slice 3d Round 1.
+console.log('\n=== F.1 Slice 3d.1 adversarial: user-supplied -c is rejected ===');
+// `git -c <kv> log` — parser tokenises into ['git','-c','...','log'];
+// dispatch tries the two-token verb prefix `git -c`, which isn't a
+// known verb → unknown_verb. (Verified by /tmp/slice3d1_adhoc.js.)
+rej('git -c alias.log=evil log (git-level -c)', "git -c alias.log=evil log", 'unknown_verb');
+rej('git -c safe.directory=/x log (git-level -c)', 'git -c safe.directory=/x log', 'unknown_verb');
+rej('git -c http.sslVerify=false log', 'git -c http.sslVerify=false log', 'unknown_verb');
+// `git log -c X` — `-c` not in git log's allowedFlags.
+rej('git log -c X (subcommand-level -c)', 'git log -c X', 'invalid_flag', 'flag_not_in_v1');
+rej('git log -c alias.log=evil', 'git log -c alias.log=evil', 'invalid_flag', 'flag_not_in_v1');
+// Same for git status.
+rej('git -c X status (git-level -c)', 'git -c safe.directory=/x status', 'unknown_verb');
+
 console.log('\n=== G. pm2 verb dispatch ===');
 ok('pm2 list (parse + dispatch only)', 'pm2 list', 'pm2 list');
 ok('pm2 ls (alias)', 'pm2 ls', 'pm2 list');


### PR DESCRIPTION
## Summary

- Adds `spawnArgvPrefix: ['-c', 'safe.directory=/root/QClaw']` to the `git status` and `git log` schemas in `src/tools/shell-exec-verb-schemas.js`.
- Wires `src/tools/shell-exec-spawn.js` to read the schema's `spawnArgvPrefix` and insert it between the binary and the verb-stripped argv.
- Restores `git log` / `git status` operation through `shell_exec` without re-enabling `/root/.gitconfig` (alias-neutralisation property from Slice 3d preserved).
- Small, tightly-scoped post-merge fix — schema + spawn glue + tests; no SAFE_ENV change, no parser change, no new allowed flags for users.

## Episode (post-deploy smoke)

After Slice 3d (PR #25, f79523a) merged, post-deploy smoke through Telegram surfaced that git verbs (`git status`, `git log`) fail with **"dubious ownership"** when invoked through `shell_exec`. Tyson verified:

- `sudo git -C /root/QClaw log` works fine as root on the qclaw host.
- `sudo git config --global --get-all safe.directory` returns `/root/QClaw`.
- The repo is fully accessible — only `shell_exec`'s sanitised env path is blocked.

## Root cause

`SAFE_ENV.GIT_CONFIG_GLOBAL=/dev/null` (set in Slice 3d Round 2 to neutralise user-level aliases in `/root/.gitconfig` — `src/tools/shell-exec-verb-schemas.js:36`) **also disables `safe.directory` resolution from the same file**. One env-var setting controls two unrelated behaviours:

- alias-neutralisation (the property Slice 3d wanted)
- `safe.directory` resolution (the property git needs for legitimate cross-uid ownership)

Slice 3d's three-gate dangerous-git-config-key model
(`DANGEROUS_GIT_CONFIG_EXACT_KEYS` / `LEAVES` / `SECTIONS`) caught attack surfaces but did not catch defensive surfaces — `safe.directory` wasn't on any dangerous list because it isn't an attack key.

## Fix (Tyson's Option A)

Generic `spawnArgvPrefix?: string[]` field on verb schemas. The spawn module inserts the prefix between the binary and the verb-stripped user argv. Per-invocation trust; no config-file dependency.

- `git status` / `git log` carry `['-c', 'safe.directory=/root/QClaw']`.
- Non-git verbs (`ls`, `cat`, `pm2 list`) have no `spawnArgvPrefix`; behaviour unchanged.
- SAFE_ENV is NOT modified — the alias-neutralisation property from Slice 3d is preserved.

The mechanism is generic — any future verb that needs spawn-side flags injected can use the same field.

## Adversarial property (preserved)

The same flag-injection concern from Slice 3d Round 1: user-supplied `-c` MUST NOT be accepted at any layer. Structural invariant: **user input → parse → schema validate → spawn prepends its own flags AFTER validation**. User input never contains `-c` in any accepted form, so the prefix can ONLY come from the schema's `spawnArgvPrefix` array.

Two protections (both verified by ad-hoc probe + new test assertions):

- **`git -c X log`** → parser tokenises to `['git','-c','X','log']`; dispatch tries the two-token verb prefix `git -c` → `unknown_verb/verb_not_in_v1` (no such verb in `VERB_SCHEMAS`). The `-c` token cannot reach the subcommand from the git-level position.
- **`git log -c X`** → `-c` is not in `git log`'s `allowedFlags` → `invalid_flag/flag_not_in_v1`.

## Tests

`tests/shell-exec-env-isolation.test.js` updates the existing argv-slice assertion (line 129) to the new prefix, plus two new sections:

- §B.1 — `git status` spawn argv: `['-c','safe.directory=/root/QClaw','status']`
- §B.2 — `ls` (no prefix expected): `[]`

Tyson's required assertions (`argv[1] === '-c'`, `argv[2] === 'safe.directory=/root/QClaw'`) are present in §B and §B.1.

`tests/shell-exec-schemas.test.js` §F.1 adds six adversarial assertions for user-supplied `-c` rejection at both git-level and subcommand-level positions, plus `git status`.

### Test output (verbatim)

```
shell-exec-parser.test.js:                64 passed, 0 failed
shell-exec-schemas.test.js:               66 passed, 0 failed   (+6 adversarial -c assertions)
shell-exec-path-resolve.test.js:          46 passed, 0 failed
shell-exec-env-isolation.test.js:         34 passed, 0 failed   (+9 spawnArgvPrefix assertions)
shell-exec-git-config-safety.test.js:     22 passed, 0 failed
approval-gate-shell-exec-parser.test.js:  81 passed, 0 failed
shell-exec-spawn-limits.test.js:          12 passed, 0 failed
verify-shell-exec-parser.js:              47 passed, 0 failed
```

### Ad-hoc probe output (verbatim — `/tmp/slice3d1_adhoc.js`)

```
=== Slice 3d.1 ad-hoc probe ===

--- (1) git log -n 5 --oneline spawn argv ---
[git log] command='git log -n 5 --oneline'
           bin=/usr/bin/git
           argv=["-c","safe.directory=/root/QClaw","log","-n","5","--oneline"]

--- (2) git status spawn argv ---
[git status] command='git status'
           bin=/usr/bin/git
           argv=["-c","safe.directory=/root/QClaw","status"]

--- (3) adversarial: user -c at git-level rejects ---
[git -c alias.log=evil log] command='git -c alias.log=evil log'
           result={"ok":false,"error":"unknown_verb","reason":"verb_not_in_v1","detail":{"verb":"git -c"}}
[git -c safe.directory=/x log] command='git -c safe.directory=/x log'
           result={"ok":false,"error":"unknown_verb","reason":"verb_not_in_v1","detail":{"verb":"git -c"}}
[git -c http.sslVerify=false status] command='git -c http.sslVerify=false status'
           result={"ok":false,"error":"unknown_verb","reason":"verb_not_in_v1","detail":{"verb":"git -c"}}

--- (4) adversarial: user -c after log subcommand rejects ---
[git log -c X] command='git log -c X'
           result={"ok":false,"error":"invalid_flag","reason":"flag_not_in_v1","detail":{"token":"-c","verb":"git log"}}
[git log -c user.name=foo] command='git log -c user.name=foo'
           result={"ok":false,"error":"invalid_flag","reason":"flag_not_in_v1","detail":{"token":"-c","verb":"git log"}}

--- (5) non-git verb (ls) — no spawnArgvPrefix expected ---
[ls (no args)] command='ls'
           bin=/bin/ls
           argv=[]
```

## Post-deploy smoke battery (1 step)

After merge + deploy:

- [ ] `show me recent git log` through Telegram returns log output (not "dubious ownership").

## Files changed

- `src/tools/shell-exec-verb-schemas.js` — `spawnArgvPrefix` field on `git status` and `git log` schemas.
- `src/tools/shell-exec-spawn.js` — imports `VERB_SCHEMAS`, reads `schema.spawnArgvPrefix`, prepends to spawn argv.
- `tests/shell-exec-env-isolation.test.js` — existing argv-slice assertion updated; §B.1 git status; §B.2 non-git verbs.
- `tests/shell-exec-schemas.test.js` — §F.1 adversarial `-c` rejection battery (6 assertions).
- `QCLAW_BUILD_LOG.md` — Slice 3d.1 entry (verbatim failure shape, root cause, fix, adversarial property, test output, ad-hoc probe output).
- `CHARLIE_OVERHAUL.md` — Slice 3d.1 marked complete; note on why the three-gate dangerous-key model didn't anticipate this (`safe.directory` is defensive, not attack-surface).

## Hard constraints honoured

- SAFE_ENV is unchanged — alias-neutralisation property from Slice 3d preserved.
- No new allowed flags for users — `-c` remains rejected at the parser/schema layer.
- Single focused commit.
- Branch: `cc/slice3d1-git-safe-directory-20260517-1142`.
- Opened as DRAFT — adversarial review next.
