### PR TITLE
security: remove hardcoded Supabase anon-key literals (server.js + polymarket_scanner.py)

### DIFF
--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -18,6 +18,21 @@ import cookieParser from 'cookie-parser';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// Supabase service-role key — SERVER-SIDE ONLY (never sent to the browser).
+// Read from the dashboard's .env (same file creteEnv uses); falls back to process.env.
+// Replaces the hardcoded anon-key literals that previously lived inline in the
+// trading / content-studio routes (Supabase anon→service-role migration).
+const SB_SERVICE_ROLE_KEY = (() => {
+  try {
+    const envFile = readFileSync('/root/.quantumclaw/.env', 'utf-8');
+    for (const line of envFile.split('\n')) {
+      const m = line.match(/^SUPABASE_SERVICE_ROLE_KEY=(.*)$/);
+      if (m) return m[1].trim().replace(/^["']|["']$/g, '');
+    }
+  } catch { /* not on the server host (local/CI) — fall through to process.env */ }
+  return process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+})();
+
 // Slice 6b: agent spawning is disabled. The /api/agents/spawn backend route was
 // already removed; this defensive handler returns a clear 403 (not a 404) so any
 // stale dashboard client gets an explicit signal. Specialists are registered via
@@ -1213,7 +1228,7 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
             const publicUrl = `https://pub-70c436931e9e4611a135e7405c596611.r2.dev/${fileKey}`;
 
             // Update Supabase job record
-            const anonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkYWJ5Z21yb211cXR5c2l0b2RwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk2NjI2OTQsImV4cCI6MjA3NTIzODY5NH0.6JJMkPXBufpLxlisH1ig32Xm8YM3p0jcXRlBzx5x8Dk';
+            const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
             const col = imageType === 'hero' ? 'hero_image_url' : 'thumbnail_url';
             await fetch(`https://fdabygmromuqtysitodp.supabase.co/rest/v1/content_studio_jobs?id=eq.${encodeURIComponent(jobId)}`, {
               method: 'PATCH',
@@ -1241,7 +1256,7 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
         if (!clipUrl || !platform || !jobId) {
           return res.status(400).json({ error: 'clipUrl, platform, and jobId are required' });
         }
-        const anonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkYWJ5Z21yb211cXR5c2l0b2RwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk2NjI2OTQsImV4cCI6MjA3NTIzODY5NH0.6JJMkPXBufpLxlisH1ig32Xm8YM3p0jcXRlBzx5x8Dk';
+        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const sbRes = await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/social_clip_schedules', {
           method: 'POST',
           headers: {
@@ -1264,7 +1279,7 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
     this.app.get('/api/content-studio/jobs', async (req, res) => {
       try {
         const limit = Math.min(parseInt(req.query.limit) || 10, 50);
-        const anonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkYWJ5Z21yb211cXR5c2l0b2RwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk2NjI2OTQsImV4cCI6MjA3NTIzODY5NH0.6JJMkPXBufpLxlisH1ig32Xm8YM3p0jcXRlBzx5x8Dk';
+        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const sbRes = await fetch(`https://fdabygmromuqtysitodp.supabase.co/rest/v1/content_studio_jobs?order=created_at.desc&limit=${limit}`, {
           headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` }
         });
@@ -1274,7 +1289,7 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
 
     this.app.get('/api/content-studio/jobs/:id', async (req, res) => {
       try {
-        const anonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkYWJ5Z21yb211cXR5c2l0b2RwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk2NjI2OTQsImV4cCI6MjA3NTIzODY5NH0.6JJMkPXBufpLxlisH1ig32Xm8YM3p0jcXRlBzx5x8Dk';
+        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const sbRes = await fetch(`https://fdabygmromuqtysitodp.supabase.co/rest/v1/content_studio_jobs?id=eq.${encodeURIComponent(req.params.id)}`, {
           headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` }
         });
@@ -1296,7 +1311,7 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
           usdcBalance = balance;
         } catch { usdcBalance = 0; }
 
-        const anonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkYWJ5Z21yb211cXR5c2l0b2RwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk2NjI2OTQsImV4cCI6MjA3NTIzODY5NH0.6JJMkPXBufpLxlisH1ig32Xm8YM3p0jcXRlBzx5x8Dk';
+        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const headers = { apikey: anonKey, Authorization: `Bearer ${anonKey}` };
 
         const [closedRes, openRes] = await Promise.all([
@@ -1325,7 +1340,7 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
         if (!mcRes.ok) return res.status(mcRes.status).json(data);
 
         // Save simulation to Supabase
-        const anonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkYWJ5Z21yb211cXR5c2l0b2RwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk2NjI2OTQsImV4cCI6MjA3NTIzODY5NH0.6JJMkPXBufpLxlisH1ig32Xm8YM3p0jcXRlBzx5x8Dk';
+        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/trading_simulations', {
           method: 'POST',
           headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}`, 'Content-Type': 'application/json' },
@@ -1363,7 +1378,7 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
     // ─── Trading: Positions ─────────────────────────────────
     this.app.get('/api/trading/positions', async (req, res) => {
       try {
-        const anonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkYWJ5Z21yb211cXR5c2l0b2RwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk2NjI2OTQsImV4cCI6MjA3NTIzODY5NH0.6JJMkPXBufpLxlisH1ig32Xm8YM3p0jcXRlBzx5x8Dk';
+        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const sbRes = await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/trading_positions?status=eq.open&order=created_at.desc&limit=50', {
           headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` }
         });
@@ -1374,7 +1389,7 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
     // ─── Trading: Simulations ───────────────────────────────
     this.app.get('/api/trading/simulations', async (req, res) => {
       try {
-        const anonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkYWJ5Z21yb211cXR5c2l0b2RwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk2NjI2OTQsImV4cCI6MjA3NTIzODY5NH0.6JJMkPXBufpLxlisH1ig32Xm8YM3p0jcXRlBzx5x8Dk';
+        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const sbRes = await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/trading_simulations?select=asset,probability,current_price,macro_factors,created_at&order=created_at.desc&limit=10', {
           headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` }
         });
@@ -1385,7 +1400,7 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
     // ─── Trading: Config ────────────────────────────────────
     this.app.get('/api/trading/config', async (req, res) => {
       try {
-        const anonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkYWJ5Z21yb211cXR5c2l0b2RwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk2NjI2OTQsImV4cCI6MjA3NTIzODY5NH0.6JJMkPXBufpLxlisH1ig32Xm8YM3p0jcXRlBzx5x8Dk';
+        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const sbRes = await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/trading_config?id=eq.1&select=*', {
           headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` }
         });
@@ -1396,7 +1411,7 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
 
     this.app.post('/api/trading/config', async (req, res) => {
       try {
-        const anonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkYWJ5Z21yb211cXR5c2l0b2RwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk2NjI2OTQsImV4cCI6MjA3NTIzODY5NH0.6JJMkPXBufpLxlisH1ig32Xm8YM3p0jcXRlBzx5x8Dk';
+        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const { trading_enabled, max_position_usdc, min_edge_threshold, daily_loss_limit } = req.body;
         // Upsert config (single row)
         const sbRes = await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/trading_config?id=eq.1', {

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -1228,11 +1228,11 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
             const publicUrl = `https://pub-70c436931e9e4611a135e7405c596611.r2.dev/${fileKey}`;
 
             // Update Supabase job record
-            const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
+            const sbKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
             const col = imageType === 'hero' ? 'hero_image_url' : 'thumbnail_url';
             await fetch(`https://fdabygmromuqtysitodp.supabase.co/rest/v1/content_studio_jobs?id=eq.${encodeURIComponent(jobId)}`, {
               method: 'PATCH',
-              headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}`, 'Content-Type': 'application/json' },
+              headers: { apikey: sbKey, Authorization: `Bearer ${sbKey}`, 'Content-Type': 'application/json' },
               body: JSON.stringify({ [col]: publicUrl })
             });
 
@@ -1256,12 +1256,12 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
         if (!clipUrl || !platform || !jobId) {
           return res.status(400).json({ error: 'clipUrl, platform, and jobId are required' });
         }
-        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
+        const sbKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const sbRes = await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/social_clip_schedules', {
           method: 'POST',
           headers: {
-            apikey: anonKey,
-            Authorization: `Bearer ${anonKey}`,
+            apikey: sbKey,
+            Authorization: `Bearer ${sbKey}`,
             'Content-Type': 'application/json',
             'Prefer': 'return=representation'
           },
@@ -1279,9 +1279,9 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
     this.app.get('/api/content-studio/jobs', async (req, res) => {
       try {
         const limit = Math.min(parseInt(req.query.limit) || 10, 50);
-        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
+        const sbKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const sbRes = await fetch(`https://fdabygmromuqtysitodp.supabase.co/rest/v1/content_studio_jobs?order=created_at.desc&limit=${limit}`, {
-          headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` }
+          headers: { apikey: sbKey, Authorization: `Bearer ${sbKey}` }
         });
         res.json(await sbRes.json());
       } catch (err) { res.status(500).json({ error: err.message }); }
@@ -1289,9 +1289,9 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
 
     this.app.get('/api/content-studio/jobs/:id', async (req, res) => {
       try {
-        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
+        const sbKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const sbRes = await fetch(`https://fdabygmromuqtysitodp.supabase.co/rest/v1/content_studio_jobs?id=eq.${encodeURIComponent(req.params.id)}`, {
-          headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` }
+          headers: { apikey: sbKey, Authorization: `Bearer ${sbKey}` }
         });
         const rows = await sbRes.json();
         if (!rows.length) return res.status(404).json({ error: 'Job not found' });
@@ -1311,8 +1311,8 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
           usdcBalance = balance;
         } catch { usdcBalance = 0; }
 
-        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
-        const headers = { apikey: anonKey, Authorization: `Bearer ${anonKey}` };
+        const sbKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
+        const headers = { apikey: sbKey, Authorization: `Bearer ${sbKey}` };
 
         const [closedRes, openRes] = await Promise.all([
           fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/trading_positions?status=eq.closed&select=pnl', { headers }),
@@ -1340,10 +1340,10 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
         if (!mcRes.ok) return res.status(mcRes.status).json(data);
 
         // Save simulation to Supabase
-        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
+        const sbKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/trading_simulations', {
           method: 'POST',
-          headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}`, 'Content-Type': 'application/json' },
+          headers: { apikey: sbKey, Authorization: `Bearer ${sbKey}`, 'Content-Type': 'application/json' },
           body: JSON.stringify({
             asset: data.asset, question: data.question, target: data.target,
             probability: data.probability, confidence_lower: data.confidence_lower,
@@ -1378,9 +1378,9 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
     // ─── Trading: Positions ─────────────────────────────────
     this.app.get('/api/trading/positions', async (req, res) => {
       try {
-        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
+        const sbKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const sbRes = await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/trading_positions?status=eq.open&order=created_at.desc&limit=50', {
-          headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` }
+          headers: { apikey: sbKey, Authorization: `Bearer ${sbKey}` }
         });
         res.json(await sbRes.json());
       } catch (err) { res.status(500).json({ error: err.message }); }
@@ -1389,9 +1389,9 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
     // ─── Trading: Simulations ───────────────────────────────
     this.app.get('/api/trading/simulations', async (req, res) => {
       try {
-        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
+        const sbKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const sbRes = await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/trading_simulations?select=asset,probability,current_price,macro_factors,created_at&order=created_at.desc&limit=10', {
-          headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` }
+          headers: { apikey: sbKey, Authorization: `Bearer ${sbKey}` }
         });
         res.json(await sbRes.json());
       } catch (err) { res.status(500).json({ error: err.message }); }
@@ -1400,9 +1400,9 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
     // ─── Trading: Config ────────────────────────────────────
     this.app.get('/api/trading/config', async (req, res) => {
       try {
-        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
+        const sbKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const sbRes = await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/trading_config?id=eq.1&select=*', {
-          headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` }
+          headers: { apikey: sbKey, Authorization: `Bearer ${sbKey}` }
         });
         const rows = await sbRes.json();
         res.json(rows[0] || { trading_enabled: false, max_position_usdc: 25, min_edge_threshold: 25, daily_loss_limit: 50 });
@@ -1411,12 +1411,12 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
 
     this.app.post('/api/trading/config', async (req, res) => {
       try {
-        const anonKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
+        const sbKey = SB_SERVICE_ROLE_KEY; // service_role (server-side only) — was a hardcoded anon literal
         const { trading_enabled, max_position_usdc, min_edge_threshold, daily_loss_limit } = req.body;
         // Upsert config (single row)
         const sbRes = await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/trading_config?id=eq.1', {
           method: 'PATCH',
-          headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}`, 'Content-Type': 'application/json', 'Prefer': 'return=representation' },
+          headers: { apikey: sbKey, Authorization: `Bearer ${sbKey}`, 'Content-Type': 'application/json', 'Prefer': 'return=representation' },
           body: JSON.stringify({ trading_enabled, max_position_usdc, min_edge_threshold, daily_loss_limit })
         });
         const result = await sbRes.json();
@@ -1424,7 +1424,7 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
           // Insert if no row exists
           await fetch('https://fdabygmromuqtysitodp.supabase.co/rest/v1/trading_config', {
             method: 'POST',
-            headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}`, 'Content-Type': 'application/json' },
+            headers: { apikey: sbKey, Authorization: `Bearer ${sbKey}`, 'Content-Type': 'application/json' },
             body: JSON.stringify({ id: 1, trading_enabled, max_position_usdc, min_edge_threshold, daily_loss_limit })
           });
         }

--- a/src/trading/polymarket_scanner.py
+++ b/src/trading/polymarket_scanner.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Polymarket market scanner — finds commodity/crypto markets via Gamma API."""
 
+import os
 import re
 import requests
 import json
@@ -22,7 +23,26 @@ KEYWORDS = {
 }
 
 SUPABASE_URL = "https://fdabygmromuqtysitodp.supabase.co/rest/v1"
-SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkYWJ5Z21yb211cXR5c2l0b2RwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTk2NjI2OTQsImV4cCI6MjA3NTIzODY5NH0.6JJMkPXBufpLxlisH1ig32Xm8YM3p0jcXRlBzx5x8Dk"
+
+
+def _service_role_key():
+    """Supabase service-role key — SERVER-SIDE ONLY (never exposed). Prefer the
+    environment; fall back to reading the root .env the rest of QClaw uses.
+    Replaces the hardcoded anon-key literal (anon→service-role migration)."""
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    if key:
+        return key
+    try:
+        with open("/root/.quantumclaw/.env") as fh:
+            for line in fh:
+                if line.startswith("SUPABASE_SERVICE_ROLE_KEY="):
+                    return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return ""
+
+
+SUPABASE_KEY = _service_role_key()
 
 
 def fetch_markets():


### PR DESCRIPTION
**Security hygiene — removes the hardcoded anon JWT literal (`x5x8Dk`) from committed source, swaps to service-role from env. Server-side only. NOT deployed — awaiting sign-off.**

Part of the Supabase anon→service-role migration (consumer map: `docs/runbooks/supabase-anon-consumer-map-2026-07-11.md`).

## Changes
- **`server.js`**: hoisted `SB_SERVICE_ROLE_KEY` (reads `/root/.quantumclaw/.env`, falls back to `process.env`), and pointed all **10** inline `const anonKey = '<anon JWT>'` (trading + content-studio routes) at it. Anon literal removed.
- **`polymarket_scanner.py`**: added `_service_role_key()` (env → root `.env` fallback), replaced the hardcoded anon literal at line 25.

## Verified
- `x5x8Dk` occurrences: **0 / 0** after the change.
- `node --check src/dashboard/server.js` ✓ · `python -m py_compile polymarket_scanner.py` ✓
- repo == deployed before the change (server.js=10, polymarket=1 both sides).

## Runtime assumption (verify at deploy)
Both run as **root** (all QClaw PM2 procs are root), so `/root/.quantumclaw/.env` is readable and `SUPABASE_SERVICE_ROLE_KEY` is present there. Deploy = `git pull` on qclaw + `pm2 restart quantumclaw --update-env`; re-run polymarket once to confirm it still writes `trading_markets`.

## Out of scope (deferred, audited)
- `server.js` Crete/GHL routes still use `creteEnv.SUPABASE_ANON_KEY` (env, not a literal) — separate migration.
- Meta Ads workflows `lrGcirtmOHb1xTq8` + `lu39mAN7epBRK3Kw` carry the literal in the n8n DB — follow-up slice.
- No `REVOKE`/RLS change; no `workout_*`.