### PR TITLE
fix(dashboard): stop qclaw dashboard CLI silently rotating the persistent auth token

### DIFF
--- a/docs/runbooks/credential-rotation.md
+++ b/docs/runbooks/credential-rotation.md
@@ -168,6 +168,16 @@ Each gap maps to a step above. Documented to keep the runbook honest about what 
 - Workflow inactive, so the failure didn't surface in execution logs.
 - Maps to step 3.2 + the **inactive-workflow blind spot**: an audit query filtered by `active=true` would have missed this entirely. The query in step 1.a deliberately includes inactive workflows.
 
+## QCLAW_API_TOKEN / dashboard authToken
+
+- **Canonical store:** `/root/.quantumclaw/config.json` -> `dashboard.authToken`. The qclaw dashboard server reads this; it is the single source of truth.
+- **Real rotation trigger:** running `qclaw dashboard` >24h after the last mint (the CLI's 24h expiry check). This is the only routine rotation path -- **not** PM2 restarts (51 restarts observed 2026-07 with a stable token; tokenCreatedAt 2026-07-06 12:21 UTC survived the 2026-07-07 restart unchanged). As of 2026-07-08 `cli/index.js` no longer expires a persistent config token, closing this trigger.
+  - Do **not** treat config.json mtime as a rotation signal -- it bumps after every restart from unrelated `saveConfig` writes (channel/agent state) without touching the token. Compare the token value or `tokenCreatedAt` instead.
+- **n8n consumer:** `QCLAW_API_TOKEN` env var, referenced in workflow `tnvXFYvODL1PrhJa` (Crete Content Generator). A static baked copy with no auto-propagation.
+- **On rotation (manual re-sync):** set `QCLAW_API_TOKEN` in `/home/n8nadmin/n8n-project/.env` to config.json's current `dashboard.authToken`, then `docker compose up -d` on the n8n host (env_file requires recreate, not `restart`).
+- **Orphan:** `DASHBOARD_AUTH_TOKEN` in qclaw's `.env` is not loaded (PM2 `env_file: none`) and is not consulted by the server -- commented out 2026-07-08. Do not reintroduce it as an auth source.
+- **Fix landed (2026-07-08):** `cli/index.js` -- persistent (config-stored) tokens no longer expire.
+
 ## Related
 
 - [SECURITY.md](../../SECURITY.md) — overall security posture, AGEX protocol (future automation of this runbook)

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -397,7 +397,10 @@ switch (command) {
       const age = Date.now() - config.dashboard.tokenCreatedAt;
       const hours = Math.floor(age / 3600000);
       const expiry = config.dashboard?.tokenExpiry || 86400000;
-      if (age > expiry) {
+      const isAutoToken = !config.dashboard?.authToken;
+      if (!isAutoToken) {
+        ok(`Token age: ${hours}h (persistent — does not expire)`);
+      } else if (age > expiry) {
         warn(`Token age: ${hours}h (expired — run qclaw dashboard for a fresh URL)`);
       } else {
         ok(`Token age: ${hours}h (expires in ${Math.floor((expiry - age) / 3600000)}h)`);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1159,11 +1159,17 @@ switch (command) {
     const host = config.dashboard?.host || '127.0.0.1';
     const localHost = (host === '0.0.0.0' || host === '127.0.0.1') ? 'localhost' : host;
 
-    // Get or generate auth token (refresh if expired)
+    // Get or generate auth token.
+    // A token persisted in config.json is operator-persistent and MUST NOT expire —
+    // mirror the dashboard server's isAutoToken logic (server.js:421-425). Only an
+    // auto-generated token (one never written to config) is subject to the 24h expiry.
+    // Without this guard, running `qclaw dashboard` >24h after the last mint silently
+    // rotated the persistent token and drifted n8n's baked QCLAW_API_TOKEN copy.
     let token = config.dashboard?.authToken || process.env.DASHBOARD_AUTH_TOKEN;
+    const isAutoToken = !config.dashboard?.authToken;
     const tokenAge = config.dashboard?.tokenCreatedAt ? Date.now() - config.dashboard.tokenCreatedAt : 0;
     const tokenExpiry = config.dashboard?.tokenExpiry || 86400000;
-    const tokenExpired = tokenAge > tokenExpiry;
+    const tokenExpired = isAutoToken && tokenAge > tokenExpiry;
 
     if (!token || tokenExpired) {
       const { randomBytes } = await import('crypto');


### PR DESCRIPTION
## What & why

The `qclaw dashboard` CLI silently rotated `config.dashboard.authToken` whenever it was run >24h after the last mint (`cli/index.js` `tokenExpired` check, `tokenExpiry` default 24h). Each rotation drifted n8n's baked `QCLAW_API_TOKEN` copy out of sync and broke the Crete Content Generator (`tnvXFYvODL1PrhJa`) until a manual re-sync — a recurring incident (2026-04-30, 2026-05-19, 2026-07-07).

The dashboard **server** already treats a config-stored token as non-expiring (`server.js:421-425`, `isAutoToken`). The CLI did not. This PR makes the CLI consistent with the server.

### Root-cause correction
The prior mental model ("every PM2 restart re-mints the token") was wrong. Audit evidence: 51 restarts observed with a stable token (`tokenCreatedAt` 2026-07-06 survived the 2026-07-07 restart unchanged). The real trigger is the CLI 24h expiry. `config.json` mtime is **not** a rotation signal — it bumps after every restart from unrelated `saveConfig` writes (channel/agent state) without touching the token.

## Changes

**`c29bb92` won't rotate persistent tokens** — `src/cli/index.js` (`qclaw dashboard`):
- `const isAutoToken = !config.dashboard?.authToken`
- `const tokenExpired = isAutoToken && tokenAge > tokenExpiry` — only an auto-generated token (never written to config) can expire. A persistent config token is returned as-is.

**`qclaw status` consistency** — `src/cli/index.js` (status token-age):
- Gated the "expired — run qclaw dashboard" warning on `isAutoToken`, and added a "persistent — does not expire" line for config tokens. Without this, `status` would tell operators to run `qclaw dashboard` to refresh a token it no longer refreshes — nudging them into a manual rotation that re-drifts n8n.

**Docs** — `docs/runbooks/credential-rotation.md`: new "QCLAW_API_TOKEN / dashboard authToken" section (canonical store, real trigger, mtime false-positive warning, n8n consumer, re-sync procedure).

(Separately, outside this repo, the orphan `DASHBOARD_AUTH_TOKEN` in `/root/.quantumclaw/.env` was commented out — it is never loaded (PM2 `env_file: none`, parser skips `#` lines) and was never consulted by the server.)

## Testing
`npm test` — full suite green (EXIT 0) on both commits. `node --check` clean.

## Adversarial review
Reviewed against: isAutoToken bypass (empty/null/undefined authToken → fails to the *safe* expirable direction, mirrors server), security regression (server already never expired config tokens, so no new change to token lifetime), other `tokenExpired` readers (only the status message, fixed here), and the `.env` comment-out (no consumer reads it). No HIGH/MEDIUM defects in the diff.

**Note (posture, not in this PR):** the token guards an internet-exposed dashboard and now provably never rotates. A deliberate rotate-and-propagate-to-n8n procedure (per the runbook) is the intended path — handled manually by the operator, not automated here.
