### PR TITLE
docs(security): Supabase Phase 2 pre-flight — anon consumer map (Phase 2 aborted)

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -16185,3 +16185,39 @@ References: dispatch brief "CC Brief: Supabase Main Project Security Audit + JWT
 plan `docs/runbooks/supabase-anon-rls-remediation-2026-07-11.md`; memory
 `project_flowos_sms_gateway_supabase`, `project_n8n_supabase_fsc_credential`,
 `feedback_adversarial_review_before_pr_ready`.
+
+---
+
+## [2026-07-11] Supabase remediation Phase 2 — ABORTED at pre-flight (no table is anon-clean; consumer map built)
+
+**Branch:** `cc/supabase-phase2-anon-revoke-20260711`. **Status:** 🛑 Phase 2 (`REVOKE ALL FROM anon`) **not
+applied — nothing revoked, no DB/host/code changes.** Pre-flight found every exposed table still has a live
+anon-role consumer, so no single-table lockdown is safe yet. Full map:
+`docs/runbooks/supabase-anon-consumer-map-2026-07-11.md`.
+
+### Why aborted
+Plan was: revoke anon on `trading_*` (assumed clean) + replace its policies, then stop. **`trading_*` is not
+clean.** Verification (grep for the anon **JWT literal**, not just the `SUPABASE_ANON_KEY` env var) found:
+- **`server.js` hardcodes the anon JWT ~13×** (lines 1216–1399) across `trading_positions`/`trading_simulations`/
+  `trading_config` routes (R/W), plus the Crete (`crete_content_queue`), GHL (`marketing_drafts`), and
+  Content-Studio (`social_clip_schedules`, line 1245) paths already known.
+- **`src/trading/polymarket_scanner.py:25`** hardcodes the anon JWT and POSTs `trading_markets`.
+- 3 more trading workflows (`3YahxqOguET3pifj` Market Scanner, `vjj2uBIPc07FpIxx` Weekly Analyst,
+  `fq7spfyiNcpt8Mf7` Trade Executor[inactive]) hit Supabase REST with unverified auth.
+
+Revoking anon on `trading_*` would have broken the trading dashboard + the Polymarket scanner. Same story for
+every other exposed table (Meta Ads workflows on `ad_creation_sessions`/`competitor_ads`/`copy_agent_output`;
+triple-a-tracker on `workout_*`, deferred).
+
+### Key discovery — Phase 1 grep undercounted the anon surface
+Phase 1 found consumers by grepping for the env var `SUPABASE_ANON_KEY`. The anon **JWT literal** is hardcoded
+in committed source (`server.js`, `polymarket_scanner.py`) and inline in n8n nodes — missed by that grep. Going
+forward, hunt with the fingerprint `x5x8Dk` (end of the anon JWT), not the env-var name. **Security note:** a
+credential literal hardcoded ~13× in committed source is worth cleaning up regardless of Phase 2.
+
+### Outcome
+Full consumer map documented for next session. Recommended order: migrate `server.js` (service-role key,
+server-side) → `polymarket_scanner.py` → remaining workflows → then Phase 2/3 **per table** with anon-probe
+verification between each. `workout_*` stays deferred (triple-a-tracker Supabase-Auth migration).
+
+References: `docs/runbooks/supabase-anon-consumer-map-2026-07-11.md`; memory `project_supabase_main_anon_rls_exposure`.

--- a/docs/runbooks/supabase-anon-consumer-map-2026-07-11.md
+++ b/docs/runbooks/supabase-anon-consumer-map-2026-07-11.md
@@ -1,0 +1,65 @@
+# Supabase anon-role consumer map — Phase 2 pre-flight (2026-07-11)
+
+**Project:** `fdabygmromuqtysitodp`. **Parent plan:** `supabase-anon-rls-remediation-2026-07-11.md`.
+**Status:** 🛑 **Phase 2 (`REVOKE ALL FROM anon`) BLOCKED — nothing revoked.** Pre-flight found that **every**
+table in the exposed set still has at least one live anon-role consumer, so no table is safe to lock yet
+(not even `trading_*`, which was assumed clean). No DB/host/code changes were made tonight.
+
+## Headline finding — the anon key is hardcoded, widely
+Phase 1 migrated 10 n8n workflows by grepping for the **env var** `SUPABASE_ANON_KEY`. That undercounted the
+surface badly: the anon **JWT literal** (`eyJ…role":"anon"…6JJ…x5x8Dk`) is **hardcoded in committed source and
+in workflow definitions** in many more places. A real Phase 2 must migrate all of these off anon first, then
+revoke table-by-table.
+
+> **Security note (new):** the publishable anon key is fine to expose, but hardcoding a credential literal
+> ~13× in `server.js` and in `polymarket_scanner.py` (both committed to the repo) is poor practice and makes
+> rotation/lockdown a multi-file code change. Worth cleaning up to `$env` / service-role regardless of Phase 2.
+
+## Full consumer map (exposed tables → who still uses anon)
+
+| Table | Consumer | Location / id | Auth | R/W |
+|---|---|---|---|---|
+| `crete_content_queue` | QClaw dashboard | `server.js` Crete routes (~1548–1676) | env `SUPABASE_ANON_KEY` | R/W (7) |
+| `marketing_drafts` | QClaw dashboard | `server.js` GHL routes (~1719–1861) | env `SUPABASE_ANON_KEY` | R/W (5) |
+| `social_clip_schedules` | QClaw dashboard | `server.js` `/api/content-studio/schedule-clip` (1245) | **hardcoded anon JWT** | W |
+| `trading_positions` | QClaw dashboard | `server.js` (1303/1304/1367…) | **hardcoded anon JWT (~13×)** | R/W |
+| `trading_simulations` | QClaw dashboard | `server.js` (1329 POST, 1378…) | hardcoded anon JWT | R/W |
+| `trading_config` | QClaw dashboard | `server.js` (1389/1402/1410) | hardcoded anon JWT | R/W |
+| `trading_markets` | **polymarket_scanner.py** | `src/trading/polymarket_scanner.py:25,129` | **hardcoded anon JWT** | W (POST) |
+| `trading_*` | Trading Market Scanner | n8n `3YahxqOguET3pifj` (active) | REST, auth **unverified** (no anon-lit/env/svc/cred detected) | ? |
+| `trading_*` | Trading Weekly Analyst | n8n `vjj2uBIPc07FpIxx` (active) | REST, auth **unverified** | ? |
+| `trading_*` | Trading Trade Executor | n8n `fq7spfyiNcpt8Mf7` (**inactive**) | REST, auth **unverified** | ? |
+| `ad_creation_sessions` | Meta Ads Telegram Bot Router | n8n `lu39mAN7epBRK3Kw` (active) | **hardcoded anon JWT inline** | R |
+| `ad_creation_sessions` | Meta Ads Ad Creation Agent | n8n `lrGcirtmOHb1xTq8` (active) | hardcoded anon JWT + `httpHeaderAuth`(FSC no-op) | R/W/DELETE |
+| `competitor_ads` | Competitor Ad Research | n8n `QnCEES9T7WxW5vVR` (active) | `httpHeaderAuth` = FSC no-op — **auth unverified** (may already 401) | R/W |
+| `copy_agent_output` | Meta Ads Copy Agent | n8n `0sIugM5o5wTwpflq` (active) | `httpHeaderAuth` = FSC no-op — **auth unverified** | W |
+| `workout_logs` / `workout_settings` | triple-a-tracker | `App.jsx` (hardcoded anon) | hardcoded anon JWT | R/W — **DEFERRED** |
+
+Already migrated in Phase 1 (now service_role, ✓): the 10 workflows (crete-*, ghl-marketing-*, Trading
+Position Monitor `UYA0JppH7eqyI7fQ`). Already-locked tables (26, service_role/deny-all/0-policy) are untouched.
+
+## Why nothing was locked tonight
+Every one of the 13 exposed tables has a live anon consumer. Revoking anon on any of them (or replacing its
+`allow_anon_all` policy) would break the dashboard, the Polymarket scanner, live Meta Ads workflows, or
+triple-a-tracker. There is **no safe single-table lockdown available** until the consumers are migrated.
+
+## Recommended sequence for next session
+1. **Migrate `server.js`** (the big one) — it's the dominant anon consumer (Crete + GHL + Content Studio +
+   Trading routes). It's server-side, so switch to the **service-role** key from `.env` (never exposed to
+   browser); remove the ~13 hardcoded anon literals. One dashboard, one redeploy (`pm2 restart quantumclaw`).
+2. **Migrate `polymarket_scanner.py`** — swap hardcoded anon JWT → `SUPABASE_SERVICE_ROLE_KEY` from env
+   (note: clipper-worker-style env caching — restart the service after).
+3. **Characterize + migrate the remaining workflows** — the 2 FSC-cred Meta Ads (`QnCEES9T7WxW5vVR`,
+   `0sIugM5o5wTwpflq`) and the 3 trading (`3YahxqOguET3pifj`, `vjj2uBIPc07FpIxx`, `fq7spfyiNcpt8Mf7`): resolve
+   their actual auth (FSC no-op likely already broken — verify executions), migrate to the
+   `Supabase Service Role (main)` cred (`fgbywZowo5p5iu9F`) or code env-swap as appropriate. The 2 hardcoded-anon
+   Meta Ads (`lu39mAN7epBRK3Kw`, `lrGcirtmOHb1xTq8`) → cred or env-swap.
+4. **Then** Phase 2/3 **per table**, once its consumers are all off anon: `REVOKE ALL … FROM anon` on the
+   table + replace `allow_anon_all` (or misnamed `TO public USING(true)`) with a `service_role` policy, verify
+   with the anon probe (expect permission-denied), move to the next.
+5. **`workout_*`** stays deferred (triple-a-tracker Supabase-Auth migration — separate issue).
+
+## Verification tooling
+- Anon probe (read-only, count-only) — the n8n-container `fetch` with `Prefer: count=exact` + `Range: 0-0`.
+- Find hardcoded anon literals: grep for the fingerprint `x5x8Dk` (end of the anon JWT) across source + n8n
+  `workflow_entity.nodes`, **not** just the env-var name `SUPABASE_ANON_KEY`.


### PR DESCRIPTION
**Phase 2 (`REVOKE ALL FROM anon`) pre-flight. Nothing revoked — no DB/host/code changes.** Documentation only.

## Why aborted
The plan was to revoke anon on `trading_*` (assumed clean) + replace its policies. Verification (grepping the anon **JWT literal**, not just the `SUPABASE_ANON_KEY` env var) showed `trading_*` is **not** clean:
- `server.js` hardcodes the anon JWT **~13×** across `trading_positions`/`trading_simulations`/`trading_config` routes (+ Crete/GHL/social_clip paths).
- `src/trading/polymarket_scanner.py` hardcodes it and writes `trading_markets`.
- 3 more trading workflows hit Supabase REST with unverified auth.

Revoking would have broken the trading dashboard + Polymarket scanner. **Every** exposed table has a live anon consumer, so no single-table lockdown is safe yet.

## Deliverable
`docs/runbooks/supabase-anon-consumer-map-2026-07-11.md` — full table→consumer map + recommended migration order (server.js → polymarket_scanner.py → remaining workflows → then Phase 2/3 per table). Key lesson: Phase 1's `SUPABASE_ANON_KEY` env-var grep undercounted the surface; the anon key is **hardcoded** in committed source + n8n nodes.

Not for merge as action — it's the plan for next session.