### PR TITLE
chore: ignore .claude/settings.local.json (per-developer CC config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ CLAUDE_CODE_TASKS.md
 *.backup.*
 .claude-code-session.lock
 
+# Claude Code per-developer local settings (not shared across the team)
+.claude/settings.local.json
+
 # Python bytecode caches
 __pycache__/
 *.pyc


### PR DESCRIPTION
## Summary
- Adds explicit per-project ignore for `.claude/settings.local.json` so per-developer Claude Code permission allowlists don't accidentally get committed.
- The file is already covered by the user-global git ignore, but the project-level entry makes it self-documenting and protects developers without that global config.

## Why
Each developer maintains their own local Claude Code permission allowlist in `.claude/settings.local.json` to pre-authorise safe read-only tools (npm test, git status/diff/log, grep, find, Read, etc.) and deny dangerous ones (rm -rf, git push --force, sudo). That file is per-developer config — it should never be shared/committed.

## Test plan
- [x] `git check-ignore -v .claude/settings.local.json` resolves to the project `.gitignore` line, not the global one
- [x] Single-file commit, only `.gitignore` modified
- [ ] After merge: restart Claude Code session, verify approval prompts drop on `npm test`, `git status`, `grep`, etc. and still fire on writes/commits/pushes