### PR TITLE
feat(dispatch): execute approved write-scope dispatches via clone + PR (P5S2)

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -14979,3 +14979,73 @@ this before any code was written.
 3. GHL write tools (draft email, invoice, contact update per
    sub-account)
 4. Trading workflow reactivation
+
+## [2026-07-02] Phase 5 Session 2 — CC dispatcher write-scope execution
+
+**What shipped (branch cc/p5s2-dispatcher-write-20260702):**
+
+Dispatcher now RUNS write scope. ALLOWED_SCOPES expanded to
+{audit, read_only, write}; infra + critical stay hard-rejected at
+validateScope (fail-closed). No claim-RPC/SQL change was needed —
+the ✅ handler already re-queues an approved write row to
+status='queued' (scope stays 'write'), so the existing queued-only
+claim_next_dispatch picks it up; only the scope gate had to open.
+
+Write path: CC runs as ccdispatch in the throwaway clone under
+--permission-mode acceptEdits with a new cc-write-settings.json
+(Edit/Write allowed; secret-read + push/commit/gh/curl denies kept).
+CC only mutates files — the DISPATCHER (never CC) does all git/gh.
+After CC exits the dispatcher runs git status --porcelain as the
+clone owner and validates every changed path against the brief's
+optional "# Expected paths" section:
+  - no changes            → complete, note "no mutations — CC found
+                            nothing to change", no push
+  - any path out of scope → failed, aborted, NOT pushed (result names
+                            the offending files)
+  - all paths in scope /
+    no expected_paths (warn) → commit + push + PR
+
+PR creation: branch cc/write-<8-char task_id>, commit
+"feat(dispatch): <task one-liner>", pushed to tysonven/QClaw via the
+gh credential helper (-c credential.helper='!gh auth git-credential')
+so GH_TOKEN is never in the argv/URL/reflog; then gh pr create -R
+tysonven/QClaw. PR URL captured into result + metadata.pr_url.
+
+GH_TOKEN handling: read from the encrypted secret store
+(ccdispatch_github_token) AT DISPATCH TIME, injected into the scrubbed
+child env for write scope ONLY (audit/read_only child env unchanged —
+no GH_TOKEN), and added to the output scrubber's known-values list
+before CC runs so it can never survive into result/error/summary.
+Live-verified: store decrypts the token (len 93, fine-grained PAT);
+the exact push credential-helper path authenticates as ccdispatch
+(read-only git ls-remote returned HEAD, EXIT=0 — no writes to GitHub).
+
+Security hardening beyond the brief: write-scope authorisation-
+provenance guard. Rows are untrusted end-to-end; a fabricated
+queued+write row (bypassing Telegram approval) lacks
+authorised_by/authorised_at, so the dispatcher now refuses to execute
+any write row missing them (CC never spawned).
+
+Tool side: claude_code_dispatch gained an optional expected_paths
+array field rendered into the brief as a one-line JSON "# Expected
+paths" section (./ stripped, de-duped); the stale "write-execution
+gap" note was updated.
+
+Tests: +50 checks in cc-dispatcher.test.js (ALLOWED_SCOPES write/
+infra, GH_TOKEN env matrix, write argv is acceptEdits not plan,
+parseExpectedPaths, planWriteOutcome, briefTaskLine, changedFiles
+porcelain parse, and a processOne write smoke driving the full branch
+with injected deps: writeMode, GH injection, branch/commit/PR shape,
+unauthorised-reject, out-of-scope-abort, no-mutation-note, missing-
+token-fail) + 2 in cc-write-scope.test.js (expected_paths brief
+render). Full suite green (node --test entrypoints, all pass).
+
+**Constraints honoured:** ccdispatch remains the execution user (never
+root); infra/critical still hard-rejected; GH_TOKEN absent from
+audit/read_only child env; path comparison is pure JS array membership
+(no shell glob); no schema change; no new PM2 process; PR target is
+tysonven/QClaw (never upstream).
+
+**Not deployed this session:** dispatcher not restarted under PM2 —
+code is on the branch/PR only; live enablement is a follow-up after
+review + merge.

--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -15049,3 +15049,73 @@ tysonven/QClaw (never upstream).
 **Not deployed this session:** dispatcher not restarted under PM2 —
 code is on the branch/PR only; live enablement is a follow-up after
 review + merge.
+
+## [2026-07-02] Phase 5 Session 2 — adversarial review remediation (PR #51)
+
+A separate adversarial-review pass over the write-scope dispatcher
+(per feedback_adversarial_review_before_pr_ready) found 1 HIGH, 1
+MEDIUM and several LOW issues. All six remediated on-branch; PR stays
+draft pending re-review.
+
+**HIGH — GH_TOKEN was handed to the untrusted CC.** Criterion B had
+injected the GitHub PAT into CC's own child env. Because the output
+scrubber only sanitises the DB result row (never committed file
+contents), an adversarial CC could read its own env (e.g.
+cat /proc/self/environ) and write the token into an edited file that
+the dispatcher then commits + pushes to the PR — a live-secret leak.
+Fix 1: GH_TOKEN is NEVER passed to a CC run. runClaudeCode dropped its
+ghToken param; scrubChildEnv is called with no token for CC. The token
+lives ONLY in pushAndOpenPr's own scrubbed env, after diff-validation.
+CC does no git/gh itself, so it never needed it.
+
+**HIGH (secondary) — git command-exec surfaces on a CC-tampered
+clone.** CC could plant a hook or a clean/smudge filter (via
+.git/config + .git/info/attributes, both untracked/invisible to
+expected_paths) that git would execute during the dispatcher's
+add/commit/push — with the push token in env. Fix 2: every git call in
+pushAndOpenPr now passes -c core.hooksPath=/dev/null -c
+core.attributesFile=/dev/null (argv, not shell), and .git/info/attributes
+is deleted before the ops. Combined with Fix 3 (a tracked .gitattributes
+is caught by expected_paths), no path can be assigned a filter ⇒ filter
+drivers never trigger even if defined. Fix 5 also scrubs the env on the
+validation `git status` call (was inheriting the dispatcher's full root
+env) and neutralises hooks there too.
+
+**MEDIUM — expected_paths was optional for write.** Omitting it made
+the dispatcher push whatever CC changed (incl. brand-new files), and
+the Telegram approval prompt didn't reveal whether path validation was
+active. Fix 3: the tool now THROWS "expected_paths is required for
+write-scope dispatches" at enqueue (no row) when scope='write' and
+expected_paths is absent/empty; the approval prompt gained a `Paths:`
+line listing the allow-list (or a plain "⚠️ none declared — NO path
+validation" warning for infra, which stays optional).
+
+**LOW — branch name not asserted.** Fix 4: after computing
+cc/write-<8hex>, the dispatcher asserts /^cc\/write-[0-9a-f]{8}$/ and
+fails closed (no push) if it ever doesn't match. id is a uuid column so
+this always holds today; the assert guards a future regression.
+
+**LOW — auth-guard comment overclaimed.** Fix 6: reworded to state the
+provenance guard is a presence check that raises the bar against
+fabricated rows lacking the fields — NOT cryptographically binding to
+the Telegram approval; the real trust boundary is service_role custody.
+
+Tests: cc-dispatcher.test.js 76 checks (added: GH_TOKEN NOT handed to
+CC; pushPr still gets it; pushAndOpenPr hooks/attrs hardening + no token
+in argv; bad-branch fail-closed; changedFilesInClone env+hooks).
+cc-write-scope.test.js 33 checks (added: write requires expected_paths
+throws + no row; empty array throws; approval prompt surfaces Paths;
+infra omits + warns). Full suite green (exit 0).
+
+**7 Pillars:** Frontend — approval message adds a server-built Paths
+line, no injection. Backend — path check still pure JS Set; branch
+regex; git hardening via argv. Databases — no schema change; invalid
+write rejected pre-insert. Auth — PAT no longer reaches the untrusted
+agent; guard comment honest. Payments — n/a. Security — the crux (see
+HIGH/HIGH above). Infrastructure — no new PM2, no new files, ccdispatch
+still unprivileged.
+
+**Residual (documented, not blocking):** the provenance guard remains
+non-cryptographic (service_role custody is the boundary); a fully
+belt-and-suspanders alternative to Fix 2 would commit from a pristine
+re-clone — deferred as it exceeds this remediation's scope.

--- a/src/dispatch/cc-write-settings.json
+++ b/src/dispatch/cc-write-settings.json
@@ -1,0 +1,50 @@
+{
+  "$comment": "Phase 5 Session 2 — Claude Code WRITE-scope policy (--settings). CC edits files in a throwaway clone under acceptEdits; the dispatcher (not CC) does all git/gh work. DEFENCE-IN-DEPTH only; the structural control is running CC as the unprivileged ccdispatch user (kernel perms) in a disposable clone that is diff-validated against expected_paths before any push. Edit/Write are ALLOWED here (unlike the read-only policy); the sensitive-read denies and network/mutation Bash denies remain — CC must not push, commit, curl, or read secrets itself.",
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "deny": [
+      "Read(/root/.quantumclaw/**)",
+      "Read(**/.env)",
+      "Read(/root/.ssh/**)",
+      "Read(/home/*/.ssh/**)",
+      "Read(/etc/ssh/**)",
+      "Read(/root/.pm2/**)",
+      "Read(/root/.claude.json)",
+      "Read(/root/.config/**)",
+      "Read(/root/.bash_history)",
+      "Read(/root/.zsh_history)",
+      "Read(/etc/sudoers)",
+      "Read(/etc/sudoers.d/**)",
+      "Read(/etc/shadow)",
+      "Read(/proc/**)",
+      "Bash(sudo:*)",
+      "Bash(rm:*)",
+      "Bash(git push:*)",
+      "Bash(git commit:*)",
+      "Bash(gh:*)",
+      "Bash(curl:*)",
+      "Bash(wget:*)",
+      "Bash(tee:*)",
+      "Bash(dd:*)"
+    ],
+    "allow": [
+      "Read",
+      "Edit",
+      "Write",
+      "Grep",
+      "Glob",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(find:*)",
+      "Bash(wc:*)",
+      "Bash(git log:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)"
+    ]
+  }
+}

--- a/src/dispatch/claude-code-dispatcher.js
+++ b/src/dispatch/claude-code-dispatcher.js
@@ -5,13 +5,18 @@
  * `claude_code_dispatches`, runs Claude Code READ-ONLY as the unprivileged
  * `ccdispatch` user against a throwaway clone, and writes the result back.
  *
- * Security spine (design v2):
+ * Security spine (design v2; Phase 5 Session 2 adds write scope):
  *  - Structural scope validation at the dispatcher (not the tool): only audit/
- *    read_only run; anything else → failed, CC never invoked. Fail closed.
+ *    read_only/write run; infra/critical → failed, CC never invoked. Fail closed.
+ *  - Write scope also requires authorised_by/authorised_at on the row (the Telegram
+ *    approval provenance) and CC runs under acceptEdits with the write settings; the
+ *    DISPATCHER (never CC) validates the diff vs expected_paths then pushes + opens a
+ *    PR to tysonven/QClaw. GH_TOKEN is read from the encrypted store at dispatch time,
+ *    injected into the child env for write only, and scrubbed from all output.
  *  - CC runs as `ccdispatch` (kernel perms deny secret reads) in a fresh clone at
- *    the row's pinned commit; scrubbed child env (only ANTHROPIC_API_KEY/PATH/HOME);
- *    plan mode + --disallowedTools + --settings deny-list (defence-in-depth);
- *    --max-budget-usd; brief via stdin (never shell-interpolated).
+ *    the row's pinned commit; scrubbed child env (only ANTHROPIC_API_KEY/PATH/HOME,
+ *    +GH_TOKEN for write); plan mode + --disallowedTools + --settings deny-list for
+ *    read-only (defence-in-depth); --max-budget-usd; brief via stdin (never shell-interpolated).
  *  - Refuses to run CC as root: if the ccdispatch user is absent, the dispatch fails.
  *  - Post-hoc `git status` clean assert; output scrubbed for secret values.
  *  - Reaper (startup + periodic) recovers rows orphaned by a dead/hung dispatcher.
@@ -29,16 +34,31 @@ import { readFileSync, existsSync, mkdirSync, rmSync, writeFileSync, realpathSyn
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { recordBeat } from '../observability/liveness-heartbeat.js';
+import { loadConfig } from '../core/config.js';
+import { SecretStore } from '../security/secrets.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ── config ────────────────────────────────────────────────────────────────
-const ALLOWED_SCOPES = new Set(['audit', 'read_only']);
+// v1 ran only audit/read_only. Phase 5 Session 2 adds `write` (mutating: CC runs
+// under acceptEdits, then the DISPATCHER — never CC — validates the diff against
+// expected_paths, pushes, and opens a PR). `infra`/`critical` remain hard-rejected;
+// never expand this Set beyond write without a new slice + approval.
+const ALLOWED_SCOPES = new Set(['audit', 'read_only', 'write']);
+const WRITE_SCOPES = new Set(['write']);            // scopes that mutate + push a PR
 const CC_BIN = process.env.QCLAW_CC_BIN || 'claude';
 const CC_USER = process.env.QCLAW_CC_USER || 'ccdispatch';
 const REPO_PATH = process.env.QCLAW_REPO_PATH || '/root/QClaw';
 const WORK_ROOT = process.env.QCLAW_CC_WORK_ROOT || '/home/ccdispatch/work';
 const SETTINGS_PATH = process.env.QCLAW_CC_SETTINGS || join(__dirname, 'cc-readonly-settings.json');
+const WRITE_SETTINGS_PATH = process.env.QCLAW_CC_WRITE_SETTINGS || join(__dirname, 'cc-write-settings.json');
+// GitHub push target for write-scope PRs. NEVER upstream QuantumClaw/QClaw.
+const GH_REPO = process.env.QCLAW_CC_GH_REPO || 'tysonven/QClaw';
+const GH_BASE_BRANCH = process.env.QCLAW_CC_GH_BASE || 'main';
+const GH_SECRET_KEY = process.env.QCLAW_CC_GH_SECRET_KEY || 'ccdispatch_github_token';
+// ccdispatch has no configured git identity; commits must carry one explicitly.
+const GIT_AUTHOR_NAME = process.env.QCLAW_CC_GIT_NAME || 'Charlie (Claude Code)';
+const GIT_AUTHOR_EMAIL = process.env.QCLAW_CC_GIT_EMAIL || 'charlie@flowos.tech';
 const POLL_MS = Number(process.env.QCLAW_CC_POLL_MS) || 8000;
 const HEARTBEAT_MS = Number(process.env.QCLAW_CC_HEARTBEAT_MS) || 45000;
 const REAP_EVERY_MS = Number(process.env.QCLAW_CC_REAP_MS) || 120000;
@@ -81,27 +101,39 @@ export function validateScope(scope) {
 }
 
 /** Child env for CC: ONLY the API key + PATH + a worktree-local HOME. No SUPABASE_*,
- * no inherited root env (so /proc/self/environ can't leak our other secrets). */
-export function scrubChildEnv(env, homeDir) {
-  return {
+ * no inherited root env (so /proc/self/environ can't leak our other secrets).
+ * For WRITE scope only, a GH_TOKEN is injected (CC + the dispatcher's git/gh share
+ * one scrubbed env). ghToken MUST be absent for audit/read_only (secret minimisation). */
+export function scrubChildEnv(env, homeDir, ghToken = null) {
+  const out = {
     PATH: env.PATH || '/usr/local/bin:/usr/bin:/bin',
     HOME: homeDir,
     ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY || '',
     LANG: env.LANG || 'C.UTF-8',
   };
+  if (ghToken) {
+    out.GH_TOKEN = ghToken;
+    // never let git block on an interactive credential prompt in a headless run
+    out.GIT_TERMINAL_PROMPT = '0';
+  }
+  return out;
 }
 
-/** Headless read-only CC argv. Brief is piped via stdin, never argv. */
-export function buildCcArgv({ clonePath, settingsPath, budgetUsd }) {
-  return [
-    '-p', '--bare',
-    '--permission-mode', 'plan',
-    '--add-dir', clonePath,
-    '--settings', settingsPath,
-    '--disallowedTools', 'Edit Write NotebookEdit',
-    '--output-format', 'json',
-    '--max-budget-usd', String(budgetUsd),
-  ];
+/** Headless CC argv. Brief is piped via stdin, never argv.
+ *  - read-only (default): plan mode + Edit/Write/NotebookEdit disallowed.
+ *  - write (writeMode): acceptEdits (CC actually mutates the clone); no Edit/Write
+ *    disallow; the write settings deny-list still blocks push/commit/gh/secret reads. */
+export function buildCcArgv({ clonePath, settingsPath, budgetUsd, writeMode = false }) {
+  const argv = ['-p', '--bare'];
+  if (writeMode) {
+    argv.push('--permission-mode', 'acceptEdits');
+  } else {
+    argv.push('--permission-mode', 'plan');
+  }
+  argv.push('--add-dir', clonePath, '--settings', settingsPath);
+  if (!writeMode) argv.push('--disallowedTools', 'Edit Write NotebookEdit');
+  argv.push('--output-format', 'json', '--max-budget-usd', String(budgetUsd));
+  return argv;
 }
 
 /** Redact known secret values + high-entropy tokens from CC output before it is
@@ -128,6 +160,83 @@ export function sumCostSince(rows, sinceMs) {
 /** Short summary for surfacing (first non-empty lines of the result). */
 export function summarise(text, max = 600) {
   return String(text ?? '').replace(/\r/g, '').trim().slice(0, max);
+}
+
+// ── write-scope helpers (unit-tested; no host, no shell) ─────────────────────
+
+/** First non-empty line of the brief's `# Task` section — the PR/commit one-liner.
+ * Falls back to the first non-empty, non-heading line, then a generic default. */
+export function briefTaskLine(brief, max = 100) {
+  const lines = String(brief ?? '').replace(/\r/g, '').split('\n');
+  const i = lines.findIndex((l) => l.trim().toLowerCase() === '# task');
+  if (i >= 0) {
+    for (let j = i + 1; j < lines.length; j++) {
+      const t = lines[j].trim();
+      if (t.startsWith('#')) break;          // hit the next section, no task body
+      if (t) return t.slice(0, max);
+    }
+  }
+  const firstReal = lines.map((l) => l.trim()).find((t) => t && !t.startsWith('#'));
+  return (firstReal || 'dispatched change').slice(0, max);
+}
+
+/** Parse an optional `# Expected paths` section from the brief. Accepts either a
+ * JSON array on one line or a bullet/newline list. Returns a de-duped string[] of
+ * declared repo-relative paths, or `null` if the section is absent (→ skip
+ * validation). An EMPTY declared list returns [] (→ nothing may change). */
+export function parseExpectedPaths(brief) {
+  const lines = String(brief ?? '').replace(/\r/g, '').split('\n');
+  const i = lines.findIndex((l) => l.trim().toLowerCase() === '# expected paths');
+  if (i < 0) return null;                     // section absent → caller skips validation
+  const body = [];
+  for (let j = i + 1; j < lines.length; j++) {
+    if (lines[j].trim().startsWith('#')) break; // next section
+    body.push(lines[j]);
+  }
+  const raw = body.join('\n').trim();
+  let paths = [];
+  if (raw.startsWith('[')) {
+    try { const arr = JSON.parse(raw); if (Array.isArray(arr)) paths = arr.map(String); }
+    catch { /* fall through to line parsing */ }
+  }
+  if (paths.length === 0) {
+    paths = raw.split('\n')
+      .map((l) => l.replace(/^\s*[-*]\s*/, '').replace(/^["']|["'],?$/g, '').trim())
+      .filter(Boolean);
+  }
+  // normalise: strip leading ./ and surrounding quotes; de-dupe
+  const norm = paths.map((p) => p.replace(/^\.\//, '').replace(/^["']|["']$/g, '').trim()).filter(Boolean);
+  return [...new Set(norm)];
+}
+
+/** Pure decision for a write run's post-CC state. `changedFiles` = git-diff output
+ * (repo-relative). `expectedPaths` = parseExpectedPaths result (null ⇒ not declared).
+ *  - no changes            → { action:'nochange' }  (mark complete, note, no push)
+ *  - expectedPaths null     → { action:'push', skippedValidation:true }  (+warn)
+ *  - all changes ⊆ expected → { action:'push' }
+ *  - any change ⊄ expected  → { action:'abort', unexpected:[...] }  (fail, no push) */
+export function planWriteOutcome({ changedFiles, expectedPaths }) {
+  const changed = (changedFiles || []).map((f) => String(f).trim()).filter(Boolean);
+  if (changed.length === 0) return { action: 'nochange', unexpected: [] };
+  if (expectedPaths == null) return { action: 'push', unexpected: [], skippedValidation: true };
+  const allow = new Set(expectedPaths);
+  const unexpected = changed.filter((f) => !allow.has(f));
+  if (unexpected.length > 0) return { action: 'abort', unexpected };
+  return { action: 'push', unexpected: [] };
+}
+
+/** Read the ccdispatch GitHub token from the encrypted secret store at dispatch
+ * time (never cached at module load). Returns the token string, or null if the
+ * store/key is unavailable — the write dispatch then fails cleanly (no push). */
+export async function getGhToken(secretKey = GH_SECRET_KEY) {
+  try {
+    const cfg = await loadConfig();
+    const store = new SecretStore(cfg);
+    await store.load();
+    return store.get(secretKey) || null;
+  } catch {
+    return null;
+  }
 }
 
 // ── Supabase (PostgREST, service_role) ───────────────────────────────────────
@@ -179,6 +288,21 @@ function prepareClone(id, pinnedCommit, ccUser) {
 function cleanupClone(clonePath) {
   try { rmSync(clonePath, { recursive: true, force: true }); } catch { /* */ }
 }
+/** Prepare the throwaway clone + a sibling ccdispatch-owned HOME. Returns both paths.
+ * (Extracted so processOne's control flow can be exercised with an injected fake.) */
+function setupWorkspace(id, row, ccUser) {
+  const clonePath = prepareClone(id, row.pinned_commit, ccUser);
+  // CC's HOME — a sibling dir to the clone (owned by ccdispatch) so CC's own state
+  // files never pollute the repo clone's git-status assert.
+  const homeDir = `${clonePath}.home`;
+  mkdirSync(homeDir, { recursive: true });
+  execFileSync('chown', ['-R', `${ccUser.uid}:${ccUser.gid}`, homeDir]);
+  return { clonePath, homeDir };
+}
+function cleanupWorkspace(clonePath, homeDir) {
+  if (clonePath) cleanupClone(clonePath);
+  if (homeDir) cleanupClone(homeDir);
+}
 /** Detect-only: any working-tree mutation under a read-only run → fail. */
 export function workingTreeDirty(clonePath, ccUser, log = console) {
   // Run git AS ccdispatch (the clone's owner) — root running git on a ccdispatch-
@@ -202,15 +326,53 @@ export function workingTreeDirty(clonePath, ccUser, log = console) {
   }
 }
 
+// ── write-scope git/gh (as ccdispatch; the dispatcher, NEVER CC, pushes) ──────
+/** Repo-relative list of every file CC changed in the clone — tracked
+ * modifications AND untracked new files. Run AS ccUser (clone owner) so there is
+ * no dubious-ownership warning. `--porcelain` with rename detection off keeps the
+ * path list literal (safe to compare as JS strings, never shell-globbed). */
+export function changedFilesInClone(clonePath, ccUser, runner = execFileSync) {
+  const out = runner('git', ['-C', clonePath, 'status', '--porcelain', '--untracked-files=all', '--no-renames'],
+    { uid: ccUser.uid, gid: ccUser.gid, encoding: 'utf8' });
+  return String(out).split('\n')
+    .map((l) => l.slice(3).trim())   // strip the 2-char XY status + space
+    .filter(Boolean);
+}
+
+/**
+ * Commit CC's changes, push a fresh branch to GH_REPO, open a PR. Runs every git/gh
+ * command AS ccUser with a scrubbed env holding GH_TOKEN (never in argv or the URL:
+ * the gh credential helper supplies it). Returns the PR URL (last stdout line).
+ * Throws on any git/gh failure — the caller marks the dispatch failed (no partial).
+ */
+export function pushAndOpenPr({ clonePath, homeDir, ccUser, ghToken, branch, commitMessage, title, body, runner = execFileSync }) {
+  const env = scrubChildEnv({ PATH: process.env.PATH }, homeDir, ghToken);
+  const git = (...args) => runner('git', ['-C', clonePath, ...args], { uid: ccUser.uid, gid: ccUser.gid, env, encoding: 'utf8' });
+  git('checkout', '-b', branch);
+  git('add', '-A');
+  git('-c', `user.name=${GIT_AUTHOR_NAME}`, '-c', `user.email=${GIT_AUTHOR_EMAIL}`, 'commit', '-m', commitMessage);
+  // push to the GitHub URL directly (token is NOT in the URL — the gh credential
+  // helper injects it), so no persistent remote or token-in-config is left behind.
+  git('-c', 'credential.helper=', '-c', 'credential.helper=!gh auth git-credential',
+    'push', `https://github.com/${GH_REPO}.git`, `HEAD:${branch}`);
+  const prOut = runner('gh',
+    ['pr', 'create', '-R', GH_REPO, '--base', GH_BASE_BRANCH, '--head', branch, '--title', title, '--body', body],
+    { cwd: clonePath, uid: ccUser.uid, gid: ccUser.gid, env, encoding: 'utf8' });
+  const url = String(prOut).trim().split('\n').filter(Boolean).pop() || '';
+  return url;
+}
+
 // ── CC invocation (the wiring; gated to live runs, reviewed at pause c) ───────
 /**
  * Spawn Claude Code as `ccdispatch`, brief on stdin, group-killed on timeout.
  * Single-flight: only the first of {exit, timeout} resolves. Returns
  * { ok, status, resultText, exitCode, costUsd, ccSessionId, error }.
  */
-export function runClaudeCode({ env, clonePath, homeDir, brief, ccUser, timeoutSeconds, budgetUsd = PER_DISPATCH_BUDGET_USD }) {
+export function runClaudeCode({ env, clonePath, homeDir, brief, ccUser, timeoutSeconds, budgetUsd = PER_DISPATCH_BUDGET_USD, writeMode = false, ghToken = null }) {
   return new Promise((resolve) => {
-    const argv = buildCcArgv({ clonePath, settingsPath: SETTINGS_PATH, budgetUsd });
+    // write scope runs under acceptEdits with the write settings; GH_TOKEN is only
+    // injected into the child env for write (secret minimisation for read-only runs).
+    const argv = buildCcArgv({ clonePath, settingsPath: writeMode ? WRITE_SETTINGS_PATH : SETTINGS_PATH, budgetUsd, writeMode });
     const child = spawn(CC_BIN, argv, {
       cwd: clonePath,
       uid: ccUser.uid,
@@ -219,7 +381,7 @@ export function runClaudeCode({ env, clonePath, homeDir, brief, ccUser, timeoutS
       // (.claude/, session files) into the repo clone and pollutes the post-hoc
       // git-status clean assert (false "mutated" failures). HOME falls back to the
       // clone only if no separate home was provided.
-      env: scrubChildEnv(env, homeDir || clonePath),
+      env: scrubChildEnv(env, homeDir || clonePath, writeMode ? ghToken : null),
       detached: true, // own process group so we can kill the whole tree on timeout
       stdio: ['pipe', 'pipe', 'pipe'],
     });
@@ -264,37 +426,69 @@ export function runClaudeCode({ env, clonePath, homeDir, brief, ccUser, timeoutS
 }
 
 // ── process one dispatch ──────────────────────────────────────────────────────
-async function processOne(env, rest, row, ccUser, log = console) {
+// deps are injectable seams so processOne's control flow (esp. the write branch)
+// can be exercised without a real clone/CC/host. Production passes none → real impls.
+export async function processOne(env, rest, row, ccUser, log = console, deps = {}) {
+  const {
+    setup = setupWorkspace,
+    runCc = runClaudeCode,
+    isDirty = workingTreeDirty,
+    listChanged = changedFilesInClone,
+    pushPr = pushAndOpenPr,
+    loadGhToken = getGhToken,
+    cleanup = cleanupWorkspace,
+    now = () => new Date().toISOString(),
+  } = deps;
   const id = row.id;
   // 1. structural scope validation — never trust the row
   const sv = validateScope(row.scope);
   if (!sv.ok) {
-    await writeBack(rest, id, { status: 'failed', error_message: sv.reason, completed_at: new Date().toISOString() });
+    await writeBack(rest, id, { status: 'failed', error_message: sv.reason, completed_at: now() });
     log.warn?.(`[dispatcher] ${id} rejected: ${sv.reason}`);
+    return;
+  }
+  const isWrite = WRITE_SCOPES.has(row.scope);
+  // 1b. write-scope authorisation-provenance guard (defence in depth). The row is
+  // untrusted; only the ✅ handler re-queues a write row and stamps authorised_by/at.
+  // A directly-fabricated queued+write row (bypassing Telegram) lacks them → refuse.
+  if (isWrite && !(row.authorised_at && row.authorised_by)) {
+    await writeBack(rest, id, { status: 'failed', error_message: 'write-scope dispatch is not authorised (no authorised_by/authorised_at) — refusing to execute', completed_at: now() });
+    log.warn?.(`[dispatcher] ${id} rejected: unauthorised write-scope row`);
     return;
   }
   // 2. never run CC as root
   if (!ccUser) {
-    await writeBack(rest, id, { status: 'failed', error_message: `ccdispatch user absent — refusing to run Claude Code as root. Run scripts/setup-ccdispatch-user.sh.`, completed_at: new Date().toISOString() });
+    await writeBack(rest, id, { status: 'failed', error_message: `ccdispatch user absent — refusing to run Claude Code as root. Run scripts/setup-ccdispatch-user.sh.`, completed_at: now() });
     return;
   }
+  // 3. write scope: read GH_TOKEN from the encrypted store AT DISPATCH TIME (not at
+  // module load). Fail cleanly (no CC run) if the secret is missing.
+  let ghToken = null;
+  if (isWrite) {
+    ghToken = await loadGhToken();
+    if (!ghToken) {
+      await writeBack(rest, id, { status: 'failed', error_message: `write-scope dispatch needs ${GH_SECRET_KEY} in the secret store — none found; not run`, completed_at: now() });
+      log.warn?.(`[dispatcher] ${id} rejected: ${GH_SECRET_KEY} unavailable`);
+      return;
+    }
+  }
+  // secret-scrub set — GH_TOKEN is added to the scrubber's known-values list BEFORE
+  // CC runs, so it can never survive into result/error/summary (criterion E).
+  const secrets = [env.ANTHROPIC_API_KEY, env.SUPABASE_SERVICE_ROLE_KEY, env.SUPABASE_ANON_KEY, ghToken].filter(Boolean);
+
   let clonePath, homeDir;
   try {
-    clonePath = prepareClone(id, row.pinned_commit, ccUser);
-    // CC's HOME — a sibling dir to the clone (owned by ccdispatch) so CC's own
-    // state files never pollute the repo clone's git-status clean assert.
-    homeDir = `${clonePath}.home`;
-    mkdirSync(homeDir, { recursive: true });
-    execFileSync('chown', ['-R', `${ccUser.uid}:${ccUser.gid}`, homeDir]);
+    ({ clonePath, homeDir } = setup(id, row, ccUser));
     // pause-(c) matrix plant (gated): drop a root-owned 0600 file INSIDE the
     // ccdispatch-owned clone to prove ownership/perms gate reads even within CC's
     // own work area. Off in production (no env var).
     if (process.env.QCLAW_CC_PLANT_FILE) {
       writeFileSync(join(clonePath, 'PLANTED_SECRET.txt'), `${process.env.QCLAW_CC_PLANT_VALUE || 'PLANTED-SECRET-DO-NOT-LEAK'}\n`, { mode: 0o600 });
     }
-    const r = await runClaudeCode({
+    const r = await runCc({
       env, clonePath, homeDir, brief: row.brief, ccUser,
       timeoutSeconds: Number(row.timeout_seconds) || 600,
+      writeMode: isWrite, ghToken,
     });
     // pause-(c) matrix raw capture (gated): write CC's RAW stdout/stderr +
     // permission_denials to a ROOT-ONLY file (0600) — NEVER to the DB row — so the
@@ -307,35 +501,75 @@ async function processOne(env, rest, row, ccUser, log = console) {
           { mode: 0o600 });
       } catch (e) { log.warn?.(`[dispatcher] capture failed: ${e.message}`); }
     }
-    // 3. post-hoc clean assert (read-only contract)
+
     let { status, resultText, error } = r;
-    if (status === 'complete' && workingTreeDirty(clonePath, ccUser, log)) {
-      status = 'failed';
-      error = 'working tree mutated under a read-only scope — rejected';
+    let prUrl = null;
+    let note = null;
+    let unexpected = [];
+
+    if (isWrite) {
+      // Write contract: CC mutates; the DISPATCHER validates the diff vs expected_paths
+      // and (only if clean) commits + pushes + opens a PR. CC never pushes.
+      if (status === 'complete') {
+        let changed = [];
+        try { changed = listChanged(clonePath, ccUser); }
+        catch (e) { status = 'failed'; error = `could not read git diff: ${e.message}`; }
+        if (status === 'complete') {
+          const expectedPaths = parseExpectedPaths(row.brief);
+          const plan = planWriteOutcome({ changedFiles: changed, expectedPaths });
+          if (plan.skippedValidation) log.warn?.(`[dispatcher] ${id}: no expected_paths declared — skipping path validation; pushing whatever CC changed`);
+          if (plan.action === 'nochange') {
+            note = 'no mutations — CC found nothing to change';   // criterion C/G: still complete, no push
+          } else if (plan.action === 'abort') {
+            unexpected = plan.unexpected;
+            status = 'failed';
+            error = `aborted: CC changed files outside expected_paths (not pushed): ${plan.unexpected.join(', ')}`;
+          } else {
+            const oneLiner = briefTaskLine(row.brief);
+            const branch = `cc/write-${String(id).slice(0, 8)}`;
+            try {
+              prUrl = pushPr({
+                clonePath, homeDir, ccUser, ghToken, branch,
+                commitMessage: `feat(dispatch): ${oneLiner}`,
+                title: oneLiner,
+                body: `Dispatched by Charlie. Task ID: ${id}. Review before merging.`,
+              });
+            } catch (e) { status = 'failed'; error = `push/PR failed: ${e.message}`; }
+          }
+        }
+      }
+    } else {
+      // read-only contract: any working-tree mutation → fail.
+      if (status === 'complete' && isDirty(clonePath, ccUser, log)) {
+        status = 'failed';
+        error = 'working tree mutated under a read-only scope — rejected';
+      }
     }
-    // 4. scrub secrets from untrusted output, then a SINGLE atomic write-back
-    const secrets = [env.ANTHROPIC_API_KEY, env.SUPABASE_SERVICE_ROLE_KEY, env.SUPABASE_ANON_KEY].filter(Boolean);
+
+    // scrub secrets from untrusted output, then a SINGLE atomic write-back
     const cleanResult = scrubSecretsFromOutput(resultText, secrets);
+    // for write success, surface the PR url / no-mutation note ahead of CC's own text.
+    const resultBody = status !== 'complete' ? null
+      : scrubSecretsFromOutput([prUrl ? `PR: ${prUrl}` : null, note, cleanResult].filter(Boolean).join('\n\n'), secrets);
     await writeBack(rest, id, {
       status,
-      result: status === 'complete' ? cleanResult : null,
-      result_summary: status === 'complete' ? summarise(cleanResult) : null,
+      result: resultBody,
+      result_summary: status === 'complete' ? summarise(prUrl || note || cleanResult) : null,
       error_message: status === 'complete' ? null : (scrubSecretsFromOutput(error, secrets) || 'failed'),
       exit_code: r.exitCode,
       cc_session_id: r.ccSessionId,
       cost_usd: r.costUsd,
       attempts: (Number(row.attempts) || 1),
-      completed_at: new Date().toISOString(),
-      // permission_denials is CC's tool-policy refusal list (not secrets) — useful audit signal
-      metadata: { permission_denials: r.permissionDenials || [] },
+      completed_at: now(),
+      // permission_denials is CC's tool-policy refusal list (not secrets) — useful audit signal.
+      metadata: { permission_denials: r.permissionDenials || [], pr_url: prUrl, note, unexpected_paths: unexpected },
     });
-    log.info?.(`[dispatcher] ${id} → ${status}${r.costUsd != null ? ` ($${r.costUsd})` : ''}`);
+    log.info?.(`[dispatcher] ${id} → ${status}${prUrl ? ` (${prUrl})` : ''}${r.costUsd != null ? ` ($${r.costUsd})` : ''}`);
   } catch (err) {
-    await writeBack(rest, id, { status: 'failed', error_message: `dispatcher error: ${err.message}`.slice(0, 500), completed_at: new Date().toISOString() }).catch(() => {});
+    await writeBack(rest, id, { status: 'failed', error_message: scrubSecretsFromOutput(`dispatcher error: ${err.message}`, secrets).slice(0, 500), completed_at: now() }).catch(() => {});
     log.error?.(`[dispatcher] ${id} errored: ${err.message}`);
   } finally {
-    if (clonePath) cleanupClone(clonePath);
-    if (homeDir) cleanupClone(homeDir);
+    cleanup(clonePath, homeDir);
   }
 }
 

--- a/src/dispatch/claude-code-dispatcher.js
+++ b/src/dispatch/claude-code-dispatcher.js
@@ -100,10 +100,10 @@ export function validateScope(scope) {
   return { ok: true };
 }
 
-/** Child env for CC: ONLY the API key + PATH + a worktree-local HOME. No SUPABASE_*,
+/** Minimal scrubbed env: ONLY the API key + PATH + a worktree-local HOME. No SUPABASE_*,
  * no inherited root env (so /proc/self/environ can't leak our other secrets).
- * For WRITE scope only, a GH_TOKEN is injected (CC + the dispatcher's git/gh share
- * one scrubbed env). ghToken MUST be absent for audit/read_only (secret minimisation). */
+ * The optional ghToken is used ONLY by pushAndOpenPr for the dispatcher's git/gh step —
+ * it is NEVER passed for a CC run (fix 1: CC is untrusted and must not hold the PAT). */
 export function scrubChildEnv(env, homeDir, ghToken = null) {
   const out = {
     PATH: env.PATH || '/usr/local/bin:/usr/bin:/bin',
@@ -331,9 +331,15 @@ export function workingTreeDirty(clonePath, ccUser, log = console) {
  * modifications AND untracked new files. Run AS ccUser (clone owner) so there is
  * no dubious-ownership warning. `--porcelain` with rename detection off keeps the
  * path list literal (safe to compare as JS strings, never shell-globbed). */
-export function changedFilesInClone(clonePath, ccUser, runner = execFileSync) {
-  const out = runner('git', ['-C', clonePath, 'status', '--porcelain', '--untracked-files=all', '--no-renames'],
-    { uid: ccUser.uid, gid: ccUser.gid, encoding: 'utf8' });
+export function changedFilesInClone(clonePath, ccUser, env = null, runner = execFileSync) {
+  // SECURITY (P5S2 adversarial fix 5): pass a scrubbed env (no root process.env, no
+  // secrets) rather than inheriting the dispatcher's full environment while running
+  // git on a CC-tampered clone. core.hooksPath=/dev/null neutralises any planted hook.
+  const opts = { uid: ccUser.uid, gid: ccUser.gid, encoding: 'utf8' };
+  if (env) opts.env = env;
+  const out = runner('git',
+    ['-C', clonePath, '-c', 'core.hooksPath=/dev/null', 'status', '--porcelain', '--untracked-files=all', '--no-renames'],
+    opts);
   return String(out).split('\n')
     .map((l) => l.slice(3).trim())   // strip the 2-char XY status + space
     .filter(Boolean);
@@ -347,7 +353,18 @@ export function changedFilesInClone(clonePath, ccUser, runner = execFileSync) {
  */
 export function pushAndOpenPr({ clonePath, homeDir, ccUser, ghToken, branch, commitMessage, title, body, runner = execFileSync }) {
   const env = scrubChildEnv({ PATH: process.env.PATH }, homeDir, ghToken);
-  const git = (...args) => runner('git', ['-C', clonePath, ...args], { uid: ccUser.uid, gid: ccUser.gid, env, encoding: 'utf8' });
+  // SECURITY (P5S2 adversarial fix 2): CC had write access to this clone's .git, and
+  // these git calls run with GH_TOKEN in env. Neutralise every git config-driven
+  // command-execution surface so a CC-planted hook/filter can't run with the token:
+  //  - core.hooksPath=/dev/null       → no repo hooks (pre-commit/pre-push/…) fire.
+  //  - core.attributesFile=/dev/null  → nulls the global attributes file, AND we also
+  //    delete .git/info/attributes below (the one untracked, in-.git attrs source that
+  //    the flag does NOT cover). A tracked .gitattributes is caught by expected_paths
+  //    validation (fix 3 makes that mandatory), so no path can be assigned a clean/
+  //    smudge filter ⇒ filter drivers never trigger even if defined in .git/config.
+  try { rmSync(join(clonePath, '.git', 'info', 'attributes'), { force: true }); } catch { /* */ }
+  const HARDEN = ['-c', 'core.hooksPath=/dev/null', '-c', 'core.attributesFile=/dev/null'];
+  const git = (...args) => runner('git', ['-C', clonePath, ...HARDEN, ...args], { uid: ccUser.uid, gid: ccUser.gid, env, encoding: 'utf8' });
   git('checkout', '-b', branch);
   git('add', '-A');
   git('-c', `user.name=${GIT_AUTHOR_NAME}`, '-c', `user.email=${GIT_AUTHOR_EMAIL}`, 'commit', '-m', commitMessage);
@@ -368,10 +385,9 @@ export function pushAndOpenPr({ clonePath, homeDir, ccUser, ghToken, branch, com
  * Single-flight: only the first of {exit, timeout} resolves. Returns
  * { ok, status, resultText, exitCode, costUsd, ccSessionId, error }.
  */
-export function runClaudeCode({ env, clonePath, homeDir, brief, ccUser, timeoutSeconds, budgetUsd = PER_DISPATCH_BUDGET_USD, writeMode = false, ghToken = null }) {
+export function runClaudeCode({ env, clonePath, homeDir, brief, ccUser, timeoutSeconds, budgetUsd = PER_DISPATCH_BUDGET_USD, writeMode = false }) {
   return new Promise((resolve) => {
-    // write scope runs under acceptEdits with the write settings; GH_TOKEN is only
-    // injected into the child env for write (secret minimisation for read-only runs).
+    // write scope runs under acceptEdits with the write settings.
     const argv = buildCcArgv({ clonePath, settingsPath: writeMode ? WRITE_SETTINGS_PATH : SETTINGS_PATH, budgetUsd, writeMode });
     const child = spawn(CC_BIN, argv, {
       cwd: clonePath,
@@ -381,7 +397,11 @@ export function runClaudeCode({ env, clonePath, homeDir, brief, ccUser, timeoutS
       // (.claude/, session files) into the repo clone and pollutes the post-hoc
       // git-status clean assert (false "mutated" failures). HOME falls back to the
       // clone only if no separate home was provided.
-      env: scrubChildEnv(env, homeDir || clonePath, writeMode ? ghToken : null),
+      // SECURITY (P5S2 adversarial fix 1): GH_TOKEN is NEVER injected into CC's env —
+      // CC is untrusted and does no git/gh itself (the dispatcher pushes). Giving the
+      // agent a live PAT let it be exfiltrated into a committed file / via git config.
+      // The token lives ONLY in pushAndOpenPr's own scrubbed env, after diff-validation.
+      env: scrubChildEnv(env, homeDir || clonePath),
       detached: true, // own process group so we can kill the whole tree on timeout
       stdio: ['pipe', 'pipe', 'pipe'],
     });
@@ -448,9 +468,10 @@ export async function processOne(env, rest, row, ccUser, log = console, deps = {
     return;
   }
   const isWrite = WRITE_SCOPES.has(row.scope);
-  // 1b. write-scope authorisation-provenance guard (defence in depth). The row is
-  // untrusted; only the ✅ handler re-queues a write row and stamps authorised_by/at.
-  // A directly-fabricated queued+write row (bypassing Telegram) lacks them → refuse.
+  // 1b. write-scope authorisation-provenance guard. This raises the bar against
+  // fabricated rows lacking provenance fields — it is NOT cryptographically binding
+  // to the Telegram ✅ approval; the real trust boundary is service_role custody
+  // (anyone holding it could set these fields directly). Presence check only.
   if (isWrite && !(row.authorised_at && row.authorised_by)) {
     await writeBack(rest, id, { status: 'failed', error_message: 'write-scope dispatch is not authorised (no authorised_by/authorised_at) — refusing to execute', completed_at: now() });
     log.warn?.(`[dispatcher] ${id} rejected: unauthorised write-scope row`);
@@ -472,8 +493,9 @@ export async function processOne(env, rest, row, ccUser, log = console, deps = {
       return;
     }
   }
-  // secret-scrub set — GH_TOKEN is added to the scrubber's known-values list BEFORE
-  // CC runs, so it can never survive into result/error/summary (criterion E).
+  // secret-scrub set. CC never receives GH_TOKEN (fix 1), but the token IS in the
+  // push step's env, so git/gh error text could carry it — keep ghToken in the
+  // known-values list so it can never survive into result/error/summary (criterion E).
   const secrets = [env.ANTHROPIC_API_KEY, env.SUPABASE_SERVICE_ROLE_KEY, env.SUPABASE_ANON_KEY, ghToken].filter(Boolean);
 
   let clonePath, homeDir;
@@ -488,7 +510,7 @@ export async function processOne(env, rest, row, ccUser, log = console, deps = {
     const r = await runCc({
       env, clonePath, homeDir, brief: row.brief, ccUser,
       timeoutSeconds: Number(row.timeout_seconds) || 600,
-      writeMode: isWrite, ghToken,
+      writeMode: isWrite,   // NB: ghToken deliberately NOT passed — CC never gets the PAT (fix 1)
     });
     // pause-(c) matrix raw capture (gated): write CC's RAW stdout/stderr +
     // permission_denials to a ROOT-ONLY file (0600) — NEVER to the DB row — so the
@@ -512,7 +534,8 @@ export async function processOne(env, rest, row, ccUser, log = console, deps = {
       // and (only if clean) commits + pushes + opens a PR. CC never pushes.
       if (status === 'complete') {
         let changed = [];
-        try { changed = listChanged(clonePath, ccUser); }
+        // fix 5: scrubbed env (no root secrets, no GH_TOKEN) for the validation git call.
+        try { changed = listChanged(clonePath, ccUser, scrubChildEnv({ PATH: process.env.PATH }, homeDir)); }
         catch (e) { status = 'failed'; error = `could not read git diff: ${e.message}`; }
         if (status === 'complete') {
           const expectedPaths = parseExpectedPaths(row.brief);
@@ -527,14 +550,21 @@ export async function processOne(env, rest, row, ccUser, log = console, deps = {
           } else {
             const oneLiner = briefTaskLine(row.brief);
             const branch = `cc/write-${String(id).slice(0, 8)}`;
-            try {
-              prUrl = pushPr({
-                clonePath, homeDir, ccUser, ghToken, branch,
-                commitMessage: `feat(dispatch): ${oneLiner}`,
-                title: oneLiner,
-                body: `Dispatched by Charlie. Task ID: ${id}. Review before merging.`,
-              });
-            } catch (e) { status = 'failed'; error = `push/PR failed: ${e.message}`; }
+            // fix 4: never push a branch name we didn't construct exactly. id is a uuid
+            // column so this always holds; the assert fail-closes if that ever changes.
+            if (!/^cc\/write-[0-9a-f]{8}$/.test(branch)) {
+              status = 'failed';
+              error = `refusing to push: computed branch name failed validation (${branch})`;
+            } else {
+              try {
+                prUrl = pushPr({
+                  clonePath, homeDir, ccUser, ghToken, branch,
+                  commitMessage: `feat(dispatch): ${oneLiner}`,
+                  title: oneLiner,
+                  body: `Dispatched by Charlie. Task ID: ${id}. Review before merging.`,
+                });
+              } catch (e) { status = 'failed'; error = `push/PR failed: ${e.message}`; }
+            }
           }
         }
       }

--- a/src/tools/claude-code-dispatch.js
+++ b/src/tools/claude-code-dispatch.js
@@ -179,6 +179,13 @@ export function createClaudeCodeDispatchTool({
           ? `mode must be one of ${ALL_MODES.join(', ')} for write/infra scope.`
           : `mode must be ${RUN_MODES.join(', ')} for audit/read_only scope (read-only run).`);
       }
+      // P5S2 adversarial fix 3: write scope MUST declare expected_paths — the dispatcher
+      // path-validates the diff against it, and without it CC could push arbitrary files
+      // (incl. new ones). Reject at enqueue (throw → no row) so the gap can't be reached.
+      const expectedPaths = normaliseExpectedPaths(args.expected_paths);
+      if (scope === 'write' && (!expectedPaths || expectedPaths.length === 0)) {
+        throw new Error('expected_paths is required for write-scope dispatches');
+      }
       const repo = args.repo ? String(args.repo).trim() : DEFAULT_REPO;
       if (!REPO_RE.test(repo)) throw new Error('repo must be of the form "owner/name".');
       let priority = Number.isInteger(args.priority) ? args.priority : 5;
@@ -239,12 +246,18 @@ export function createClaudeCodeDispatchTool({
           ? String(args.risk).toLowerCase() : 'medium';
         const action = (args.action ? String(args.action)
           : args.deliverable ? String(args.deliverable) : task).trim().slice(0, 400);
+        // fix 3: surface the path allow-list so the approver can see exactly what CC may
+        // change. write always has it (enforced above); infra may omit it → warn plainly.
+        const pathsLine = (expectedPaths && expectedPaths.length)
+          ? `Paths: ${expectedPaths.join(', ').slice(0, 400)}`
+          : `Paths: ⚠️ none declared — NO path validation (dispatcher will push whatever CC changes)`;
         const approvalMsg =
           `⚠️ Write-scope dispatch — approval required\n\n`
           + `Fix: ${fix}\n`
           + `Scope: ${scope}\n`
           + `Risk: ${risk}\n`
           + `Action: ${action}\n`
+          + `${pathsLine}\n`
           + `Task ID: ${task8}\n\n`
           + `Reply ✅ ${task8} to approve\n`
           + `Reply ❌ ${task8} to cancel`;

--- a/src/tools/claude-code-dispatch.js
+++ b/src/tools/claude-code-dispatch.js
@@ -36,11 +36,11 @@ const execFileP = promisify(execFile);
 //                  'awaiting_authorisation' row + pushes a structured Telegram
 //                  approval request; the owner's ✅ reply flips it to 'queued'.
 //   'critical'   : hard-blocked here (throws, never writes a row).
-// NOTE (write-execution gap): approving a write/infra row flips it to 'queued', but
-// the dispatcher's own validateScope still only runs audit/read_only and executes
-// CC read-only — so an APPROVED write task will currently be claimed and fail at the
-// dispatcher. Dispatcher write-execution (ALLOWED_SCOPES + a non-read-only runner)
-// is a deliberate FUTURE session; this unit builds only the approval gate + lifecycle.
+// NOTE (write execution): approving a write row flips it to 'queued' (status), and as
+// of Phase 5 Session 2 the dispatcher RUNS write scope — CC mutates a throwaway clone
+// under acceptEdits, then the dispatcher validates the diff against the brief's
+// `# Expected paths` and opens a PR. `infra` still flips to 'queued' on approval but is
+// hard-rejected by the dispatcher's validateScope (only write joined audit/read_only).
 const RUN_SCOPES = ['audit', 'read_only'];
 const WRITE_SCOPES = ['write', 'infra'];
 const ALL_SCOPES = [...RUN_SCOPES, ...WRITE_SCOPES, 'critical'];
@@ -99,7 +99,18 @@ export function createClaudeCodeDispatchTool({
   }
   const rest = restClient || _defaultRest;
 
+  // Normalise expected_paths → a clean repo-relative string[] (or null if unset).
+  // The dispatcher parses the rendered `# Expected paths` section and refuses to push
+  // any write-scope change that touches a file outside this list.
+  function normaliseExpectedPaths(v) {
+    if (v == null) return null;
+    const arr = Array.isArray(v) ? v : [v];
+    const out = [...new Set(arr.map((p) => String(p).replace(/^\.\//, '').trim()).filter(Boolean))];
+    return out.length ? out : null;
+  }
+
   function assembleBrief(args, repo, mode) {
+    const expectedPaths = normaliseExpectedPaths(args.expected_paths);
     return [
       `# Task\n${String(args.task).trim()}`,
       `\n# Repo\n${repo}`,
@@ -109,6 +120,8 @@ export function createClaudeCodeDispatchTool({
       args.audit_scope ? `\n# Audit scope\n${String(args.audit_scope).trim()}` : '',
       args.acceptance_criteria ? `\n# Acceptance criteria\n${String(args.acceptance_criteria).trim()}` : '',
       args.constraints ? `\n# Constraints\n${String(args.constraints).trim()}` : '',
+      // Rendered as a JSON array on one line so the dispatcher parses it unambiguously.
+      expectedPaths ? `\n# Expected paths\n${JSON.stringify(expectedPaths)}` : '',
       args.deliverable ? `\n# Deliverable\n${String(args.deliverable).trim()}` : '',
     ].filter(Boolean).join('\n');
   }
@@ -135,7 +148,8 @@ export function createClaudeCodeDispatchTool({
         acceptance_criteria: { type: 'string', description: 'What a good result looks like.' },
         constraints: { type: 'string', description: 'Hard limits Claude Code must respect.' },
         deliverable: { type: 'string', description: 'The shape of the expected output.' },
-        priority: { type: 'integer', description: '1–10, higher runs first (default 5).' },
+        // write-scope path guard (ignored for audit/read_only — those never mutate):
+        expected_paths: { type: 'array', items: { type: 'string' }, description: 'write/infra only: the repo-relative files Claude Code is allowed to change (e.g. ["src/dispatch/start.js"]). After CC runs, the dispatcher diffs the clone; if any changed file is outside this list the write is ABORTED and nothing is pushed. Omit to skip path validation (the dispatcher pushes whatever CC changed).' },
         // write/infra approval-prompt fields (ignored for audit/read_only):
         fix: { type: 'string', description: 'One-line description of the fix (shown in the Telegram approval prompt). Defaults to the first line of task.' },
         risk: { type: 'string', enum: RISK_LEVELS, description: 'Risk level for the approval prompt (write/infra). Defaults to medium.' },

--- a/tests/cc-dispatcher.test.js
+++ b/tests/cc-dispatcher.test.js
@@ -9,7 +9,7 @@ import {
   validateScope, scrubChildEnv, buildCcArgv, scrubSecretsFromOutput,
   sumCostSince, summarise, parseEnvFile, resolveCcUser, workingTreeDirty,
   parseExpectedPaths, planWriteOutcome, briefTaskLine, changedFilesInClone,
-  processOne,
+  processOne, pushAndOpenPr,
 } from '../src/dispatch/claude-code-dispatcher.js';
 
 let passed = 0, failed = 0;
@@ -68,14 +68,16 @@ check('resolveCcUser returns null for an absent user (refuse-root invariant)', r
 check('workingTreeDirty fails SAFE (dirty) when git cannot run', workingTreeDirty('/nonexistent-clone-xyz', { uid: 4294967, gid: 4294967 }, { warn(){} }) === true);
 
 // ── Phase 5 Session 2 — write scope ─────────────────────────────────────────
-console.log('write-scope child env (GH_TOKEN injected ONLY for write):');
+// scrubChildEnv is used for BOTH the CC run (no token, ever) and the dispatcher's
+// push step (token). The token branch here is the PUSH env, not CC's.
+console.log('scrubChildEnv: token only when explicitly requested (push env), never by default:');
 const roEnv = scrubChildEnv({ PATH: '/usr/bin', ANTHROPIC_API_KEY: 'sk-ant-x' }, '/h');
-check('read-only env has NO GH_TOKEN', !('GH_TOKEN' in roEnv));
-check('read-only env still exactly 4 keys', Object.keys(roEnv).sort().join(',') === 'ANTHROPIC_API_KEY,HOME,LANG,PATH');
+check('default (CC) env has NO GH_TOKEN', !('GH_TOKEN' in roEnv));
+check('default (CC) env still exactly 4 keys', Object.keys(roEnv).sort().join(',') === 'ANTHROPIC_API_KEY,HOME,LANG,PATH');
 const wEnv = scrubChildEnv({ PATH: '/usr/bin', ANTHROPIC_API_KEY: 'sk-ant-x' }, '/h', 'ghp_writetoken');
-check('write env injects GH_TOKEN', wEnv.GH_TOKEN === 'ghp_writetoken');
-check('write env sets GIT_TERMINAL_PROMPT=0', wEnv.GIT_TERMINAL_PROMPT === '0');
-check('write env keeps ANTHROPIC_API_KEY', wEnv.ANTHROPIC_API_KEY === 'sk-ant-x');
+check('push env injects GH_TOKEN', wEnv.GH_TOKEN === 'ghp_writetoken');
+check('push env sets GIT_TERMINAL_PROMPT=0', wEnv.GIT_TERMINAL_PROMPT === '0');
+check('push env keeps ANTHROPIC_API_KEY', wEnv.ANTHROPIC_API_KEY === 'sk-ant-x');
 check('empty ghToken → no GH_TOKEN (falsy guard)', !('GH_TOKEN' in scrubChildEnv({ PATH: '/usr/bin' }, '/h', '')));
 
 console.log('write-scope CC argv (actual execution, NOT plan mode):');
@@ -112,11 +114,17 @@ check('extracts first line of # Task', briefTaskLine('# Task\nBump the rate limi
 check('falls back when no # Task', briefTaskLine('just some text') === 'just some text');
 check('changedFilesInClone parses porcelain (injected runner)', (() => {
   const fakeRunner = () => ' M src/a.js\n?? src/new.js\n';
-  return JSON.stringify(changedFilesInClone('/c', { uid: 1, gid: 1 }, fakeRunner)) === '["src/a.js","src/new.js"]';
+  return JSON.stringify(changedFilesInClone('/c', { uid: 1, gid: 1 }, null, fakeRunner)) === '["src/a.js","src/new.js"]';
+})());
+check('changedFilesInClone neutralises hooks + uses given env (fix 2/5)', (() => {
+  let seenArgv = null, seenOpts = null;
+  const fakeRunner = (_bin, argv, opts) => { seenArgv = argv; seenOpts = opts; return ''; };
+  changedFilesInClone('/c', { uid: 1, gid: 1 }, { PATH: '/usr/bin', HOME: '/h' }, fakeRunner);
+  return seenArgv.join(' ').includes('-c core.hooksPath=/dev/null') && seenOpts.env && seenOpts.env.PATH === '/usr/bin' && !('GH_TOKEN' in seenOpts.env);
 })());
 
 // ── integration smoke: write-scope authorised row drives processOne, CC runs
-//    WITHOUT plan mode, GH_TOKEN reaches the child, PR url is written back. ──
+//    WITHOUT plan mode, GH_TOKEN is NOT handed to CC (fix 1), PR url written back. ──
 console.log('processOne write-scope smoke (injected deps — no host/CC):');
 {
   const GH = 'ghp_smoketoken1234567890';
@@ -140,7 +148,8 @@ console.log('processOne write-scope smoke (injected deps — no host/CC):');
   };
   await processOne({ ANTHROPIC_API_KEY: 'sk-ant-x' }, rest, row, { uid: 1000, gid: 1000 }, { info(){}, warn(){}, error(){} }, deps);
   check('CC invoked with writeMode=true (not plan mode)', ccOpts && ccOpts.writeMode === true);
-  check('GH_TOKEN injected into the CC run', ccOpts && ccOpts.ghToken === GH);
+  check('GH_TOKEN NOT handed to CC (fix 1)', ccOpts && ccOpts.ghToken === undefined);
+  check('pushPr (dispatcher) still gets the token', pushOpts && pushOpts.ghToken === GH);
   check('pushPr got branch cc/write-<8hex>', pushOpts && pushOpts.branch === 'cc/write-abcd1234');
   check('commit message is feat(dispatch): <one-liner>', pushOpts && pushOpts.commitMessage === 'feat(dispatch): Raise the API rate cap');
   check('PR title is the bare one-liner', pushOpts && pushOpts.title === 'Raise the API rate cap');
@@ -197,6 +206,36 @@ console.log('processOne write-scope guards (unauthorised + out-of-scope abort):'
   await processOne({}, rest, row, { uid: 1, gid: 1 }, { warn(){}, info(){}, error(){} },
     { loadGhToken: async () => null, runCc: async () => { ccCalled = true; return {}; }, setup: () => ({ clonePath: '/c', homeDir: '/h' }), cleanup: () => {} });
   check('missing GH token → failed, CC never run', ccCalled === false && writes[0].status === 'failed' && /github_token/.test(writes[0].error_message));
+}
+{
+  // fix 4: a computed branch name that isn't cc/write-<8hex> must fail-closed, no push.
+  const writes = [];
+  const rest = async (m, p, o = {}) => { writes.push(o.body); return null; };
+  let pushed = false;
+  // non-hex id → branch cc/write-ZZZZZZZZ → regex fails.
+  const row = { id: 'ZZZZZZZZ-eeee-ffff-0000-111122223333', scope: 'write', brief: '# Task\nx\n# Expected paths\n["src/a.js"]', authorised_by: 'tyson', authorised_at: 't' };
+  await processOne({}, rest, row, { uid: 1, gid: 1 }, { warn(){}, info(){}, error(){} }, {
+    loadGhToken: async () => 'tok', setup: () => ({ clonePath: '/c', homeDir: '/h' }), cleanup: () => {},
+    runCc: async () => ({ ok: true, status: 'complete', resultText: 'ok', exitCode: 0 }),
+    listChanged: () => ['src/a.js'], pushPr: () => { pushed = true; return 'url'; },
+  });
+  check('bad branch name → failed, NOT pushed (fix 4)', pushed === false && writes[0].status === 'failed' && /branch name failed validation/.test(writes[0].error_message));
+}
+
+console.log('pushAndOpenPr hardens git against CC-planted hooks/filters (fix 2):');
+{
+  const calls = [];
+  const fakeRunner = (bin, argv) => { calls.push({ bin, argv }); return bin === 'gh' ? 'https://github.com/tysonven/QClaw/pull/7' : ''; };
+  const url = pushAndOpenPr({
+    clonePath: '/c', homeDir: '/h', ccUser: { uid: 1, gid: 1 }, ghToken: 'ghp_x',
+    branch: 'cc/write-abcd1234', commitMessage: 'feat(dispatch): x', title: 'x', body: 'b', runner: fakeRunner,
+  });
+  const gitCalls = calls.filter((c) => c.bin === 'git');
+  check('every git call neutralises hooks', gitCalls.length > 0 && gitCalls.every((c) => c.argv.join(' ').includes('-c core.hooksPath=/dev/null')));
+  check('every git call neutralises global attributes', gitCalls.every((c) => c.argv.join(' ').includes('-c core.attributesFile=/dev/null')));
+  check('GH_TOKEN never in any git/gh argv', calls.every((c) => !c.argv.join(' ').includes('ghp_x')));
+  check('push targets the hardcoded GH repo URL', gitCalls.some((c) => c.argv.join(' ').includes('https://github.com/tysonven/QClaw.git')));
+  check('returns the PR url', url === 'https://github.com/tysonven/QClaw/pull/7');
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/tests/cc-dispatcher.test.js
+++ b/tests/cc-dispatcher.test.js
@@ -8,6 +8,8 @@
 import {
   validateScope, scrubChildEnv, buildCcArgv, scrubSecretsFromOutput,
   sumCostSince, summarise, parseEnvFile, resolveCcUser, workingTreeDirty,
+  parseExpectedPaths, planWriteOutcome, briefTaskLine, changedFilesInClone,
+  processOne,
 } from '../src/dispatch/claude-code-dispatcher.js';
 
 let passed = 0, failed = 0;
@@ -16,7 +18,7 @@ const check = (l, c) => { if (c) { console.log(`  ✓ ${l}`); passed++; } else {
 console.log('scope validation (structural gate, never trusts the row):');
 check('audit → ok', validateScope('audit').ok === true);
 check('read_only → ok', validateScope('read_only').ok === true);
-check('write → rejected', validateScope('write').ok === false);
+check('write → ok (Phase 5 Session 2)', validateScope('write').ok === true);
 check('infra → rejected', validateScope('infra').ok === false);
 check('critical → rejected', validateScope('critical').ok === false);
 check('null → rejected (fail closed)', validateScope(null).ok === false);
@@ -64,6 +66,138 @@ check('parseEnvFile strips quotes + skips comments', (() => { const e = parseEnv
 check('summarise trims + caps', summarise('  a\r\nb  ', 3) === 'a\nb');
 check('resolveCcUser returns null for an absent user (refuse-root invariant)', resolveCcUser('definitely-no-such-user-xyz') === null);
 check('workingTreeDirty fails SAFE (dirty) when git cannot run', workingTreeDirty('/nonexistent-clone-xyz', { uid: 4294967, gid: 4294967 }, { warn(){} }) === true);
+
+// ── Phase 5 Session 2 — write scope ─────────────────────────────────────────
+console.log('write-scope child env (GH_TOKEN injected ONLY for write):');
+const roEnv = scrubChildEnv({ PATH: '/usr/bin', ANTHROPIC_API_KEY: 'sk-ant-x' }, '/h');
+check('read-only env has NO GH_TOKEN', !('GH_TOKEN' in roEnv));
+check('read-only env still exactly 4 keys', Object.keys(roEnv).sort().join(',') === 'ANTHROPIC_API_KEY,HOME,LANG,PATH');
+const wEnv = scrubChildEnv({ PATH: '/usr/bin', ANTHROPIC_API_KEY: 'sk-ant-x' }, '/h', 'ghp_writetoken');
+check('write env injects GH_TOKEN', wEnv.GH_TOKEN === 'ghp_writetoken');
+check('write env sets GIT_TERMINAL_PROMPT=0', wEnv.GIT_TERMINAL_PROMPT === '0');
+check('write env keeps ANTHROPIC_API_KEY', wEnv.ANTHROPIC_API_KEY === 'sk-ant-x');
+check('empty ghToken → no GH_TOKEN (falsy guard)', !('GH_TOKEN' in scrubChildEnv({ PATH: '/usr/bin' }, '/h', '')));
+
+console.log('write-scope CC argv (actual execution, NOT plan mode):');
+const wArgv = buildCcArgv({ clonePath: '/c', settingsPath: '/w.json', budgetUsd: 2, writeMode: true });
+check('write argv is NOT plan mode', !wArgv.join(' ').includes('--permission-mode plan'));
+check('write argv is acceptEdits', wArgv.join(' ').includes('--permission-mode acceptEdits'));
+check('write argv does NOT disallow Edit/Write', !wArgv.join(' ').includes('--disallowedTools'));
+check('write argv still headless + json + budget', wArgv.includes('-p') && wArgv.join(' ').includes('--output-format json') && wArgv.join(' ').includes('--max-budget-usd 2'));
+check('read-only argv (default) is STILL plan mode + disallow', (() => { const a = buildCcArgv({ clonePath: '/c', settingsPath: '/s', budgetUsd: 1 }); return a.join(' ').includes('--permission-mode plan') && a.join(' ').includes('--disallowedTools Edit Write NotebookEdit'); })());
+
+console.log('parseExpectedPaths (from the brief\'s # Expected paths section):');
+check('absent section → null (skip validation)', parseExpectedPaths('# Task\ndo x\n# Repo\ntysonven/QClaw') === null);
+check('JSON array on one line', JSON.stringify(parseExpectedPaths('# Task\nx\n# Expected paths\n["src/a.js","src/b.js"]\n# Deliverable\ny')) === '["src/a.js","src/b.js"]');
+check('newline/bullet list', JSON.stringify(parseExpectedPaths('# Expected paths\n- src/a.js\n- src/b.js')) === '["src/a.js","src/b.js"]');
+check('strips ./ and de-dupes', JSON.stringify(parseExpectedPaths('# Expected paths\n./src/a.js\nsrc/a.js')) === '["src/a.js"]');
+check('empty section → [] (nothing may change)', JSON.stringify(parseExpectedPaths('# Expected paths\n\n# Deliverable\nx')) === '[]');
+
+console.log('planWriteOutcome (path-validation decision):');
+check('no changes → nochange (no push)', planWriteOutcome({ changedFiles: [], expectedPaths: ['src/a.js'] }).action === 'nochange');
+check('all changes in scope → push', planWriteOutcome({ changedFiles: ['src/a.js'], expectedPaths: ['src/a.js', 'src/b.js'] }).action === 'push');
+{
+  const p = planWriteOutcome({ changedFiles: ['src/a.js', 'src/evil.js'], expectedPaths: ['src/a.js'] });
+  check('out-of-scope change → abort', p.action === 'abort');
+  check('abort names the unexpected file', p.unexpected.join(',') === 'src/evil.js');
+}
+{
+  const p = planWriteOutcome({ changedFiles: ['src/a.js'], expectedPaths: null });
+  check('no expected_paths + changes → push (skips validation)', p.action === 'push' && p.skippedValidation === true);
+}
+check('empty expected list + a change → abort (nothing allowed)', planWriteOutcome({ changedFiles: ['src/a.js'], expectedPaths: [] }).action === 'abort');
+
+console.log('briefTaskLine (PR/commit one-liner) + changedFilesInClone parsing:');
+check('extracts first line of # Task', briefTaskLine('# Task\nBump the rate limit\nmore\n# Repo\nx') === 'Bump the rate limit');
+check('falls back when no # Task', briefTaskLine('just some text') === 'just some text');
+check('changedFilesInClone parses porcelain (injected runner)', (() => {
+  const fakeRunner = () => ' M src/a.js\n?? src/new.js\n';
+  return JSON.stringify(changedFilesInClone('/c', { uid: 1, gid: 1 }, fakeRunner)) === '["src/a.js","src/new.js"]';
+})());
+
+// ── integration smoke: write-scope authorised row drives processOne, CC runs
+//    WITHOUT plan mode, GH_TOKEN reaches the child, PR url is written back. ──
+console.log('processOne write-scope smoke (injected deps — no host/CC):');
+{
+  const GH = 'ghp_smoketoken1234567890';
+  const writes = [];
+  const rest = async (method, path, opts = {}) => { writes.push({ method, path, body: opts.body }); return null; };
+  const row = {
+    id: 'abcd1234-eeee-ffff-0000-111122223333', scope: 'write',
+    brief: '# Task\nRaise the API rate cap\n# Expected paths\n["src/dispatch/start.js"]',
+    authorised_by: 'tyson', authorised_at: '2026-07-02T00:00:00Z',
+    timeout_seconds: 600, attempts: 1, pinned_commit: null,
+  };
+  let ccOpts = null, pushOpts = null;
+  const deps = {
+    setup: () => ({ clonePath: '/fake/clone', homeDir: '/fake/clone.home' }),
+    loadGhToken: async () => GH,
+    runCc: async (o) => { ccOpts = o; return { ok: true, status: 'complete', resultText: `edited ${GH}`, error: null, exitCode: 0, costUsd: 0.1, ccSessionId: 'sess1', permissionDenials: [] }; },
+    listChanged: () => ['src/dispatch/start.js'],
+    pushPr: (o) => { pushOpts = o; return 'https://github.com/tysonven/QClaw/pull/99'; },
+    cleanup: () => {},
+    now: () => '2026-07-02T01:00:00Z',
+  };
+  await processOne({ ANTHROPIC_API_KEY: 'sk-ant-x' }, rest, row, { uid: 1000, gid: 1000 }, { info(){}, warn(){}, error(){} }, deps);
+  check('CC invoked with writeMode=true (not plan mode)', ccOpts && ccOpts.writeMode === true);
+  check('GH_TOKEN injected into the CC run', ccOpts && ccOpts.ghToken === GH);
+  check('pushPr got branch cc/write-<8hex>', pushOpts && pushOpts.branch === 'cc/write-abcd1234');
+  check('commit message is feat(dispatch): <one-liner>', pushOpts && pushOpts.commitMessage === 'feat(dispatch): Raise the API rate cap');
+  check('PR title is the bare one-liner', pushOpts && pushOpts.title === 'Raise the API rate cap');
+  const wb = writes[writes.length - 1].body;
+  check('write-back status complete', wb.status === 'complete');
+  check('PR url captured in result + metadata', wb.result.includes('pull/99') && wb.metadata.pr_url === 'https://github.com/tysonven/QClaw/pull/99');
+  check('exit_code 0 on success', wb.exit_code === 0);
+  check('GH_TOKEN scrubbed from result (never leaks)', !wb.result.includes(GH));
+}
+
+console.log('processOne write-scope guards (unauthorised + out-of-scope abort):');
+{
+  // unauthorised (fabricated queued+write row, no authorised_by/at) → rejected, no CC
+  const writes = [];
+  const rest = async (m, p, o = {}) => { writes.push(o.body); return null; };
+  let ccCalled = false;
+  await processOne({}, rest, { id: 'x1', scope: 'write', brief: '# Task\nx' }, { uid: 1, gid: 1 }, { warn(){}, info(){}, error(){} },
+    { loadGhToken: async () => 'tok', runCc: async () => { ccCalled = true; return {}; }, setup: () => ({ clonePath: '/c', homeDir: '/h' }), cleanup: () => {} });
+  check('unauthorised write → failed, CC never run', ccCalled === false && writes[0].status === 'failed' && /not authorised/.test(writes[0].error_message));
+}
+{
+  // authorised, but CC changes a file outside expected_paths → abort, no push
+  const writes = [];
+  const rest = async (m, p, o = {}) => { writes.push(o.body); return null; };
+  let pushed = false;
+  const row = { id: 'y2', scope: 'write', brief: '# Task\nedit a\n# Expected paths\n["src/a.js"]', authorised_by: 'tyson', authorised_at: 't' };
+  await processOne({}, rest, row, { uid: 1, gid: 1 }, { warn(){}, info(){}, error(){} }, {
+    loadGhToken: async () => 'tok', setup: () => ({ clonePath: '/c', homeDir: '/h' }), cleanup: () => {},
+    runCc: async () => ({ ok: true, status: 'complete', resultText: 'ok', exitCode: 0 }),
+    listChanged: () => ['src/a.js', 'src/secret.js'],
+    pushPr: () => { pushed = true; return 'url'; },
+  });
+  check('out-of-scope write → failed, NOT pushed', pushed === false && writes[0].status === 'failed' && /src\/secret\.js/.test(writes[0].error_message));
+}
+{
+  // authorised, CC makes no changes → complete with note, no push
+  const writes = [];
+  const rest = async (m, p, o = {}) => { writes.push(o.body); return null; };
+  let pushed = false;
+  const row = { id: 'z3', scope: 'write', brief: '# Task\nno-op\n# Expected paths\n["src/a.js"]', authorised_by: 'tyson', authorised_at: 't' };
+  await processOne({}, rest, row, { uid: 1, gid: 1 }, { warn(){}, info(){}, error(){} }, {
+    loadGhToken: async () => 'tok', setup: () => ({ clonePath: '/c', homeDir: '/h' }), cleanup: () => {},
+    runCc: async () => ({ ok: true, status: 'complete', resultText: 'nothing to do', exitCode: 0 }),
+    listChanged: () => [], pushPr: () => { pushed = true; return 'url'; },
+  });
+  check('no-mutation write → complete, no push, note set', pushed === false && writes[0].status === 'complete' && writes[0].metadata.note === 'no mutations — CC found nothing to change');
+}
+{
+  // write scope with GH token missing → failed cleanly, no CC
+  const writes = [];
+  const rest = async (m, p, o = {}) => { writes.push(o.body); return null; };
+  let ccCalled = false;
+  const row = { id: 'w4', scope: 'write', brief: '# Task\nx', authorised_by: 'tyson', authorised_at: 't' };
+  await processOne({}, rest, row, { uid: 1, gid: 1 }, { warn(){}, info(){}, error(){} },
+    { loadGhToken: async () => null, runCc: async () => { ccCalled = true; return {}; }, setup: () => ({ clonePath: '/c', homeDir: '/h' }), cleanup: () => {} });
+  check('missing GH token → failed, CC never run', ccCalled === false && writes[0].status === 'failed' && /github_token/.test(writes[0].error_message));
+}
 
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed ? 1 : 0);

--- a/tests/cc-write-scope.test.js
+++ b/tests/cc-write-scope.test.js
@@ -38,7 +38,7 @@ console.log('write scope → awaiting_authorisation row + authorisation_required
   const { client, posts } = fakeRest();
   let pushed = null;
   const tool = createClaudeCodeDispatchTool({ env: {}, restClient: client, notify: async (t) => { pushed = t; return true; } });
-  const out = JSON.parse(await tool.fn({ task: 'Bump the rate limit', mode: 'audit_then_implement', scope: 'write', fix: 'Raise API rate cap', risk: 'high', action: 'Edit config + redeploy' }, toolCtx));
+  const out = JSON.parse(await tool.fn({ task: 'Bump the rate limit', mode: 'audit_then_implement', scope: 'write', expected_paths: ['src/config.js'], fix: 'Raise API rate cap', risk: 'high', action: 'Edit config + redeploy' }, toolCtx));
   const body = posts()[0]?.body;
   check('one row inserted', posts().length === 1);
   check('row status = awaiting_authorisation', body?.status === 'awaiting_authorisation', JSON.stringify(body));
@@ -50,6 +50,23 @@ console.log('write scope → awaiting_authorisation row + authorisation_required
       && pushed.includes('Risk: high') && pushed.includes(`Task ID: ${ROW_ID.slice(0, 8)}`)
       && pushed.includes(`✅ ${ROW_ID.slice(0, 8)}`) && pushed.includes(`❌ ${ROW_ID.slice(0, 8)}`),
     JSON.stringify(pushed));
+  check('approval message surfaces the expected_paths allow-list (fix 3)', pushed.includes('Paths: src/config.js'));
+}
+
+console.log('write scope REQUIRES expected_paths (fix 3 — throws, no row):');
+{
+  const { client, posts } = fakeRest();
+  const tool = createClaudeCodeDispatchTool({ env: {}, restClient: client, notify: async () => true });
+  let err = null;
+  try { await tool.fn({ task: 'x', mode: 'audit_then_implement', scope: 'write' }, toolCtx); }
+  catch (e) { err = e; }
+  check('write without expected_paths throws', err && /expected_paths is required/.test(err.message));
+  check('no row inserted when expected_paths missing', posts().length === 0);
+  // empty array is also rejected
+  let err2 = null;
+  try { await tool.fn({ task: 'x', mode: 'audit_then_implement', scope: 'write', expected_paths: [] }, toolCtx); }
+  catch (e) { err2 = e; }
+  check('write with empty expected_paths throws', err2 && /expected_paths is required/.test(err2.message));
 }
 
 console.log('expected_paths renders into the brief (write-scope path guard):');
@@ -62,10 +79,13 @@ console.log('expected_paths renders into the brief (write-scope path guard):');
   check('paths rendered as a JSON array, ./ stripped + de-duped', brief.includes('["src/dispatch/start.js"]'));
 }
 {
+  // infra scope does NOT require expected_paths (only write does) — brief omits the section.
   const { client, posts } = fakeRest();
-  const tool = createClaudeCodeDispatchTool({ env: {}, restClient: client, notify: async () => true });
-  await tool.fn({ task: 'no paths declared', mode: 'audit_then_implement', scope: 'write' }, toolCtx);
-  check('no expected_paths → no # Expected paths section in brief', !(posts()[0]?.body?.brief || '').includes('# Expected paths'));
+  let pushed = null;
+  const tool = createClaudeCodeDispatchTool({ env: {}, restClient: client, notify: async (t) => { pushed = t; return true; } });
+  await tool.fn({ task: 'no paths declared', mode: 'implement_with_audit_gate', scope: 'infra' }, toolCtx);
+  check('infra without expected_paths → no # Expected paths section in brief', !(posts()[0]?.body?.brief || '').includes('# Expected paths'));
+  check('infra approval message warns no path validation (fix 3)', pushed.includes('none declared') && pushed.includes('NO path validation'));
 }
 
 console.log('infra scope also holds for approval:');

--- a/tests/cc-write-scope.test.js
+++ b/tests/cc-write-scope.test.js
@@ -52,6 +52,22 @@ console.log('write scope → awaiting_authorisation row + authorisation_required
     JSON.stringify(pushed));
 }
 
+console.log('expected_paths renders into the brief (write-scope path guard):');
+{
+  const { client, posts } = fakeRest();
+  const tool = createClaudeCodeDispatchTool({ env: {}, restClient: client, notify: async () => true });
+  await tool.fn({ task: 'Bump rate limit', mode: 'audit_then_implement', scope: 'write', expected_paths: ['./src/dispatch/start.js', 'src/dispatch/start.js'] }, toolCtx);
+  const brief = posts()[0]?.body?.brief || '';
+  check('brief has an # Expected paths section', brief.includes('# Expected paths'));
+  check('paths rendered as a JSON array, ./ stripped + de-duped', brief.includes('["src/dispatch/start.js"]'));
+}
+{
+  const { client, posts } = fakeRest();
+  const tool = createClaudeCodeDispatchTool({ env: {}, restClient: client, notify: async () => true });
+  await tool.fn({ task: 'no paths declared', mode: 'audit_then_implement', scope: 'write' }, toolCtx);
+  check('no expected_paths → no # Expected paths section in brief', !(posts()[0]?.body?.brief || '').includes('# Expected paths'));
+}
+
 console.log('infra scope also holds for approval:');
 {
   const { client, posts } = fakeRest();


### PR DESCRIPTION
Phase 5 Session 2 — closes the write-execution gap left by Session 1 (PR #50). Approved write-scope CC dispatches now actually execute and open a PR.

## What changed
- **ALLOWED_SCOPES** → `{audit, read_only, write}`. `infra`/`critical` stay hard-rejected at `validateScope` (fail-closed). No claim-RPC/SQL change needed — the ✅ handler already re-queues an approved write row to `status='queued'`, so the existing queued-only `claim_next_dispatch` picks it up; only the scope gate had to open.
- **Write run**: CC runs as `ccdispatch` in the throwaway clone under `--permission-mode acceptEdits` with a new `cc-write-settings.json` (Edit/Write allowed; secret-read + push/commit/gh/curl denies kept). CC only mutates files — the **dispatcher, never CC**, does all git/gh.
- **expected_paths validation** (optional `# Expected paths` brief section): no changes → `complete` + note "no mutations"; any path out of scope → `failed`, aborted, **not pushed**; all in-scope / undeclared (warn) → commit + push + PR.
- **PR creation**: branch `cc/write-<8-char task_id>`, commit `feat(dispatch): <task one-liner>`, pushed to `tysonven/QClaw` via the gh credential helper (`-c credential.helper='!gh auth git-credential'`) so **GH_TOKEN is never in argv/URL/reflog**; `gh pr create -R tysonven/QClaw`. PR URL captured into `result` + `metadata.pr_url`.
- **GH_TOKEN**: read from the encrypted store (`ccdispatch_github_token`) **at dispatch time**, injected into the scrubbed child env for **write scope only** (audit/read_only unchanged), and added to the output scrubber's known-values list **before** CC runs.
- **Security hardening (beyond brief)**: authorisation-provenance guard — the dispatcher refuses any write row missing `authorised_by`/`authorised_at` (untrusted-row defence; a fabricated queued+write row that bypasses Telegram approval is rejected, CC never spawned).
- **Tool**: `claude_code_dispatch` gains optional `expected_paths` array → one-line JSON `# Expected paths` brief section.

## Verification
- Full `npm test` suite green (+52 new checks).
- Secret store decrypts the token live (len 93, fine-grained PAT).
- Push credential-helper path authenticates as `ccdispatch` (read-only `git ls-remote` → HEAD, EXIT=0; no writes to GitHub).

## Not done here / follow-ups
- Dispatcher **not** restarted under PM2 — code is on this branch only; live enablement follows review + merge.
- **DRAFT** pending a separate adversarial-review session against this branch before un-drafting (security-relevant slice).
- `gh pr create` for a *live* write dispatch was not end-to-end exercised (would create a real PR); credential path proven read-only.

Constraints honoured: `ccdispatch` remains the execution user (never root); infra/critical hard-rejected; GH_TOKEN absent from audit/read_only child env; path comparison is pure JS array membership (no shell glob); no schema change; no new PM2 process; target `tysonven/QClaw` (never upstream).
