### PR TITLE
feat(ghl-marketing): standalone Flow OS image card generator

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -16366,3 +16366,76 @@ References: memory `project_supabase_main_anon_rls_exposure`, `project_n8n_supab
 `project_n8n_edit_workflow_no_api_key` (corrected for the 2.4.8 publish model); PR #65 note (build-log EOF + server.js
 regions do not overlap). Deployment via SSH to n8n droplet + `docker exec n8n-postgres psql` and per-workflow
 published-version sync.
+
+---
+
+## [2026-07-14] GHL Marketing image staleness → standalone Flow OS image generator (LIVE end-to-end)
+
+**Branch:** `flowos-image-generator` (PR #65, **draft** — adversarial review owed before un-draft).
+**Status:** ✅ endpoint live on qclaw, ✅ workflow `Awo65rdSe5BvDHtC` PUT applied + verified. First scheduled
+production run: Wed 2026-07-15.
+
+### Root cause (read-only audit, same day)
+Images were never generated: `Assign Image URL` code node hardcoded 3 static R2 JPGs keyed by weekday
+(pain/value/offer-led), files unchanged since 27 Apr / 13 May. 20 most recent `marketing_drafts` rows → 3 unique
+`image_url`s. The healthy Crete generator (`/api/crete/generate-image`) was never wired to GHL Marketing.
+
+### Shipped
+- `src/flowos-marketing/generate-image-card.js` — standalone (zero crete-marketing imports), 1080×1350 PNG,
+  three card types (`editorial`/`stat`/`feature`), measure-then-center layout, 422-coded validation, logomark
+  fetched once from `https://media.flowos.tech/brand/logo-mark.png` and cached (text-only footer fallback).
+  Pill label hardcoded `FLOW OS` — internal `post_type` taxonomy cannot leak onto cards (fffb59b).
+- `server.js` — `POST /api/flowos/generate-image` after the Crete block; global auth middleware inherited,
+  `express-rate-limit` 20/min, uploads via `FLOWOS_R2_*` creds (`.env` read per-request, `process.env` fallback)
+  to `flowos-content` at `marketing/images/{uuid}.png`, public via `media.flowos.tech`. No stack traces in
+  responses (422 descriptive / 500 generic).
+- Host: Raleway Regular+SemiBold TTFs → `/usr/share/fonts/truetype/flowos/` + `fc-cache -f` (system-font
+  pattern; skipped @fontsource — ships woff2 only). Logo mark cropped from `FlowOsLogoWordmark.png` (alpha-trim,
+  268×455) → `flowos-content/brand/logo-mark.png`.
+- Workflow rewire: Claude prompt outputs `headline`/`stat`/`stat_label` (+ 3-field few-shot, value-led example);
+  `Assign Image URL` → `Build Image Request` (pain→editorial, value→stat w/ editorial degrade on null stat,
+  offer→feature) → `Generate Flow OS Image` (HTTP) → `Merge Image URL`; error output → `Image Gen Fallback`
+  (`image_url: null`, draft still saves) → `Alert: Image Gen Failed` (Telegram). Telegram draft-ID fix
+  `{{ $json[0].id }}` → `{{ $json.id }}`. Backup: `n8n-workflows/Awo65rdSe5BvDHtC.before-image-gen.json`.
+
+### Evidence (verbatim)
+Endpoint suite: valid editorial/stat → `{"success":true,"url":"https://media.flowos.tech/marketing/images/<uuid>.png",...}`;
+`{"success":false,"error":"card_type must be one of: editorial, stat, feature (got: bogus)"} [422]`;
+`{"success":false,"error":"stat_label is required for stat cards"} [422]`;
+`{"success":false,"error":"headline is required and must be a non-empty string"} [422]`; no-auth → `[401]`;
+Crete regression → `{"success":true,...}` (token unchanged post-restart). Cross-host from n8n droplet via
+`https://agentboardroom.flowos.tech/api/flowos/generate-image` + `Bearer $QCLAW_API_TOKEN` → success
+(token sha256 prefix `8bd25dcda796067c` identical on both hosts — no drift).
+PUT `https://webhook.flowos.tech/api/v1/workflows/Awo65rdSe5BvDHtC` → `HTTP 200`; re-GET:
+`updatedAt: 2026-07-14T19:47:19.151Z`, `versionId: 9f70057e-919b-492a-99de-7a02862434f1`, `active: true`,
+16 nodes, `settings: {"executionOrder": "v1", "callerPolicy": "workflowsFromSameOwner", "availableInMCP": true}`,
+error branch `Generate Flow OS Image --[err]--> Image Gen Fallback` present.
+Approved samples: editorial `2ea4de6e-c4ab-4089-95ab-f1a3261294ec.png`, stat
+`e6bab3d3-2837-4827-8497-cf8be63b6f78.png`, feature `3de34825-a5a8-49e7-b1c8-a44ac8584d07.png`.
+
+### Discoveries / gotchas
+- **n8n API key 401 RESOLVED**: qclaw `.env` `N8N_API_KEY` now returns 200 on `webhook.flowos.tech/api/v1`
+  (GET + PUT both used this session). May 2026 memory was stale; memory file updated.
+- n8n→qclaw calls MUST use `https://agentboardroom.flowos.tech/...` — dashboard binds `127.0.0.1:4000` only;
+  brief's `localhost:4000` is a different-droplet trap. Crete precedent uses `?token=` query auth; new node
+  uses the cleaner `Authorization: Bearer` header (verified through the tunnel).
+- Root CLI renders into `/tmp` hit `Error: EACCES: permission denied, open '/tmp/sample-editorial.png'` when the
+  file pre-existed owned by `flowos` (`fs.protected_regular` + sticky bit blocks root O_CREAT over others'
+  files). `rm` first.
+- Spec deviations (approved via samples): pill/badge label 2× spec size (10→20px, 9→18px — spec sizes illegible
+  at 1080px); type upsized + center-weighted layout per review round 2; editorial pill brand-only per round 3.
+
+### Residual / follow-ups
+- Observe Wed 2026-07-15 run end-to-end (first live generation; check Telegram draft message + `marketing_drafts.image_url`).
+- Adversarial review session against the branch, then un-draft PR #65.
+- `headline`/`stat`/`stat_label` are not persisted to `marketing_drafts` (image-gen only); add columns if the
+  approval UI should show/edit them.
+- `feature_line` hardcodes "Founders Offer: 3 months free with code GHLPOWER50" in `Build Image Request` —
+  update when the promo changes (also lives in the Claude system prompt).
+- Cron node labeled "MWF 07:00 UTC" but drafts historically land 11:00 UTC — label/timezone mismatch, benign,
+  worth renaming.
+- Old `marketing-templates/*.jpg` statics + unused `ghl-template-story.png` (emma-content-studio) can be
+  retired once the new pipeline proves out.
+
+References: memory `project_flowos_image_generator`, `project_n8n_api_key_401` (resolved),
+`reference_gh_not_on_qclaw_host`; PR #65; commits dae3b37, d4f4c1e, fffb59b.

--- a/n8n-workflows/Awo65rdSe5BvDHtC-ghl-marketing-content-generator.json
+++ b/n8n-workflows/Awo65rdSe5BvDHtC-ghl-marketing-content-generator.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-05-13T20:29:42.993Z",
+  "updatedAt": "2026-07-14T16:12:36.164Z",
   "createdAt": "2026-04-13T12:03:02.932Z",
   "id": "Awo65rdSe5BvDHtC",
   "name": "GHL Marketing: Content Generator",
@@ -43,26 +43,16 @@
     {
       "parameters": {
         "url": "https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts?select=hooks_used,instagram_hook_text&status=eq.published&order=created_at.desc&limit=10",
-        "sendHeaders": true,
-        "headerParameters": {
-          "parameters": [
-            {
-              "name": "apikey",
-              "value": "={{$env.SUPABASE_ANON_KEY}}"
-            },
-            {
-              "name": "Authorization",
-              "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
-            }
-          ]
-        },
+        "sendHeaders": false,
         "options": {
           "response": {
             "response": {
               "responseFormat": "json"
             }
           }
-        }
+        },
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpCustomAuth"
       },
       "id": "a1000001-0001-4000-8000-000000000003",
       "name": "Fetch Recent Hooks",
@@ -72,7 +62,13 @@
         640,
         304
       ],
-      "alwaysOutputData": true
+      "alwaysOutputData": true,
+      "credentials": {
+        "httpCustomAuth": {
+          "id": "q309m8yfLKGxywMb",
+          "name": "Supabase Service Role (main)"
+        }
+      }
     },
     {
       "parameters": {
@@ -108,7 +104,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ model: 'claude-sonnet-4-20250514', max_tokens: 2000, system: \"You are a marketing copywriter for GHL Support Specialist. Product: AI-powered 24/7 support for GoHighLevel users. URL: support.flowos.tech/ghl/landing. Price: $29/month or $290/year. Founders Offer: first 50 members get 3 months free with code GHLPOWER50.\\n\\nTone: Direct, practical, slightly irreverent. Speak like a GHL power user. No corporate language. Short sentences. No em dashes. No hashtags in body copy (Instagram hashtags go in a separate block).\\n\\nNever say: game-changer, revolutionary, unlock your potential, or generic SaaS language.\\n\\nThree pain points to rotate:\\n1. Time lost \\u2014 hours in YouTube, Facebook groups, help docs\\n2. Support frustration \\u2014 tickets take days, group answers unreliable\\n3. Confidence gap \\u2014 'I know GHL can do this, I just don't know how'\\n\\nOne promise: Ask it anything about GHL. Get an expert answer in seconds.\\n\\nUse specific GHL terms: workflows, automations, pipelines, funnels, SaaS mode, merge fields, calendars, triggers, actions.\", messages: [{ role: 'user', content: 'Generate a ' + $json.postType + ' organic post for GHL Support Specialist. Today is ' + new Date().toLocaleDateString('en-US', {weekday:'long',month:'long',day:'numeric'}) + '.\\n\\nProvide output as JSON with these exact keys:\\n- facebook_post (plain text, no hashtags, 100-200 words)\\n- linkedin_post (plain text, no hashtags, 80-150 words)\\n- instagram_caption (with hashtag block at end, 60-120 words before hashtags)\\n- instagram_hook_text (5-8 words, overlay text for image)\\n- ad_headline (under 10 words)\\n- ad_body (80-120 words, includes pain point + solution + Founders Offer + URL with UTMs: support.flowos.tech/ghl/landing?utm_source=facebook&utm_medium=paid_social&utm_campaign=founders_offer)\\n- ad_cta (3-4 words for button text)\\n- retargeting_copy (60-100 words, acknowledges they visited, restates value, urgency)\\n\\nDo NOT repeat any of these recently used hooks: ' + $json.recentHooks + '\\n\\nReturn ONLY valid JSON. No markdown fences. No explanation.' }] }) }}",
+        "jsonBody": "={{ JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 2000, system: \"You are a marketing copywriter for GHL Support Specialist. Product: AI-powered 24/7 support for GoHighLevel users. URL: support.flowos.tech/ghl/landing. Price: $29/month or $290/year. Founders Offer: first 50 members get 3 months free with code GHLPOWER50.\\n\\nTone: Direct, practical, slightly irreverent. Speak like a GHL power user. No corporate language. Short sentences. No em dashes. No hashtags in body copy (Instagram hashtags go in a separate block).\\n\\nNever say: game-changer, revolutionary, unlock your potential, or generic SaaS language.\\n\\nThree pain points to rotate:\\n1. Time lost \\u2014 hours in YouTube, Facebook groups, help docs\\n2. Support frustration \\u2014 tickets take days, group answers unreliable\\n3. Confidence gap \\u2014 'I know GHL can do this, I just don't know how'\\n\\nOne promise: Ask it anything about GHL. Get an expert answer in seconds.\\n\\nUse specific GHL terms: workflows, automations, pipelines, funnels, SaaS mode, merge fields, calendars, triggers, actions.\", messages: [{ role: 'user', content: 'Generate a ' + $json.postType + ' organic post for GHL Support Specialist. Today is ' + new Date().toLocaleDateString('en-US', {weekday:'long',month:'long',day:'numeric'}) + '.\\n\\nProvide output as JSON with these exact keys:\\n- facebook_post (plain text, no hashtags, 100-200 words)\\n- linkedin_post (plain text, no hashtags, 80-150 words)\\n- instagram_caption (with hashtag block at end, 60-120 words before hashtags)\\n- instagram_hook_text (5-8 words, overlay text for image)\\n- ad_headline (under 10 words)\\n- ad_body (80-120 words, includes pain point + solution + Founders Offer + URL with UTMs: support.flowos.tech/ghl/landing?utm_source=facebook&utm_medium=paid_social&utm_campaign=founders_offer)\\n- ad_cta (3-4 words for button text)\\n- retargeting_copy (60-100 words, acknowledges they visited, restates value, urgency)\\n- headline (punchy 8-12 word hook, no full stop, stands alone without the caption body)\\n- stat (a specific statistic, number, or percentage relevant to this post; null if not applicable)\\n- stat_label (6-10 word phrase contextualising the stat; null if stat is null)\\n\\nExample of the three new fields for a value-led Wednesday post:\\n\"headline\": \"Every GHL answer you need in under thirty seconds\",\\n\"stat\": \"73%\",\\n\"stat_label\": \"of GHL builders lose an hour daily searching for answers\"\\n\\nDo NOT repeat any of these recently used hooks: ' + $json.recentHooks + '\\n\\nReturn ONLY valid JSON. No markdown fences. No explanation.' }] }) }}",
         "options": {
           "response": {
             "response": {
@@ -127,8 +123,8 @@
       ],
       "credentials": {
         "httpHeaderAuth": {
-          "id": "V9YcuDfp9lqydyDH",
-          "name": "Anthropic Header Auth"
+          "id": "LUUeAdpObQjzRbct",
+          "name": "Anthropic - QuantumClaw"
         }
       }
     },
@@ -153,20 +149,12 @@
         "headerParameters": {
           "parameters": [
             {
-              "name": "apikey",
-              "value": "={{$env.SUPABASE_ANON_KEY}}"
-            },
-            {
               "name": "Content-Type",
               "value": "application/json"
             },
             {
               "name": "Prefer",
               "value": "return=representation"
-            },
-            {
-              "name": "Authorization",
-              "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
             }
           ]
         },
@@ -179,21 +167,29 @@
               "responseFormat": "json"
             }
           }
-        }
+        },
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpCustomAuth"
       },
       "id": "a1000001-0001-4000-8000-000000000007",
       "name": "Save to Supabase",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        1744,
+        2128,
         304
-      ]
+      ],
+      "credentials": {
+        "httpCustomAuth": {
+          "id": "q309m8yfLKGxywMb",
+          "name": "Supabase Service Role (main)"
+        }
+      }
     },
     {
       "parameters": {
         "chatId": "1375806243",
-        "text": "=\ud83d\udce3 <b>New GHL marketing draft ready for review</b>\nType: {{ $('Parse Response').first().json.post_type }}\nDraft ID: <code>{{ $json[0].id }}</code>\n\nReview at https://agentboardroom.flowos.tech (GHL Marketing tab).",
+        "text": "=📣 <b>New GHL marketing draft ready for review</b>\nType: {{ $('Parse Response').first().json.post_type }}\nDraft ID: <code>{{ $json.id }}</code>\n\nReview at https://agentboardroom.flowos.tech (GHL Marketing tab).",
         "additionalFields": {
           "parse_mode": "HTML"
         }
@@ -203,7 +199,7 @@
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
       "position": [
-        1904,
+        2304,
         304
       ],
       "webhookId": "78c28696-5041-402a-a116-2f5c00bc05d3",
@@ -216,19 +212,6 @@
     },
     {
       "parameters": {
-        "jsCode": "// Map post_type -> R2 template URL; rotation for Mon/Wed/Fri.\nconst BASE = 'https://pub-1fa192ebc8ff40dba2b9a0f1890e6f7a.r2.dev/marketing-templates';\nconst IMAGE_MAP = {\n  'pain-led':  BASE + '/ghl-template-pain-led.jpg',\n  'value-led': BASE + '/ghl-template-value-led.jpg',\n  'offer-led': BASE + '/ghl-template-offer-led.jpg'\n};\nconst draft = $input.first().json;\nconst image_url = IMAGE_MAP[draft.post_type] || IMAGE_MAP['value-led'];\nreturn [{ json: { ...draft, image_url } }];"
-      },
-      "id": "a1000001-0001-4000-8000-000000000009",
-      "name": "Assign Image URL",
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
-      "position": [
-        1424,
-        304
-      ]
-    },
-    {
-      "parameters": {
         "jsCode": "// Cap IG hashtags to 5; defensive against AI drift\n// Pattern source: kJ2EdkOeEAwVbMwU 'Cap Hashtags' (commit e4ad82c, Apr 29)\nconst MAX_HASHTAGS = 5;\nconst item = $input.first().json;\nconst caption = item.instagram_caption;\nif (typeof caption !== 'string' || !caption) {\n  return [{ json: item }];\n}\nlet count = 0;\nconst stripped = caption.replace(/#\\w+/g, (m) => (++count <= MAX_HASHTAGS ? m : ''));\nconst cleaned = stripped\n  .replace(/[ \\t]+/g, ' ')\n  .replace(/\\n[ \\t]+/g, '\\n')\n  .replace(/\\n{3,}/g, '\\n\\n')\n  .trim();\nreturn [{\n  json: {\n    ...item,\n    instagram_caption: cleaned,\n    _hashtag_cap_applied: { max: MAX_HASHTAGS, original_count: count, dropped: Math.max(0, count - MAX_HASHTAGS), at: new Date().toISOString() }\n  }\n}];"
       },
       "id": "a1000001-0001-4000-8000-000000000020",
@@ -236,7 +219,7 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1504,
+        1952,
         304
       ]
     },
@@ -275,7 +258,7 @@
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
       "position": [
-        2160,
+        2480,
         304
       ],
       "retryOnFail": true,
@@ -289,6 +272,107 @@
         }
       },
       "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "jsCode": "// Map post_type -> card_type; build the /api/flowos/generate-image request body.\n// Mon/pain-led -> editorial; Wed/value-led -> stat (editorial if no stat); Fri/offer-led -> feature.\nconst draft = $input.first().json;\nconst CARD_MAP = { 'pain-led': 'editorial', 'value-led': 'stat', 'offer-led': 'feature' };\nlet card_type = CARD_MAP[draft.post_type] || 'editorial';\nif (card_type === 'stat' && (!draft.stat || !draft.stat_label)) card_type = 'editorial';\n\nconst firstSentences = (draft.facebook_post || '')\n  .split(/(?<=[.!?])\\s+/).slice(0, 2).join(' ').slice(0, 220);\n\nconst imageRequest = {\n  card_type,\n  post_type: draft.post_type,\n  headline: draft.headline || draft.ad_headline || draft.instagram_hook_text || '',\n  subtext: firstSentences || draft.instagram_hook_text || ''\n};\nif (card_type === 'stat') {\n  imageRequest.stat = String(draft.stat);\n  imageRequest.stat_label = draft.stat_label;\n}\nif (card_type === 'feature') {\n  imageRequest.feature_line = 'Founders Offer: 3 months free with code GHLPOWER50';\n}\nreturn [{ json: { draft, imageRequest } }];"
+      },
+      "id": "f71a3ad0-b2f6-4bcd-bf9e-132e803acb92",
+      "name": "Build Image Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1424,
+        304
+      ]
+    },
+    {
+      "parameters": {
+        "url": "https://agentboardroom.flowos.tech/api/flowos/generate-image",
+        "method": "POST",
+        "options": {
+          "timeout": 60000,
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          }
+        },
+        "jsonBody": "={{ JSON.stringify($json.imageRequest) }}",
+        "sendBody": true,
+        "sendHeaders": true,
+        "specifyBody": "json",
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $env.QCLAW_API_TOKEN }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        }
+      },
+      "id": "f4bedc9c-2640-48b0-9176-a5a3d4501a15",
+      "name": "Generate Flow OS Image",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1600,
+        304
+      ],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const resp = $input.first().json;\nif (!resp.url) throw new Error(\n  'Flow OS image gen returned no URL. Response: ' +\n  JSON.stringify(resp).slice(0,300)\n);\nconst draft = $('Build Image Request').first().json.draft;\nreturn [{ json: { ...draft, image_url: resp.url } }];"
+      },
+      "id": "e3c0d25d-a783-49fc-b74e-791b69dfa8ed",
+      "name": "Merge Image URL",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1776,
+        304
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Image generation failed - continue with a null image so the draft still saves.\nconst draft = $('Build Image Request').first().json.draft;\nconst errItem = $input.first().json;\nconst detail = JSON.stringify(errItem.error ?? errItem).slice(0, 300);\nreturn [{ json: { ...draft, image_url: null, _image_gen_error: detail } }];"
+      },
+      "id": "a06cf54a-f654-4617-8e85-acb4638df44c",
+      "name": "Image Gen Fallback",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1600,
+        520
+      ]
+    },
+    {
+      "parameters": {
+        "text": "=⚠️ <b>GHL marketing image generation FAILED</b>\nType: {{ $json.post_type }}\nDraft continues with no image. Error: <code>{{ $json._image_gen_error }}</code>",
+        "chatId": "1375806243",
+        "additionalFields": {
+          "parse_mode": "HTML"
+        }
+      },
+      "id": "dbd7422a-a749-4972-b7ee-bf5b4ab8dba3",
+      "name": "Alert: Image Gen Failed",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        1776,
+        680
+      ],
+      "credentials": {
+        "telegramApi": {
+          "id": "UR6xX8CchGBKaP3h",
+          "name": "Flow States Ads Bot"
+        }
+      }
     }
   ],
   "connections": {
@@ -356,7 +440,7 @@
       "main": [
         [
           {
-            "node": "Assign Image URL",
+            "node": "Build Image Request",
             "type": "main",
             "index": 0
           }
@@ -368,17 +452,6 @@
         [
           {
             "node": "Send to Telegram",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Assign Image URL": {
-      "main": [
-        [
-          {
-            "node": "Cap Hashtags",
             "type": "main",
             "index": 0
           }
@@ -411,6 +484,62 @@
           }
         ]
       ]
+    },
+    "Build Image Request": {
+      "main": [
+        [
+          {
+            "node": "Generate Flow OS Image",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generate Flow OS Image": {
+      "main": [
+        [
+          {
+            "node": "Merge Image URL",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Image Gen Fallback",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Image URL": {
+      "main": [
+        [
+          {
+            "node": "Cap Hashtags",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Image Gen Fallback": {
+      "main": [
+        [
+          {
+            "node": "Cap Hashtags",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Alert: Image Gen Failed",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
   "settings": {
@@ -425,9 +554,9 @@
   },
   "meta": null,
   "pinData": {},
-  "versionId": "9404b9b6-a95d-4610-9932-7864f158fd7d",
-  "activeVersionId": "9404b9b6-a95d-4610-9932-7864f158fd7d",
-  "versionCounter": 69,
+  "versionId": "593188b5-7b3b-427b-a87e-4a250553adc8",
+  "activeVersionId": "7ef7d704-43b5-4bd3-b0f0-cfa787f6646d",
+  "versionCounter": 99,
   "triggerCount": 1,
   "shared": [
     {
@@ -452,7 +581,7 @@
             "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
             "projectId": "KwpTDWcFWL3DfyW3",
             "user": {
-              "updatedAt": "2026-05-13T02:04:11.362Z",
+              "updatedAt": "2026-07-14T18:38:42.164Z",
               "createdAt": "2025-06-06T11:27:13.858Z",
               "id": "b1512bca-25b8-4b8b-add0-b86540e5144d",
               "email": "tysonvenables@protonmail.com",
@@ -479,7 +608,7 @@
               },
               "disabled": false,
               "mfaEnabled": false,
-              "lastActiveAt": "2026-05-13",
+              "lastActiveAt": "2026-07-14",
               "isPending": false
             }
           }
@@ -489,9 +618,9 @@
   ],
   "tags": [],
   "activeVersion": {
-    "updatedAt": "2026-05-13T20:29:42.997Z",
-    "createdAt": "2026-05-13T20:29:42.997Z",
-    "versionId": "9404b9b6-a95d-4610-9932-7864f158fd7d",
+    "updatedAt": "2026-06-18T20:20:22.221Z",
+    "createdAt": "2026-06-18T20:20:20.248Z",
+    "versionId": "7ef7d704-43b5-4bd3-b0f0-cfa787f6646d",
     "workflowId": "Awo65rdSe5BvDHtC",
     "nodes": [
       {
@@ -595,7 +724,7 @@
           },
           "sendBody": true,
           "specifyBody": "json",
-          "jsonBody": "={{ JSON.stringify({ model: 'claude-sonnet-4-20250514', max_tokens: 2000, system: \"You are a marketing copywriter for GHL Support Specialist. Product: AI-powered 24/7 support for GoHighLevel users. URL: support.flowos.tech/ghl/landing. Price: $29/month or $290/year. Founders Offer: first 50 members get 3 months free with code GHLPOWER50.\\n\\nTone: Direct, practical, slightly irreverent. Speak like a GHL power user. No corporate language. Short sentences. No em dashes. No hashtags in body copy (Instagram hashtags go in a separate block).\\n\\nNever say: game-changer, revolutionary, unlock your potential, or generic SaaS language.\\n\\nThree pain points to rotate:\\n1. Time lost \\u2014 hours in YouTube, Facebook groups, help docs\\n2. Support frustration \\u2014 tickets take days, group answers unreliable\\n3. Confidence gap \\u2014 'I know GHL can do this, I just don't know how'\\n\\nOne promise: Ask it anything about GHL. Get an expert answer in seconds.\\n\\nUse specific GHL terms: workflows, automations, pipelines, funnels, SaaS mode, merge fields, calendars, triggers, actions.\", messages: [{ role: 'user', content: 'Generate a ' + $json.postType + ' organic post for GHL Support Specialist. Today is ' + new Date().toLocaleDateString('en-US', {weekday:'long',month:'long',day:'numeric'}) + '.\\n\\nProvide output as JSON with these exact keys:\\n- facebook_post (plain text, no hashtags, 100-200 words)\\n- linkedin_post (plain text, no hashtags, 80-150 words)\\n- instagram_caption (with hashtag block at end, 60-120 words before hashtags)\\n- instagram_hook_text (5-8 words, overlay text for image)\\n- ad_headline (under 10 words)\\n- ad_body (80-120 words, includes pain point + solution + Founders Offer + URL with UTMs: support.flowos.tech/ghl/landing?utm_source=facebook&utm_medium=paid_social&utm_campaign=founders_offer)\\n- ad_cta (3-4 words for button text)\\n- retargeting_copy (60-100 words, acknowledges they visited, restates value, urgency)\\n\\nDo NOT repeat any of these recently used hooks: ' + $json.recentHooks + '\\n\\nReturn ONLY valid JSON. No markdown fences. No explanation.' }] }) }}",
+          "jsonBody": "={{ JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 2000, system: \"You are a marketing copywriter for GHL Support Specialist. Product: AI-powered 24/7 support for GoHighLevel users. URL: support.flowos.tech/ghl/landing. Price: $29/month or $290/year. Founders Offer: first 50 members get 3 months free with code GHLPOWER50.\\n\\nTone: Direct, practical, slightly irreverent. Speak like a GHL power user. No corporate language. Short sentences. No em dashes. No hashtags in body copy (Instagram hashtags go in a separate block).\\n\\nNever say: game-changer, revolutionary, unlock your potential, or generic SaaS language.\\n\\nThree pain points to rotate:\\n1. Time lost \\u2014 hours in YouTube, Facebook groups, help docs\\n2. Support frustration \\u2014 tickets take days, group answers unreliable\\n3. Confidence gap \\u2014 'I know GHL can do this, I just don't know how'\\n\\nOne promise: Ask it anything about GHL. Get an expert answer in seconds.\\n\\nUse specific GHL terms: workflows, automations, pipelines, funnels, SaaS mode, merge fields, calendars, triggers, actions.\", messages: [{ role: 'user', content: 'Generate a ' + $json.postType + ' organic post for GHL Support Specialist. Today is ' + new Date().toLocaleDateString('en-US', {weekday:'long',month:'long',day:'numeric'}) + '.\\n\\nProvide output as JSON with these exact keys:\\n- facebook_post (plain text, no hashtags, 100-200 words)\\n- linkedin_post (plain text, no hashtags, 80-150 words)\\n- instagram_caption (with hashtag block at end, 60-120 words before hashtags)\\n- instagram_hook_text (5-8 words, overlay text for image)\\n- ad_headline (under 10 words)\\n- ad_body (80-120 words, includes pain point + solution + Founders Offer + URL with UTMs: support.flowos.tech/ghl/landing?utm_source=facebook&utm_medium=paid_social&utm_campaign=founders_offer)\\n- ad_cta (3-4 words for button text)\\n- retargeting_copy (60-100 words, acknowledges they visited, restates value, urgency)\\n\\nDo NOT repeat any of these recently used hooks: ' + $json.recentHooks + '\\n\\nReturn ONLY valid JSON. No markdown fences. No explanation.' }] }) }}",
           "options": {
             "response": {
               "response": {
@@ -614,8 +743,8 @@
         ],
         "credentials": {
           "httpHeaderAuth": {
-            "id": "V9YcuDfp9lqydyDH",
-            "name": "Anthropic Header Auth"
+            "id": "LUUeAdpObQjzRbct",
+            "name": "Anthropic - QuantumClaw"
           }
         }
       },
@@ -680,7 +809,7 @@
       {
         "parameters": {
           "chatId": "1375806243",
-          "text": "=\ud83d\udce3 <b>New GHL marketing draft ready for review</b>\nType: {{ $('Parse Response').first().json.post_type }}\nDraft ID: <code>{{ $json[0].id }}</code>\n\nReview at https://agentboardroom.flowos.tech (GHL Marketing tab).",
+          "text": "=📣 <b>New GHL marketing draft ready for review</b>\nType: {{ $('Parse Response').first().json.post_type }}\nDraft ID: <code>{{ $json[0].id }}</code>\n\nReview at https://agentboardroom.flowos.tech (GHL Marketing tab).",
           "additionalFields": {
             "parse_mode": "HTML"
           }
@@ -723,7 +852,7 @@
         "type": "n8n-nodes-base.code",
         "typeVersion": 2,
         "position": [
-          1504,
+          1600,
           304
         ]
       },
@@ -901,15 +1030,15 @@
       }
     },
     "authors": "Tyson Venables",
-    "name": null,
-    "description": null,
+    "name": "Version 7ef7d704",
+    "description": "",
     "autosaved": false,
     "workflowPublishHistory": [
       {
-        "createdAt": "2026-05-13T20:29:43.194Z",
-        "id": 966,
+        "createdAt": "2026-06-18T20:20:22.213Z",
+        "id": 1014,
         "workflowId": "Awo65rdSe5BvDHtC",
-        "versionId": "9404b9b6-a95d-4610-9932-7864f158fd7d",
+        "versionId": "7ef7d704-43b5-4bd3-b0f0-cfa787f6646d",
         "event": "activated",
         "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d"
       }

--- a/n8n-workflows/Awo65rdSe5BvDHtC.before-image-gen.json
+++ b/n8n-workflows/Awo65rdSe5BvDHtC.before-image-gen.json
@@ -1,0 +1,914 @@
+{
+    "updatedAt": "2026-07-14T16:12:36.164Z",
+    "createdAt": "2026-04-13T12:03:02.932Z",
+    "id": "Awo65rdSe5BvDHtC",
+    "name": "GHL Marketing: Content Generator",
+    "description": null,
+    "active": true,
+    "isArchived": false,
+    "nodes": [
+        {
+            "parameters": {
+                "rule": {
+                    "interval": [
+                        {
+                            "field": "cronExpression",
+                            "expression": "0 7 * * 1,3,5"
+                        }
+                    ]
+                }
+            },
+            "id": "a1000001-0001-4000-8000-000000000001",
+            "name": "Cron MWF 07:00 UTC",
+            "type": "n8n-nodes-base.scheduleTrigger",
+            "typeVersion": 1.2,
+            "position": [
+                208,
+                304
+            ]
+        },
+        {
+            "parameters": {
+                "jsCode": "const dayOfWeek = new Date().getDay();\nconst postTypes = { 1: 'pain-led', 3: 'value-led', 5: 'offer-led' };\nconst postType = postTypes[dayOfWeek] || 'value-led';\nreturn [{ json: { postType, date: new Date().toISOString().split('T')[0] } }];"
+            },
+            "id": "a1000001-0001-4000-8000-000000000002",
+            "name": "Determine Post Type",
+            "type": "n8n-nodes-base.code",
+            "typeVersion": 2,
+            "position": [
+                432,
+                304
+            ]
+        },
+        {
+            "parameters": {
+                "url": "https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts?select=hooks_used,instagram_hook_text&status=eq.published&order=created_at.desc&limit=10",
+                "sendHeaders": false,
+                "options": {
+                    "response": {
+                        "response": {
+                            "responseFormat": "json"
+                        }
+                    }
+                },
+                "authentication": "genericCredentialType",
+                "genericAuthType": "httpCustomAuth"
+            },
+            "id": "a1000001-0001-4000-8000-000000000003",
+            "name": "Fetch Recent Hooks",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                640,
+                304
+            ],
+            "alwaysOutputData": true,
+            "credentials": {
+                "httpCustomAuth": {
+                    "id": "q309m8yfLKGxywMb",
+                    "name": "Supabase Service Role (main)"
+                }
+            }
+        },
+        {
+            "parameters": {
+                "jsCode": "const postType = $('Determine Post Type').first().json.postType;\nconst recentRows = $input.first().json;\nlet recentHooks = [];\nif (Array.isArray(recentRows)) {\n  recentRows.forEach(r => {\n    if (r.instagram_hook_text) recentHooks.push(r.instagram_hook_text);\n    if (Array.isArray(r.hooks_used)) recentHooks.push(...r.hooks_used);\n  });\n}\nrecentHooks = [...new Set(recentHooks)];\nreturn [{ json: { postType, recentHooks: recentHooks.join(', ') || 'none' } }];"
+            },
+            "id": "a1000001-0001-4000-8000-000000000004",
+            "name": "Prepare Prompt Data",
+            "type": "n8n-nodes-base.code",
+            "typeVersion": 2,
+            "position": [
+                864,
+                304
+            ]
+        },
+        {
+            "parameters": {
+                "method": "POST",
+                "url": "https://api.anthropic.com/v1/messages",
+                "authentication": "genericCredentialType",
+                "genericAuthType": "httpHeaderAuth",
+                "sendHeaders": true,
+                "headerParameters": {
+                    "parameters": [
+                        {
+                            "name": "anthropic-version",
+                            "value": "2023-06-01"
+                        },
+                        {
+                            "name": "content-type",
+                            "value": "application/json"
+                        }
+                    ]
+                },
+                "sendBody": true,
+                "specifyBody": "json",
+                "jsonBody": "={{ JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 2000, system: \"You are a marketing copywriter for GHL Support Specialist. Product: AI-powered 24/7 support for GoHighLevel users. URL: support.flowos.tech/ghl/landing. Price: $29/month or $290/year. Founders Offer: first 50 members get 3 months free with code GHLPOWER50.\\n\\nTone: Direct, practical, slightly irreverent. Speak like a GHL power user. No corporate language. Short sentences. No em dashes. No hashtags in body copy (Instagram hashtags go in a separate block).\\n\\nNever say: game-changer, revolutionary, unlock your potential, or generic SaaS language.\\n\\nThree pain points to rotate:\\n1. Time lost \\u2014 hours in YouTube, Facebook groups, help docs\\n2. Support frustration \\u2014 tickets take days, group answers unreliable\\n3. Confidence gap \\u2014 'I know GHL can do this, I just don't know how'\\n\\nOne promise: Ask it anything about GHL. Get an expert answer in seconds.\\n\\nUse specific GHL terms: workflows, automations, pipelines, funnels, SaaS mode, merge fields, calendars, triggers, actions.\", messages: [{ role: 'user', content: 'Generate a ' + $json.postType + ' organic post for GHL Support Specialist. Today is ' + new Date().toLocaleDateString('en-US', {weekday:'long',month:'long',day:'numeric'}) + '.\\n\\nProvide output as JSON with these exact keys:\\n- facebook_post (plain text, no hashtags, 100-200 words)\\n- linkedin_post (plain text, no hashtags, 80-150 words)\\n- instagram_caption (with hashtag block at end, 60-120 words before hashtags)\\n- instagram_hook_text (5-8 words, overlay text for image)\\n- ad_headline (under 10 words)\\n- ad_body (80-120 words, includes pain point + solution + Founders Offer + URL with UTMs: support.flowos.tech/ghl/landing?utm_source=facebook&utm_medium=paid_social&utm_campaign=founders_offer)\\n- ad_cta (3-4 words for button text)\\n- retargeting_copy (60-100 words, acknowledges they visited, restates value, urgency)\\n\\nDo NOT repeat any of these recently used hooks: ' + $json.recentHooks + '\\n\\nReturn ONLY valid JSON. No markdown fences. No explanation.' }] }) }}",
+                "options": {
+                    "response": {
+                        "response": {
+                            "responseFormat": "json"
+                        }
+                    }
+                }
+            },
+            "id": "a1000001-0001-4000-8000-000000000005",
+            "name": "Generate Content (Claude)",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                1088,
+                304
+            ],
+            "credentials": {
+                "httpHeaderAuth": {
+                    "id": "LUUeAdpObQjzRbct",
+                    "name": "Anthropic - QuantumClaw"
+                }
+            }
+        },
+        {
+            "parameters": {
+                "jsCode": "const response = $input.first().json;\nconst content = response.content?.[0]?.text;\nif (!content) throw new Error('No content in Claude response: ' + JSON.stringify(response).substring(0, 500));\n\nlet parsed;\ntry {\n  const cleaned = content.replace(/```json\\n?/g, '').replace(/```\\n?/g, '').trim();\n  parsed = JSON.parse(cleaned);\n} catch (e) {\n  throw new Error('Failed to parse Claude response: ' + e.message + '\\nRaw: ' + content.substring(0, 500));\n}\n\nreturn [{\n  json: {\n    ...parsed,\n    post_type: $('Determine Post Type').first().json.postType,\n    status: 'pending_approval'\n  }\n}];"
+            },
+            "id": "a1000001-0001-4000-8000-000000000006",
+            "name": "Parse Response",
+            "type": "n8n-nodes-base.code",
+            "typeVersion": 2,
+            "position": [
+                1248,
+                304
+            ]
+        },
+        {
+            "parameters": {
+                "method": "POST",
+                "url": "https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts",
+                "sendHeaders": true,
+                "headerParameters": {
+                    "parameters": [
+                        {
+                            "name": "Content-Type",
+                            "value": "application/json"
+                        },
+                        {
+                            "name": "Prefer",
+                            "value": "return=representation"
+                        }
+                    ]
+                },
+                "sendBody": true,
+                "specifyBody": "json",
+                "jsonBody": "={{ JSON.stringify({ post_type: $json.post_type, status: 'pending_approval', facebook_post: $json.facebook_post, linkedin_post: $json.linkedin_post, instagram_caption: $json.instagram_caption, instagram_hook_text: $json.instagram_hook_text, ad_headline: $json.ad_headline, ad_body: $json.ad_body, ad_cta: $json.ad_cta, retargeting_copy: $json.retargeting_copy, hooks_used: [$json.instagram_hook_text], image_url: $json.image_url }) }}",
+                "options": {
+                    "response": {
+                        "response": {
+                            "responseFormat": "json"
+                        }
+                    }
+                },
+                "authentication": "genericCredentialType",
+                "genericAuthType": "httpCustomAuth"
+            },
+            "id": "a1000001-0001-4000-8000-000000000007",
+            "name": "Save to Supabase",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                1744,
+                304
+            ],
+            "credentials": {
+                "httpCustomAuth": {
+                    "id": "q309m8yfLKGxywMb",
+                    "name": "Supabase Service Role (main)"
+                }
+            }
+        },
+        {
+            "parameters": {
+                "chatId": "1375806243",
+                "text": "=\ud83d\udce3 <b>New GHL marketing draft ready for review</b>\nType: {{ $('Parse Response').first().json.post_type }}\nDraft ID: <code>{{ $json[0].id }}</code>\n\nReview at https://agentboardroom.flowos.tech (GHL Marketing tab).",
+                "additionalFields": {
+                    "parse_mode": "HTML"
+                }
+            },
+            "id": "a1000001-0001-4000-8000-000000000008",
+            "name": "Send to Telegram",
+            "type": "n8n-nodes-base.telegram",
+            "typeVersion": 1.2,
+            "position": [
+                1904,
+                304
+            ],
+            "webhookId": "78c28696-5041-402a-a116-2f5c00bc05d3",
+            "credentials": {
+                "telegramApi": {
+                    "id": "UR6xX8CchGBKaP3h",
+                    "name": "Flow States Ads Bot"
+                }
+            }
+        },
+        {
+            "parameters": {
+                "jsCode": "// Map post_type -> R2 template URL; rotation for Mon/Wed/Fri.\nconst BASE = 'https://pub-1fa192ebc8ff40dba2b9a0f1890e6f7a.r2.dev/marketing-templates';\nconst IMAGE_MAP = {\n  'pain-led':  BASE + '/ghl-template-pain-led.jpg',\n  'value-led': BASE + '/ghl-template-value-led.jpg',\n  'offer-led': BASE + '/ghl-template-offer-led.jpg'\n};\nconst draft = $input.first().json;\nconst image_url = IMAGE_MAP[draft.post_type] || IMAGE_MAP['value-led'];\nreturn [{ json: { ...draft, image_url } }];"
+            },
+            "id": "a1000001-0001-4000-8000-000000000009",
+            "name": "Assign Image URL",
+            "type": "n8n-nodes-base.code",
+            "typeVersion": 2,
+            "position": [
+                1424,
+                304
+            ]
+        },
+        {
+            "parameters": {
+                "jsCode": "// Cap IG hashtags to 5; defensive against AI drift\n// Pattern source: kJ2EdkOeEAwVbMwU 'Cap Hashtags' (commit e4ad82c, Apr 29)\nconst MAX_HASHTAGS = 5;\nconst item = $input.first().json;\nconst caption = item.instagram_caption;\nif (typeof caption !== 'string' || !caption) {\n  return [{ json: item }];\n}\nlet count = 0;\nconst stripped = caption.replace(/#\\w+/g, (m) => (++count <= MAX_HASHTAGS ? m : ''));\nconst cleaned = stripped\n  .replace(/[ \\t]+/g, ' ')\n  .replace(/\\n[ \\t]+/g, '\\n')\n  .replace(/\\n{3,}/g, '\\n\\n')\n  .trim();\nreturn [{\n  json: {\n    ...item,\n    instagram_caption: cleaned,\n    _hashtag_cap_applied: { max: MAX_HASHTAGS, original_count: count, dropped: Math.max(0, count - MAX_HASHTAGS), at: new Date().toISOString() }\n  }\n}];"
+            },
+            "id": "a1000001-0001-4000-8000-000000000020",
+            "name": "Cap Hashtags",
+            "type": "n8n-nodes-base.code",
+            "typeVersion": 2,
+            "position": [
+                1600,
+                304
+            ]
+        },
+        {
+            "parameters": {
+                "operation": "executeQuery",
+                "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'started'::text, 'GHL Marketing: Content Generator'::text, '{{ $execution.id }}'::text);",
+                "options": {}
+            },
+            "name": "Heartbeat: Start",
+            "type": "n8n-nodes-base.postgres",
+            "typeVersion": 2.6,
+            "position": [
+                432,
+                544
+            ],
+            "retryOnFail": true,
+            "maxTries": 2,
+            "waitBetweenTries": 2000,
+            "id": "66497534-563c-4884-a001-87c1125f6b07",
+            "credentials": {
+                "postgres": {
+                    "id": "qGUxEHfEZkZGdAcZ",
+                    "name": "Supabase Postgres DB"
+                }
+            },
+            "continueOnFail": true
+        },
+        {
+            "parameters": {
+                "operation": "executeQuery",
+                "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'success'::text, 'GHL Marketing: Content Generator'::text, '{{ $execution.id }}'::text);",
+                "options": {}
+            },
+            "name": "Heartbeat: Success",
+            "type": "n8n-nodes-base.postgres",
+            "typeVersion": 2.6,
+            "position": [
+                2160,
+                304
+            ],
+            "retryOnFail": true,
+            "maxTries": 2,
+            "waitBetweenTries": 2000,
+            "id": "b42f1173-aba3-4e18-8688-234a00bd876d",
+            "credentials": {
+                "postgres": {
+                    "id": "qGUxEHfEZkZGdAcZ",
+                    "name": "Supabase Postgres DB"
+                }
+            },
+            "continueOnFail": true
+        }
+    ],
+    "connections": {
+        "Cron MWF 07:00 UTC": {
+            "main": [
+                [
+                    {
+                        "node": "Determine Post Type",
+                        "type": "main",
+                        "index": 0
+                    },
+                    {
+                        "node": "Heartbeat: Start",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Determine Post Type": {
+            "main": [
+                [
+                    {
+                        "node": "Fetch Recent Hooks",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Fetch Recent Hooks": {
+            "main": [
+                [
+                    {
+                        "node": "Prepare Prompt Data",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Prepare Prompt Data": {
+            "main": [
+                [
+                    {
+                        "node": "Generate Content (Claude)",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Generate Content (Claude)": {
+            "main": [
+                [
+                    {
+                        "node": "Parse Response",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Parse Response": {
+            "main": [
+                [
+                    {
+                        "node": "Assign Image URL",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Save to Supabase": {
+            "main": [
+                [
+                    {
+                        "node": "Send to Telegram",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Assign Image URL": {
+            "main": [
+                [
+                    {
+                        "node": "Cap Hashtags",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Heartbeat: Start": {
+            "main": [
+                []
+            ]
+        },
+        "Send to Telegram": {
+            "main": [
+                [
+                    {
+                        "node": "Heartbeat: Success",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Cap Hashtags": {
+            "main": [
+                [
+                    {
+                        "node": "Save to Supabase",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        }
+    },
+    "settings": {
+        "executionOrder": "v1",
+        "callerPolicy": "workflowsFromSameOwner",
+        "availableInMCP": true
+    },
+    "staticData": {
+        "node:Cron MWF 07:00 UTC": {
+            "recurrenceRules": []
+        }
+    },
+    "meta": null,
+    "pinData": {},
+    "versionId": "593188b5-7b3b-427b-a87e-4a250553adc8",
+    "activeVersionId": "7ef7d704-43b5-4bd3-b0f0-cfa787f6646d",
+    "versionCounter": 99,
+    "triggerCount": 1,
+    "shared": [
+        {
+            "updatedAt": "2026-04-13T12:03:02.932Z",
+            "createdAt": "2026-04-13T12:03:02.932Z",
+            "role": "workflow:owner",
+            "workflowId": "Awo65rdSe5BvDHtC",
+            "projectId": "KwpTDWcFWL3DfyW3",
+            "project": {
+                "updatedAt": "2026-04-08T20:28:08.726Z",
+                "createdAt": "2025-06-06T11:27:14.830Z",
+                "id": "KwpTDWcFWL3DfyW3",
+                "name": "Tyson Venables <tysonvenables@protonmail.com>",
+                "type": "personal",
+                "icon": null,
+                "description": null,
+                "creatorId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+                "projectRelations": [
+                    {
+                        "updatedAt": "2025-06-06T11:27:14.830Z",
+                        "createdAt": "2025-06-06T11:27:14.830Z",
+                        "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+                        "projectId": "KwpTDWcFWL3DfyW3",
+                        "user": {
+                            "updatedAt": "2026-07-14T18:38:42.164Z",
+                            "createdAt": "2025-06-06T11:27:13.858Z",
+                            "id": "b1512bca-25b8-4b8b-add0-b86540e5144d",
+                            "email": "tysonvenables@protonmail.com",
+                            "firstName": "Tyson",
+                            "lastName": "Venables",
+                            "personalizationAnswers": {
+                                "version": "v4",
+                                "personalization_survey_submitted_at": "2025-06-06T11:42:52.454Z",
+                                "personalization_survey_n8n_version": "1.95.3",
+                                "companySize": "<20",
+                                "companyType": "saas",
+                                "role": "business-owner",
+                                "reportedSource": "friend"
+                            },
+                            "settings": {
+                                "userActivated": true,
+                                "easyAIWorkflowOnboarded": true,
+                                "firstSuccessfulWorkflowId": "WVXrFCjb8wO7RWRX",
+                                "userActivatedAt": 1751062185356,
+                                "npsSurvey": {
+                                    "responded": true,
+                                    "lastShownAt": 1769430963515
+                                }
+                            },
+                            "disabled": false,
+                            "mfaEnabled": false,
+                            "lastActiveAt": "2026-07-14",
+                            "isPending": false
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "tags": [],
+    "activeVersion": {
+        "updatedAt": "2026-06-18T20:20:22.221Z",
+        "createdAt": "2026-06-18T20:20:20.248Z",
+        "versionId": "7ef7d704-43b5-4bd3-b0f0-cfa787f6646d",
+        "workflowId": "Awo65rdSe5BvDHtC",
+        "nodes": [
+            {
+                "parameters": {
+                    "rule": {
+                        "interval": [
+                            {
+                                "field": "cronExpression",
+                                "expression": "0 7 * * 1,3,5"
+                            }
+                        ]
+                    }
+                },
+                "id": "a1000001-0001-4000-8000-000000000001",
+                "name": "Cron MWF 07:00 UTC",
+                "type": "n8n-nodes-base.scheduleTrigger",
+                "typeVersion": 1.2,
+                "position": [
+                    208,
+                    304
+                ]
+            },
+            {
+                "parameters": {
+                    "jsCode": "const dayOfWeek = new Date().getDay();\nconst postTypes = { 1: 'pain-led', 3: 'value-led', 5: 'offer-led' };\nconst postType = postTypes[dayOfWeek] || 'value-led';\nreturn [{ json: { postType, date: new Date().toISOString().split('T')[0] } }];"
+                },
+                "id": "a1000001-0001-4000-8000-000000000002",
+                "name": "Determine Post Type",
+                "type": "n8n-nodes-base.code",
+                "typeVersion": 2,
+                "position": [
+                    432,
+                    304
+                ]
+            },
+            {
+                "parameters": {
+                    "url": "https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts?select=hooks_used,instagram_hook_text&status=eq.published&order=created_at.desc&limit=10",
+                    "sendHeaders": true,
+                    "headerParameters": {
+                        "parameters": [
+                            {
+                                "name": "apikey",
+                                "value": "={{$env.SUPABASE_ANON_KEY}}"
+                            },
+                            {
+                                "name": "Authorization",
+                                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+                            }
+                        ]
+                    },
+                    "options": {
+                        "response": {
+                            "response": {
+                                "responseFormat": "json"
+                            }
+                        }
+                    }
+                },
+                "id": "a1000001-0001-4000-8000-000000000003",
+                "name": "Fetch Recent Hooks",
+                "type": "n8n-nodes-base.httpRequest",
+                "typeVersion": 4.2,
+                "position": [
+                    640,
+                    304
+                ],
+                "alwaysOutputData": true
+            },
+            {
+                "parameters": {
+                    "jsCode": "const postType = $('Determine Post Type').first().json.postType;\nconst recentRows = $input.first().json;\nlet recentHooks = [];\nif (Array.isArray(recentRows)) {\n  recentRows.forEach(r => {\n    if (r.instagram_hook_text) recentHooks.push(r.instagram_hook_text);\n    if (Array.isArray(r.hooks_used)) recentHooks.push(...r.hooks_used);\n  });\n}\nrecentHooks = [...new Set(recentHooks)];\nreturn [{ json: { postType, recentHooks: recentHooks.join(', ') || 'none' } }];"
+                },
+                "id": "a1000001-0001-4000-8000-000000000004",
+                "name": "Prepare Prompt Data",
+                "type": "n8n-nodes-base.code",
+                "typeVersion": 2,
+                "position": [
+                    864,
+                    304
+                ]
+            },
+            {
+                "parameters": {
+                    "method": "POST",
+                    "url": "https://api.anthropic.com/v1/messages",
+                    "authentication": "genericCredentialType",
+                    "genericAuthType": "httpHeaderAuth",
+                    "sendHeaders": true,
+                    "headerParameters": {
+                        "parameters": [
+                            {
+                                "name": "anthropic-version",
+                                "value": "2023-06-01"
+                            },
+                            {
+                                "name": "content-type",
+                                "value": "application/json"
+                            }
+                        ]
+                    },
+                    "sendBody": true,
+                    "specifyBody": "json",
+                    "jsonBody": "={{ JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 2000, system: \"You are a marketing copywriter for GHL Support Specialist. Product: AI-powered 24/7 support for GoHighLevel users. URL: support.flowos.tech/ghl/landing. Price: $29/month or $290/year. Founders Offer: first 50 members get 3 months free with code GHLPOWER50.\\n\\nTone: Direct, practical, slightly irreverent. Speak like a GHL power user. No corporate language. Short sentences. No em dashes. No hashtags in body copy (Instagram hashtags go in a separate block).\\n\\nNever say: game-changer, revolutionary, unlock your potential, or generic SaaS language.\\n\\nThree pain points to rotate:\\n1. Time lost \\u2014 hours in YouTube, Facebook groups, help docs\\n2. Support frustration \\u2014 tickets take days, group answers unreliable\\n3. Confidence gap \\u2014 'I know GHL can do this, I just don't know how'\\n\\nOne promise: Ask it anything about GHL. Get an expert answer in seconds.\\n\\nUse specific GHL terms: workflows, automations, pipelines, funnels, SaaS mode, merge fields, calendars, triggers, actions.\", messages: [{ role: 'user', content: 'Generate a ' + $json.postType + ' organic post for GHL Support Specialist. Today is ' + new Date().toLocaleDateString('en-US', {weekday:'long',month:'long',day:'numeric'}) + '.\\n\\nProvide output as JSON with these exact keys:\\n- facebook_post (plain text, no hashtags, 100-200 words)\\n- linkedin_post (plain text, no hashtags, 80-150 words)\\n- instagram_caption (with hashtag block at end, 60-120 words before hashtags)\\n- instagram_hook_text (5-8 words, overlay text for image)\\n- ad_headline (under 10 words)\\n- ad_body (80-120 words, includes pain point + solution + Founders Offer + URL with UTMs: support.flowos.tech/ghl/landing?utm_source=facebook&utm_medium=paid_social&utm_campaign=founders_offer)\\n- ad_cta (3-4 words for button text)\\n- retargeting_copy (60-100 words, acknowledges they visited, restates value, urgency)\\n\\nDo NOT repeat any of these recently used hooks: ' + $json.recentHooks + '\\n\\nReturn ONLY valid JSON. No markdown fences. No explanation.' }] }) }}",
+                    "options": {
+                        "response": {
+                            "response": {
+                                "responseFormat": "json"
+                            }
+                        }
+                    }
+                },
+                "id": "a1000001-0001-4000-8000-000000000005",
+                "name": "Generate Content (Claude)",
+                "type": "n8n-nodes-base.httpRequest",
+                "typeVersion": 4.2,
+                "position": [
+                    1088,
+                    304
+                ],
+                "credentials": {
+                    "httpHeaderAuth": {
+                        "id": "LUUeAdpObQjzRbct",
+                        "name": "Anthropic - QuantumClaw"
+                    }
+                }
+            },
+            {
+                "parameters": {
+                    "jsCode": "const response = $input.first().json;\nconst content = response.content?.[0]?.text;\nif (!content) throw new Error('No content in Claude response: ' + JSON.stringify(response).substring(0, 500));\n\nlet parsed;\ntry {\n  const cleaned = content.replace(/```json\\n?/g, '').replace(/```\\n?/g, '').trim();\n  parsed = JSON.parse(cleaned);\n} catch (e) {\n  throw new Error('Failed to parse Claude response: ' + e.message + '\\nRaw: ' + content.substring(0, 500));\n}\n\nreturn [{\n  json: {\n    ...parsed,\n    post_type: $('Determine Post Type').first().json.postType,\n    status: 'pending_approval'\n  }\n}];"
+                },
+                "id": "a1000001-0001-4000-8000-000000000006",
+                "name": "Parse Response",
+                "type": "n8n-nodes-base.code",
+                "typeVersion": 2,
+                "position": [
+                    1248,
+                    304
+                ]
+            },
+            {
+                "parameters": {
+                    "method": "POST",
+                    "url": "https://fdabygmromuqtysitodp.supabase.co/rest/v1/marketing_drafts",
+                    "sendHeaders": true,
+                    "headerParameters": {
+                        "parameters": [
+                            {
+                                "name": "apikey",
+                                "value": "={{$env.SUPABASE_ANON_KEY}}"
+                            },
+                            {
+                                "name": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "name": "Prefer",
+                                "value": "return=representation"
+                            },
+                            {
+                                "name": "Authorization",
+                                "value": "=Bearer {{$env.SUPABASE_ANON_KEY}}"
+                            }
+                        ]
+                    },
+                    "sendBody": true,
+                    "specifyBody": "json",
+                    "jsonBody": "={{ JSON.stringify({ post_type: $json.post_type, status: 'pending_approval', facebook_post: $json.facebook_post, linkedin_post: $json.linkedin_post, instagram_caption: $json.instagram_caption, instagram_hook_text: $json.instagram_hook_text, ad_headline: $json.ad_headline, ad_body: $json.ad_body, ad_cta: $json.ad_cta, retargeting_copy: $json.retargeting_copy, hooks_used: [$json.instagram_hook_text], image_url: $json.image_url }) }}",
+                    "options": {
+                        "response": {
+                            "response": {
+                                "responseFormat": "json"
+                            }
+                        }
+                    }
+                },
+                "id": "a1000001-0001-4000-8000-000000000007",
+                "name": "Save to Supabase",
+                "type": "n8n-nodes-base.httpRequest",
+                "typeVersion": 4.2,
+                "position": [
+                    1744,
+                    304
+                ]
+            },
+            {
+                "parameters": {
+                    "chatId": "1375806243",
+                    "text": "=\ud83d\udce3 <b>New GHL marketing draft ready for review</b>\nType: {{ $('Parse Response').first().json.post_type }}\nDraft ID: <code>{{ $json[0].id }}</code>\n\nReview at https://agentboardroom.flowos.tech (GHL Marketing tab).",
+                    "additionalFields": {
+                        "parse_mode": "HTML"
+                    }
+                },
+                "id": "a1000001-0001-4000-8000-000000000008",
+                "name": "Send to Telegram",
+                "type": "n8n-nodes-base.telegram",
+                "typeVersion": 1.2,
+                "position": [
+                    1904,
+                    304
+                ],
+                "webhookId": "78c28696-5041-402a-a116-2f5c00bc05d3",
+                "credentials": {
+                    "telegramApi": {
+                        "id": "UR6xX8CchGBKaP3h",
+                        "name": "Flow States Ads Bot"
+                    }
+                }
+            },
+            {
+                "parameters": {
+                    "jsCode": "// Map post_type -> R2 template URL; rotation for Mon/Wed/Fri.\nconst BASE = 'https://pub-1fa192ebc8ff40dba2b9a0f1890e6f7a.r2.dev/marketing-templates';\nconst IMAGE_MAP = {\n  'pain-led':  BASE + '/ghl-template-pain-led.jpg',\n  'value-led': BASE + '/ghl-template-value-led.jpg',\n  'offer-led': BASE + '/ghl-template-offer-led.jpg'\n};\nconst draft = $input.first().json;\nconst image_url = IMAGE_MAP[draft.post_type] || IMAGE_MAP['value-led'];\nreturn [{ json: { ...draft, image_url } }];"
+                },
+                "id": "a1000001-0001-4000-8000-000000000009",
+                "name": "Assign Image URL",
+                "type": "n8n-nodes-base.code",
+                "typeVersion": 2,
+                "position": [
+                    1424,
+                    304
+                ]
+            },
+            {
+                "parameters": {
+                    "jsCode": "// Cap IG hashtags to 5; defensive against AI drift\n// Pattern source: kJ2EdkOeEAwVbMwU 'Cap Hashtags' (commit e4ad82c, Apr 29)\nconst MAX_HASHTAGS = 5;\nconst item = $input.first().json;\nconst caption = item.instagram_caption;\nif (typeof caption !== 'string' || !caption) {\n  return [{ json: item }];\n}\nlet count = 0;\nconst stripped = caption.replace(/#\\w+/g, (m) => (++count <= MAX_HASHTAGS ? m : ''));\nconst cleaned = stripped\n  .replace(/[ \\t]+/g, ' ')\n  .replace(/\\n[ \\t]+/g, '\\n')\n  .replace(/\\n{3,}/g, '\\n\\n')\n  .trim();\nreturn [{\n  json: {\n    ...item,\n    instagram_caption: cleaned,\n    _hashtag_cap_applied: { max: MAX_HASHTAGS, original_count: count, dropped: Math.max(0, count - MAX_HASHTAGS), at: new Date().toISOString() }\n  }\n}];"
+                },
+                "id": "a1000001-0001-4000-8000-000000000020",
+                "name": "Cap Hashtags",
+                "type": "n8n-nodes-base.code",
+                "typeVersion": 2,
+                "position": [
+                    1600,
+                    304
+                ]
+            },
+            {
+                "parameters": {
+                    "operation": "executeQuery",
+                    "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'started'::text, 'GHL Marketing: Content Generator'::text, '{{ $execution.id }}'::text);",
+                    "options": {}
+                },
+                "name": "Heartbeat: Start",
+                "type": "n8n-nodes-base.postgres",
+                "typeVersion": 2.6,
+                "position": [
+                    432,
+                    544
+                ],
+                "retryOnFail": true,
+                "maxTries": 2,
+                "waitBetweenTries": 2000,
+                "id": "66497534-563c-4884-a001-87c1125f6b07",
+                "credentials": {
+                    "postgres": {
+                        "id": "qGUxEHfEZkZGdAcZ",
+                        "name": "Supabase Postgres DB"
+                    }
+                },
+                "continueOnFail": true
+            },
+            {
+                "parameters": {
+                    "operation": "executeQuery",
+                    "query": "select public.record_heartbeat('{{ $workflow.id }}'::text, 'success'::text, 'GHL Marketing: Content Generator'::text, '{{ $execution.id }}'::text);",
+                    "options": {}
+                },
+                "name": "Heartbeat: Success",
+                "type": "n8n-nodes-base.postgres",
+                "typeVersion": 2.6,
+                "position": [
+                    2160,
+                    304
+                ],
+                "retryOnFail": true,
+                "maxTries": 2,
+                "waitBetweenTries": 2000,
+                "id": "b42f1173-aba3-4e18-8688-234a00bd876d",
+                "credentials": {
+                    "postgres": {
+                        "id": "qGUxEHfEZkZGdAcZ",
+                        "name": "Supabase Postgres DB"
+                    }
+                },
+                "continueOnFail": true
+            }
+        ],
+        "connections": {
+            "Cron MWF 07:00 UTC": {
+                "main": [
+                    [
+                        {
+                            "node": "Determine Post Type",
+                            "type": "main",
+                            "index": 0
+                        },
+                        {
+                            "node": "Heartbeat: Start",
+                            "type": "main",
+                            "index": 0
+                        }
+                    ]
+                ]
+            },
+            "Determine Post Type": {
+                "main": [
+                    [
+                        {
+                            "node": "Fetch Recent Hooks",
+                            "type": "main",
+                            "index": 0
+                        }
+                    ]
+                ]
+            },
+            "Fetch Recent Hooks": {
+                "main": [
+                    [
+                        {
+                            "node": "Prepare Prompt Data",
+                            "type": "main",
+                            "index": 0
+                        }
+                    ]
+                ]
+            },
+            "Prepare Prompt Data": {
+                "main": [
+                    [
+                        {
+                            "node": "Generate Content (Claude)",
+                            "type": "main",
+                            "index": 0
+                        }
+                    ]
+                ]
+            },
+            "Generate Content (Claude)": {
+                "main": [
+                    [
+                        {
+                            "node": "Parse Response",
+                            "type": "main",
+                            "index": 0
+                        }
+                    ]
+                ]
+            },
+            "Parse Response": {
+                "main": [
+                    [
+                        {
+                            "node": "Assign Image URL",
+                            "type": "main",
+                            "index": 0
+                        }
+                    ]
+                ]
+            },
+            "Save to Supabase": {
+                "main": [
+                    [
+                        {
+                            "node": "Send to Telegram",
+                            "type": "main",
+                            "index": 0
+                        }
+                    ]
+                ]
+            },
+            "Assign Image URL": {
+                "main": [
+                    [
+                        {
+                            "node": "Cap Hashtags",
+                            "type": "main",
+                            "index": 0
+                        }
+                    ]
+                ]
+            },
+            "Heartbeat: Start": {
+                "main": [
+                    []
+                ]
+            },
+            "Send to Telegram": {
+                "main": [
+                    [
+                        {
+                            "node": "Heartbeat: Success",
+                            "type": "main",
+                            "index": 0
+                        }
+                    ]
+                ]
+            },
+            "Cap Hashtags": {
+                "main": [
+                    [
+                        {
+                            "node": "Save to Supabase",
+                            "type": "main",
+                            "index": 0
+                        }
+                    ]
+                ]
+            }
+        },
+        "authors": "Tyson Venables",
+        "name": "Version 7ef7d704",
+        "description": "",
+        "autosaved": false,
+        "workflowPublishHistory": [
+            {
+                "createdAt": "2026-06-18T20:20:22.213Z",
+                "id": 1014,
+                "workflowId": "Awo65rdSe5BvDHtC",
+                "versionId": "7ef7d704-43b5-4bd3-b0f0-cfa787f6646d",
+                "event": "activated",
+                "userId": "b1512bca-25b8-4b8b-add0-b86540e5144d"
+            }
+        ]
+    }
+}

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -116,6 +116,7 @@ export class DashboardServer {
     this.app.use('/api/content-studio/upload', rateLimit({ windowMs: 60000, max: 5, message: { error: 'Too many upload requests' } }));
     this.app.use('/api/content-studio/upload-image', rateLimit({ windowMs: 60000, max: 10, message: { error: 'Too many image upload requests' } }));
     this.app.use("/api/crete/generate-image", rateLimit({ windowMs: 60000, max: 10, message: { error: "Too many image generation requests" } }));
+    this.app.use("/api/flowos/generate-image", rateLimit({ windowMs: 60000, max: 20, message: { error: "Too many image generation requests" } }));
     this.app.use('/api/trading/execute', rateLimit({ windowMs: 60000, max: 5, message: { error: 'Too many trade requests' } }));
 
     // Serve agency character assets
@@ -1959,6 +1960,72 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
       } catch (err) {
         log.error(`[CRETE] generate-image error: ${err.message}`);
         res.status(500).json({ error: err.message });
+      }
+    });
+
+    // POST /api/flowos/generate-image
+    // Body: { card_type: "editorial"|"stat"|"feature", headline, subtext?, post_type?,
+    //         stat?, stat_label?, badge_label?, feature_line? }
+    // Returns: { success: true, url: "https://media.flowos.tech/marketing/images/<uuid>.png" }
+    this.app.post('/api/flowos/generate-image', async (req, res) => {
+      const { card_type, headline, subtext, post_type, stat, stat_label, badge_label, feature_line } = req.body || {};
+
+      let pngBuffer;
+      try {
+        const { generateImageCard } = await import('../flowos-marketing/generate-image-card.js');
+        pngBuffer = await generateImageCard({ card_type, headline, subtext, post_type, stat, stat_label, badge_label, feature_line });
+      } catch (err) {
+        if (err.statusCode === 422) {
+          return res.status(422).json({ success: false, error: err.message });
+        }
+        log.error(`[FLOWOS] generate-image render error: ${err.message}`);
+        return res.status(500).json({ success: false, error: 'Image generation failed' });
+      }
+
+      try {
+        const { S3Client, PutObjectCommand } = await import('@aws-sdk/client-s3');
+        const { randomUUID } = await import('crypto');
+
+        const envPath = join(process.env.HOME || '/root', '.quantumclaw', '.env');
+        const envVars = {};
+        try {
+          const envContent = readFileSync(envPath, 'utf-8');
+          for (const line of envContent.split('\n')) {
+            const match = line.match(/^([A-Z0-9_]+)=(.+)$/);
+            if (match) envVars[match[1]] = match[2];
+          }
+        } catch { /* fall through to process.env */ }
+
+        const accountId = envVars.R2_ACCOUNT_ID || process.env.R2_ACCOUNT_ID;
+        const accessKeyId = envVars.FLOWOS_R2_ACCESS_KEY_ID || process.env.FLOWOS_R2_ACCESS_KEY_ID;
+        const secretAccessKey = envVars.FLOWOS_R2_SECRET_ACCESS_KEY || process.env.FLOWOS_R2_SECRET_ACCESS_KEY;
+        const bucket = envVars.FLOWOS_R2_BUCKET_NAME || process.env.FLOWOS_R2_BUCKET_NAME || 'flowos-content';
+        const publicBase = (envVars.FLOWOS_R2_PUBLIC_URL || process.env.FLOWOS_R2_PUBLIC_URL || 'https://media.flowos.tech').replace(/\/+$/, '');
+
+        if (!accountId || !accessKeyId || !secretAccessKey) {
+          return res.status(500).json({ success: false, error: 'R2 credentials not configured' });
+        }
+
+        const s3 = new S3Client({
+          region: 'auto',
+          endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+          credentials: { accessKeyId, secretAccessKey }
+        });
+
+        const fileKey = `marketing/images/${randomUUID()}.png`;
+        await s3.send(new PutObjectCommand({
+          Bucket: bucket,
+          Key: fileKey,
+          Body: pngBuffer,
+          ContentType: 'image/png'
+        }));
+
+        const publicUrl = `${publicBase}/${fileKey}`;
+        log.info(`[FLOWOS] Generated ${card_type} card → ${publicUrl}`);
+        res.json({ success: true, url: publicUrl, card_type, key: fileKey });
+      } catch (err) {
+        log.error(`[FLOWOS] generate-image upload error: ${err.message}`);
+        res.status(500).json({ success: false, error: 'Image upload failed' });
       }
     });
 

--- a/src/flowos-marketing/generate-image-card.js
+++ b/src/flowos-marketing/generate-image-card.js
@@ -136,7 +136,7 @@ let _logoPromise = null;
 function getLogoMark() {
   if (!_logoPromise) {
     _logoPromise = (async () => {
-      const res = await fetch(LOGO_URL);
+      const res = await fetch(LOGO_URL, { signal: AbortSignal.timeout(5000) });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const buf = Buffer.from(await res.arrayBuffer());
       return await loadImage(buf);

--- a/src/flowos-marketing/generate-image-card.js
+++ b/src/flowos-marketing/generate-image-card.js
@@ -1,0 +1,428 @@
+/**
+ * Flow OS — Marketing Image Card Generator
+ *
+ * Generates branded 1080×1350 (4:5) PNG cards for GHL Marketing posts.
+ * Three card types:
+ *   - editorial: dark card — pill label, accent bar, headline + body
+ *   - stat:      dark card — large stat number, label, hook line
+ *   - feature:   light teal card — badge, headline + body, feature callout strip
+ *
+ * Standalone module — no imports from crete-marketing.
+ *
+ * Usage (CLI):
+ *   node generate-image-card.js --card_type editorial --post_type pain-led \
+ *     --headline "..." --subtext "..." --output /tmp/card.png
+ *
+ * Usage (module):
+ *   import { generateImageCard } from './generate-image-card.js';
+ *   const buffer = await generateImageCard({ card_type: 'editorial', headline: '...' });
+ */
+
+import { createCanvas, loadImage } from 'canvas';
+import { writeFileSync } from 'fs';
+import { parseArgs } from 'util';
+
+// ─── Brand Palette ───────────────────────────────────────────
+const DARK_BG     = '#1a2a2a';
+const LIGHT_BG    = '#e8f2f2';
+const TEAL_ACCENT = '#99cccc';
+const CREAM_TEXT  = '#eae5da';
+const TEAL_DEEP   = '#2a7070';
+const TEAL_DARK   = '#1a3a3a';
+const TEAL_BODY   = '#3a5a5a';
+const TEAL_MID    = '#2a5a5a';
+
+const WIDTH  = 1080;
+const HEIGHT = 1350;
+const PAD    = 100;
+const TEXT_W = WIDTH - PAD * 2;
+const FOOTER_H = 150;
+
+const CARD_TYPES = ['editorial', 'stat', 'feature'];
+
+// Brand assets are fetched from the public CDN URL — no credentials needed here.
+const PUBLIC_BASE = (process.env.FLOWOS_R2_PUBLIC_URL || 'https://media.flowos.tech').replace(/\/+$/, '');
+const LOGO_URL = `${PUBLIC_BASE}/brand/logo-mark.png`;
+
+// ─── Helpers ─────────────────────────────────────────────────
+
+/** Strip dangerous chars; keep printable text + common punctuation + emojis. */
+export function sanitise(str) {
+  if (typeof str !== 'string') return '';
+  return str
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')   // strip control chars
+    .replace(/\s+[–—―]\s+/g, ' - ')
+    .replace(/[–—―]/g, '-')
+    .replace(/ {2,}/g, ' ')
+    .trim()
+    .slice(0, 2000);
+}
+
+function invalid(msg) {
+  const err = new Error(msg);
+  err.statusCode = 422;
+  return err;
+}
+
+/** Word-wrap text to maxWidth; truncate with ellipsis beyond maxLines. */
+function wrapText(ctx, text, maxWidth, maxLines = Infinity) {
+  const lines = [];
+  for (const paragraph of text.split('\n')) {
+    if (paragraph.trim() === '') { lines.push(''); continue; }
+    const words = paragraph.split(/\s+/);
+    let line = '';
+    for (const word of words) {
+      const test = line ? `${line} ${word}` : word;
+      if (ctx.measureText(test).width > maxWidth && line) {
+        lines.push(line);
+        line = word;
+      } else {
+        line = test;
+      }
+    }
+    if (line) lines.push(line);
+  }
+  if (lines.length > maxLines) {
+    const kept = lines.slice(0, maxLines);
+    let last = kept[maxLines - 1].replace(/[\s.,;:!?]+$/, '');
+    while (last && ctx.measureText(last + '…').width > maxWidth) {
+      last = last.slice(0, -1).trimEnd();
+    }
+    kept[maxLines - 1] = last + '…';
+    return kept;
+  }
+  return lines;
+}
+
+/** Draw text with manual letter-spacing (node-canvas has no letterSpacing). */
+function drawTrackedText(ctx, text, x, y, tracking) {
+  let cx = x;
+  for (const ch of text) {
+    ctx.fillText(ch, cx, y);
+    cx += ctx.measureText(ch).width + tracking;
+  }
+}
+
+function measureTracked(ctx, text, tracking) {
+  let w = 0;
+  for (const ch of text) w += ctx.measureText(ch).width + tracking;
+  return w - tracking;
+}
+
+/** Rounded-rect path (node-canvas lacks ctx.roundRect on older builds). */
+function roundRectPath(ctx, x, y, w, h, r) {
+  const radius = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.arcTo(x + w, y, x + w, y + h, radius);
+  ctx.arcTo(x + w, y + h, x, y + h, radius);
+  ctx.arcTo(x, y + h, x, y, radius);
+  ctx.arcTo(x, y, x + w, y, radius);
+  ctx.closePath();
+}
+
+/** Subtle radial glow in a corner. */
+function drawRadialGlow(ctx, cx, cy, radius, rgba) {
+  const g = ctx.createRadialGradient(cx, cy, 0, cx, cy, radius);
+  g.addColorStop(0, rgba);
+  g.addColorStop(1, 'rgba(153,204,204,0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, WIDTH, HEIGHT);
+}
+
+// ─── Logo (fetched once from R2 public URL, cached in memory) ─
+
+let _logoPromise = null;
+function getLogoMark() {
+  if (!_logoPromise) {
+    _logoPromise = (async () => {
+      const res = await fetch(LOGO_URL);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const buf = Buffer.from(await res.arrayBuffer());
+      return await loadImage(buf);
+    })().catch(err => {
+      console.warn(`[flowos-marketing] logo-mark unavailable (${err.message}); rendering text-only footer`);
+      _logoPromise = null; // allow retry on next generation
+      return null;
+    });
+  }
+  return _logoPromise;
+}
+
+/** Recolour the logomark to a flat tint (silhouette) at the given height. */
+function tintedLogo(logo, color, height) {
+  const w = Math.round(logo.width * (height / logo.height));
+  const c = createCanvas(w, height);
+  const cctx = c.getContext('2d');
+  cctx.drawImage(logo, 0, 0, w, height);
+  cctx.globalCompositeOperation = 'source-in';
+  cctx.fillStyle = color;
+  cctx.fillRect(0, 0, w, height);
+  return c;
+}
+
+/** Footer: hairline border, logomark + FLOW OS text. */
+async function drawFooter(ctx, { line, tint, alpha }) {
+  const yLine = HEIGHT - FOOTER_H;
+  ctx.save();
+  ctx.strokeStyle = line;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(PAD, yLine);
+  ctx.lineTo(WIDTH - PAD, yLine);
+  ctx.stroke();
+
+  const logo = await getLogoMark();
+  const midY = yLine + FOOTER_H / 2 - 5;
+  ctx.globalAlpha = alpha;
+  let tx = PAD;
+  if (logo) {
+    const logoH = 56;
+    const mark = tintedLogo(logo, tint, logoH);
+    ctx.drawImage(mark, PAD, midY - logoH / 2);
+    tx = PAD + mark.width + 24;
+  }
+  ctx.fillStyle = tint;
+  ctx.font = '600 24px "Montserrat"';
+  ctx.textBaseline = 'middle';
+  drawTrackedText(ctx, 'FLOW OS', tx, midY, 6);
+  ctx.restore();
+  ctx.textBaseline = 'alphabetic';
+}
+
+// ─── Card Renderers ──────────────────────────────────────────
+
+async function renderEditorial(ctx, { headline, subtext, post_type }) {
+  ctx.fillStyle = DARK_BG;
+  ctx.fillRect(0, 0, WIDTH, HEIGHT);
+  drawRadialGlow(ctx, WIDTH - 80, 80, 720, 'rgba(153,204,204,0.08)');
+
+  // Pill label — post type. Spec said 10px; at 1080px wide that is illegible, so 2× applied.
+  const label = (post_type || 'FLOW OS').toUpperCase();
+  ctx.font = 'bold 20px "Montserrat"';
+  const track = 4;
+  const labelW = measureTracked(ctx, label, track);
+  const pillH = 44;
+  roundRectPath(ctx, PAD, PAD, labelW + 48, pillH, pillH / 2);
+  ctx.fillStyle = 'rgba(153,204,204,0.08)';
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(153,204,204,0.35)';
+  ctx.lineWidth = 1;
+  ctx.stroke();
+  ctx.fillStyle = TEAL_ACCENT;
+  ctx.textBaseline = 'middle';
+  drawTrackedText(ctx, label, PAD + 24, PAD + pillH / 2 + 1, track);
+  ctx.textBaseline = 'alphabetic';
+
+  // Teal accent bar above headline
+  let y = PAD + 150;
+  ctx.fillStyle = TEAL_ACCENT;
+  ctx.fillRect(PAD, y, 60, 5);
+  y += 85;
+
+  // Headline
+  ctx.fillStyle = CREAM_TEXT;
+  ctx.font = 'bold 48px "Montserrat"';
+  for (const l of wrapText(ctx, headline, TEXT_W, 3)) {
+    ctx.fillText(l, PAD, y);
+    y += 62;
+  }
+
+  // Body
+  if (subtext) {
+    y += 30;
+    ctx.fillStyle = 'rgba(234,229,218,0.65)';
+    ctx.font = '28px "Raleway"';
+    for (const l of wrapText(ctx, subtext, TEXT_W, 4)) {
+      ctx.fillText(l, PAD, y);
+      y += 42;
+    }
+  }
+
+  await drawFooter(ctx, { line: 'rgba(153,204,204,0.2)', tint: TEAL_ACCENT, alpha: 0.4 });
+}
+
+async function renderStat(ctx, { stat, stat_label, headline }) {
+  ctx.fillStyle = DARK_BG;
+  ctx.fillRect(0, 0, WIDTH, HEIGHT);
+  drawRadialGlow(ctx, WIDTH - 80, 80, 720, 'rgba(153,204,204,0.08)');
+
+  // Accent bar top-left
+  ctx.fillStyle = TEAL_ACCENT;
+  ctx.fillRect(PAD, PAD, 60, 5);
+
+  // Stat number — auto-shrink to fit width
+  let size = 120;
+  ctx.font = `bold ${size}px "Montserrat"`;
+  while (size > 48 && ctx.measureText(stat).width > TEXT_W) {
+    size -= 4;
+    ctx.font = `bold ${size}px "Montserrat"`;
+  }
+  ctx.fillStyle = TEAL_ACCENT;
+  const statBaseline = PAD + 160 + size;
+  ctx.fillText(stat, PAD, statBaseline);
+
+  // Stat label
+  ctx.fillStyle = 'rgba(234,229,218,0.70)';
+  ctx.font = '28px "Raleway"';
+  let ly = statBaseline + 70;
+  for (const l of wrapText(ctx, stat_label, TEXT_W, 2)) {
+    ctx.fillText(l, PAD, ly);
+    ly += 42;
+  }
+
+  // Hook line — bottom third
+  ctx.fillStyle = CREAM_TEXT;
+  ctx.font = '600 36px "Montserrat"';
+  const hookLines = wrapText(ctx, headline, TEXT_W, 3);
+  let hy = HEIGHT - FOOTER_H - 70 - (hookLines.length - 1) * 50;
+  for (const l of hookLines) {
+    ctx.fillText(l, PAD, hy);
+    hy += 50;
+  }
+
+  await drawFooter(ctx, { line: 'rgba(153,204,204,0.2)', tint: TEAL_ACCENT, alpha: 0.4 });
+}
+
+async function renderFeature(ctx, { headline, subtext, badge_label, feature_line }) {
+  ctx.fillStyle = LIGHT_BG;
+  ctx.fillRect(0, 0, WIDTH, HEIGHT);
+  drawRadialGlow(ctx, WIDTH - 120, HEIGHT - 160, 760, 'rgba(153,204,204,0.15)');
+
+  // Badge pill. Spec said 9px; at 1080px wide that is illegible, so 2× applied.
+  const label = (badge_label || 'Feature spotlight').toUpperCase();
+  ctx.font = 'bold 18px "Montserrat"';
+  const track = 3;
+  const labelW = measureTracked(ctx, label, track);
+  const pillH = 42;
+  roundRectPath(ctx, PAD, PAD, labelW + 56, pillH, 20);
+  ctx.fillStyle = 'rgba(153,204,204,0.25)';
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(153,204,204,0.4)';
+  ctx.lineWidth = 1;
+  ctx.stroke();
+  ctx.fillStyle = TEAL_DEEP;
+  ctx.textBaseline = 'middle';
+  drawTrackedText(ctx, label, PAD + 28, PAD + pillH / 2 + 1, track);
+  ctx.textBaseline = 'alphabetic';
+
+  // Headline
+  let y = PAD + 170;
+  ctx.fillStyle = TEAL_DARK;
+  ctx.font = 'bold 48px "Montserrat"';
+  for (const l of wrapText(ctx, headline, TEXT_W, 3)) {
+    ctx.fillText(l, PAD, y);
+    y += 62;
+  }
+
+  // Body
+  if (subtext) {
+    y += 30;
+    ctx.fillStyle = TEAL_BODY;
+    ctx.font = '28px "Raleway"';
+    for (const l of wrapText(ctx, subtext, TEXT_W, 4)) {
+      ctx.fillText(l, PAD, y);
+      y += 42;
+    }
+  }
+
+  // Feature callout strip — white rounded rect, bottom third
+  if (feature_line) {
+    const stripH = 150;
+    const stripY = HEIGHT - FOOTER_H - stripH - 60;
+    ctx.save();
+    ctx.shadowColor = 'rgba(42,90,90,0.10)';
+    ctx.shadowBlur = 24;
+    ctx.shadowOffsetY = 6;
+    roundRectPath(ctx, PAD, stripY, TEXT_W, stripH, 24);
+    ctx.fillStyle = '#ffffff';
+    ctx.fill();
+    ctx.restore();
+
+    const dotX = PAD + 48;
+    const dotY = stripY + stripH / 2;
+    ctx.fillStyle = TEAL_DEEP;
+    ctx.beginPath();
+    ctx.arc(dotX, dotY, 9, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = TEAL_MID;
+    ctx.font = '600 26px "Montserrat"';
+    const fx = dotX + 36;
+    const fLines = wrapText(ctx, feature_line, PAD + TEXT_W - 40 - fx, 2);
+    ctx.textBaseline = 'middle';
+    let fy = dotY - (fLines.length - 1) * 19;
+    for (const l of fLines) {
+      ctx.fillText(l, fx, fy);
+      fy += 38;
+    }
+    ctx.textBaseline = 'alphabetic';
+  }
+
+  await drawFooter(ctx, { line: 'rgba(42,90,90,0.15)', tint: TEAL_MID, alpha: 0.5 });
+}
+
+// ─── Public API ──────────────────────────────────────────────
+
+export async function generateImageCard(opts = {}) {
+  const card_type = opts.card_type;
+  if (!CARD_TYPES.includes(card_type)) {
+    throw invalid(`card_type must be one of: ${CARD_TYPES.join(', ')} (got: ${card_type ?? 'undefined'})`);
+  }
+  const headline = sanitise(opts.headline);
+  if (!headline) throw invalid('headline is required and must be a non-empty string');
+
+  const fields = {
+    headline,
+    subtext: sanitise(opts.subtext),
+    post_type: sanitise(opts.post_type).slice(0, 40),
+    stat: sanitise(opts.stat).slice(0, 40),
+    stat_label: sanitise(opts.stat_label),
+    badge_label: sanitise(opts.badge_label).slice(0, 60),
+    feature_line: sanitise(opts.feature_line),
+  };
+  if (card_type === 'stat') {
+    if (!fields.stat) throw invalid('stat is required for stat cards');
+    if (!fields.stat_label) throw invalid('stat_label is required for stat cards');
+  }
+
+  const canvas = createCanvas(WIDTH, HEIGHT);
+  const ctx = canvas.getContext('2d');
+  ctx.antialias = 'subpixel';
+  ctx.quality = 'best';
+
+  if (card_type === 'editorial') await renderEditorial(ctx, fields);
+  else if (card_type === 'stat') await renderStat(ctx, fields);
+  else await renderFeature(ctx, fields);
+
+  return canvas.toBuffer('image/png');
+}
+
+// ─── CLI ─────────────────────────────────────────────────────
+
+const isMain = process.argv[1]?.endsWith('generate-image-card.js');
+if (isMain) {
+  const { values } = parseArgs({
+    options: {
+      card_type:    { type: 'string', default: 'editorial' },
+      headline:     { type: 'string', default: '' },
+      subtext:      { type: 'string', default: '' },
+      post_type:    { type: 'string', default: '' },
+      stat:         { type: 'string', default: '' },
+      stat_label:   { type: 'string', default: '' },
+      badge_label:  { type: 'string', default: '' },
+      feature_line: { type: 'string', default: '' },
+      output:       { type: 'string', default: '/tmp/flowos-card.png' },
+    },
+    strict: false,
+  });
+
+  try {
+    const buf = await generateImageCard(values);
+    writeFileSync(values.output, buf);
+    console.log(`✓ ${values.output} (${buf.length} bytes, ${WIDTH}×${HEIGHT})`);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/src/flowos-marketing/generate-image-card.js
+++ b/src/flowos-marketing/generate-image-card.js
@@ -192,13 +192,14 @@ async function drawFooter(ctx, { line, tint, alpha }) {
 
 // ─── Card Renderers ──────────────────────────────────────────
 
-async function renderEditorial(ctx, { headline, subtext, post_type }) {
+async function renderEditorial(ctx, { headline, subtext }) {
   ctx.fillStyle = DARK_BG;
   ctx.fillRect(0, 0, WIDTH, HEIGHT);
   drawRadialGlow(ctx, WIDTH - 80, 80, 720, 'rgba(153,204,204,0.08)');
 
-  // Pill label — post type. Spec said 10px; at 1080px wide that is illegible, so 2× applied.
-  const label = (post_type || 'FLOW OS').toUpperCase();
+  // Pill label — always the brand, never internal taxonomy (post_type is not consumer-facing).
+  // Spec said 10px; at 1080px wide that is illegible, so 2× applied.
+  const label = 'FLOW OS';
   ctx.font = 'bold 20px "Montserrat"';
   const track = 4;
   const labelW = measureTracked(ctx, label, track);

--- a/src/flowos-marketing/generate-image-card.js
+++ b/src/flowos-marketing/generate-image-card.js
@@ -203,7 +203,8 @@ async function renderEditorial(ctx, { headline, subtext, post_type }) {
   const track = 4;
   const labelW = measureTracked(ctx, label, track);
   const pillH = 44;
-  roundRectPath(ctx, PAD, PAD, labelW + 48, pillH, pillH / 2);
+  const pillY = 80;
+  roundRectPath(ctx, PAD, pillY, labelW + 48, pillH, pillH / 2);
   ctx.fillStyle = 'rgba(153,204,204,0.08)';
   ctx.fill();
   ctx.strokeStyle = 'rgba(153,204,204,0.35)';
@@ -211,31 +212,45 @@ async function renderEditorial(ctx, { headline, subtext, post_type }) {
   ctx.stroke();
   ctx.fillStyle = TEAL_ACCENT;
   ctx.textBaseline = 'middle';
-  drawTrackedText(ctx, label, PAD + 24, PAD + pillH / 2 + 1, track);
+  drawTrackedText(ctx, label, PAD + 24, pillY + pillH / 2 + 1, track);
   ctx.textBaseline = 'alphabetic';
 
+  // Measure the content block (accent bar + headline + body), then centre it
+  // vertically between the pill and the footer.
+  const HEAD_SIZE = 56, HEAD_LH = 72, BODY_SIZE = 30, BODY_LH = 46;
+  ctx.font = `bold ${HEAD_SIZE}px "Montserrat"`;
+  const headLines = wrapText(ctx, headline, TEXT_W, 3);
+  ctx.font = `${BODY_SIZE}px "Raleway"`;
+  const bodyLines = subtext ? wrapText(ctx, subtext, TEXT_W, 4) : [];
+
+  const blockH = 60 + HEAD_SIZE + (headLines.length - 1) * HEAD_LH
+    + (bodyLines.length ? 40 + BODY_SIZE + (bodyLines.length - 1) * BODY_LH : 0);
+  const zoneTop = pillY + pillH + 40;
+  const zoneBottom = HEIGHT - FOOTER_H - 40;
+  const top = zoneTop + Math.max(0, (zoneBottom - zoneTop - blockH) / 2);
+
   // Teal accent bar above headline
-  let y = PAD + 150;
   ctx.fillStyle = TEAL_ACCENT;
-  ctx.fillRect(PAD, y, 60, 5);
-  y += 85;
+  ctx.fillRect(PAD, top, 60, 5);
 
   // Headline
+  let y = top + 60 + HEAD_SIZE;
   ctx.fillStyle = CREAM_TEXT;
-  ctx.font = 'bold 48px "Montserrat"';
-  for (const l of wrapText(ctx, headline, TEXT_W, 3)) {
+  ctx.font = `bold ${HEAD_SIZE}px "Montserrat"`;
+  for (const l of headLines) {
     ctx.fillText(l, PAD, y);
-    y += 62;
+    y += HEAD_LH;
   }
+  y -= HEAD_LH;
 
   // Body
-  if (subtext) {
-    y += 30;
+  if (bodyLines.length) {
+    y += 40 + BODY_SIZE;
     ctx.fillStyle = 'rgba(234,229,218,0.65)';
-    ctx.font = '28px "Raleway"';
-    for (const l of wrapText(ctx, subtext, TEXT_W, 4)) {
+    ctx.font = `${BODY_SIZE}px "Raleway"`;
+    for (const l of bodyLines) {
       ctx.fillText(l, PAD, y);
-      y += 42;
+      y += BODY_LH;
     }
   }
 
@@ -248,37 +263,53 @@ async function renderStat(ctx, { stat, stat_label, headline }) {
   drawRadialGlow(ctx, WIDTH - 80, 80, 720, 'rgba(153,204,204,0.08)');
 
   // Accent bar top-left
+  const barY = 80;
   ctx.fillStyle = TEAL_ACCENT;
-  ctx.fillRect(PAD, PAD, 60, 5);
+  ctx.fillRect(PAD, barY, 60, 5);
+
+  // Hook line — pinned to the bottom third, above the footer
+  const HOOK_SIZE = 42, HOOK_LH = 58;
+  ctx.font = `600 ${HOOK_SIZE}px "Montserrat"`;
+  const hookLines = wrapText(ctx, headline, TEXT_W, 3);
+  const hookLast = HEIGHT - FOOTER_H - 70;
+  const hookFirst = hookLast - (hookLines.length - 1) * HOOK_LH;
 
   // Stat number — auto-shrink to fit width
-  let size = 120;
+  let size = 140;
   ctx.font = `bold ${size}px "Montserrat"`;
-  while (size > 48 && ctx.measureText(stat).width > TEXT_W) {
+  while (size > 60 && ctx.measureText(stat).width > TEXT_W) {
     size -= 4;
     ctx.font = `bold ${size}px "Montserrat"`;
   }
+  const LABEL_SIZE = 32, LABEL_LH = 48;
+  ctx.font = `${LABEL_SIZE}px "Raleway"`;
+  const labelLines = wrapText(ctx, stat_label, TEXT_W, 2);
+
+  // Centre the stat + label block between the accent bar and the hook
+  const blockH = size + 70 + (labelLines.length - 1) * LABEL_LH;
+  const zoneTop = barY + 5 + 40;
+  const zoneBottom = hookFirst - HOOK_SIZE - 50;
+  const top = zoneTop + Math.max(0, (zoneBottom - zoneTop - blockH) / 2);
+
   ctx.fillStyle = TEAL_ACCENT;
-  const statBaseline = PAD + 160 + size;
+  ctx.font = `bold ${size}px "Montserrat"`;
+  const statBaseline = top + size;
   ctx.fillText(stat, PAD, statBaseline);
 
-  // Stat label
   ctx.fillStyle = 'rgba(234,229,218,0.70)';
-  ctx.font = '28px "Raleway"';
+  ctx.font = `${LABEL_SIZE}px "Raleway"`;
   let ly = statBaseline + 70;
-  for (const l of wrapText(ctx, stat_label, TEXT_W, 2)) {
+  for (const l of labelLines) {
     ctx.fillText(l, PAD, ly);
-    ly += 42;
+    ly += LABEL_LH;
   }
 
-  // Hook line — bottom third
   ctx.fillStyle = CREAM_TEXT;
-  ctx.font = '600 36px "Montserrat"';
-  const hookLines = wrapText(ctx, headline, TEXT_W, 3);
-  let hy = HEIGHT - FOOTER_H - 70 - (hookLines.length - 1) * 50;
+  ctx.font = `600 ${HOOK_SIZE}px "Montserrat"`;
+  let hy = hookFirst;
   for (const l of hookLines) {
     ctx.fillText(l, PAD, hy);
-    hy += 50;
+    hy += HOOK_LH;
   }
 
   await drawFooter(ctx, { line: 'rgba(153,204,204,0.2)', tint: TEAL_ACCENT, alpha: 0.4 });
@@ -295,7 +326,8 @@ async function renderFeature(ctx, { headline, subtext, badge_label, feature_line
   const track = 3;
   const labelW = measureTracked(ctx, label, track);
   const pillH = 42;
-  roundRectPath(ctx, PAD, PAD, labelW + 56, pillH, 20);
+  const pillY = 80;
+  roundRectPath(ctx, PAD, pillY, labelW + 56, pillH, 20);
   ctx.fillStyle = 'rgba(153,204,204,0.25)';
   ctx.fill();
   ctx.strokeStyle = 'rgba(153,204,204,0.4)';
@@ -303,33 +335,47 @@ async function renderFeature(ctx, { headline, subtext, badge_label, feature_line
   ctx.stroke();
   ctx.fillStyle = TEAL_DEEP;
   ctx.textBaseline = 'middle';
-  drawTrackedText(ctx, label, PAD + 28, PAD + pillH / 2 + 1, track);
+  drawTrackedText(ctx, label, PAD + 28, pillY + pillH / 2 + 1, track);
   ctx.textBaseline = 'alphabetic';
 
+  // Measure headline + body, then centre the block between badge and callout strip
+  const HEAD_SIZE = 56, HEAD_LH = 72, BODY_SIZE = 30, BODY_LH = 46;
+  const stripH = 150;
+  const stripY = HEIGHT - FOOTER_H - stripH - 60;
+  ctx.font = `bold ${HEAD_SIZE}px "Montserrat"`;
+  const headLines = wrapText(ctx, headline, TEXT_W, 3);
+  ctx.font = `${BODY_SIZE}px "Raleway"`;
+  const bodyLines = subtext ? wrapText(ctx, subtext, TEXT_W, 4) : [];
+
+  const blockH = HEAD_SIZE + (headLines.length - 1) * HEAD_LH
+    + (bodyLines.length ? 40 + BODY_SIZE + (bodyLines.length - 1) * BODY_LH : 0);
+  const zoneTop = pillY + pillH + 40;
+  const zoneBottom = (feature_line ? stripY : HEIGHT - FOOTER_H) - 40;
+  const top = zoneTop + Math.max(0, (zoneBottom - zoneTop - blockH) / 2);
+
   // Headline
-  let y = PAD + 170;
+  let y = top + HEAD_SIZE;
   ctx.fillStyle = TEAL_DARK;
-  ctx.font = 'bold 48px "Montserrat"';
-  for (const l of wrapText(ctx, headline, TEXT_W, 3)) {
+  ctx.font = `bold ${HEAD_SIZE}px "Montserrat"`;
+  for (const l of headLines) {
     ctx.fillText(l, PAD, y);
-    y += 62;
+    y += HEAD_LH;
   }
+  y -= HEAD_LH;
 
   // Body
-  if (subtext) {
-    y += 30;
+  if (bodyLines.length) {
+    y += 40 + BODY_SIZE;
     ctx.fillStyle = TEAL_BODY;
-    ctx.font = '28px "Raleway"';
-    for (const l of wrapText(ctx, subtext, TEXT_W, 4)) {
+    ctx.font = `${BODY_SIZE}px "Raleway"`;
+    for (const l of bodyLines) {
       ctx.fillText(l, PAD, y);
-      y += 42;
+      y += BODY_LH;
     }
   }
 
   // Feature callout strip — white rounded rect, bottom third
   if (feature_line) {
-    const stripH = 150;
-    const stripY = HEIGHT - FOOTER_H - stripH - 60;
     ctx.save();
     ctx.shadowColor = 'rgba(42,90,90,0.10)';
     ctx.shadowBlur = 24;


### PR DESCRIPTION
## What

Replaces the GHL Marketing static 3-image rotation with a standalone Flow OS branded image generator. Completely separate from the Crete generator (zero imports, zero Crete file changes).

### Server side (live on the branch, tested)
- **`src/flowos-marketing/generate-image-card.js`** — 1080×1350 (4:5) PNG cards via node-canvas. Three card types: `editorial` (dark), `stat` (dark, large number), `feature` (light teal, callout strip). System fonts (Montserrat + newly installed Raleway), Flow OS logomark fetched once from R2 and cached, input validation with descriptive 422 errors.
- **`server.js`** — `POST /api/flowos/generate-image` registered after the Crete block. Inherits the global auth middleware, 20/min rate limit, uploads to `flowos-content` R2 bucket via `FLOWOS_R2_*` env creds, returns `https://media.flowos.tech/marketing/images/{uuid}.png`. No stack traces in responses.

### n8n workflow (JSON in repo — **not yet applied to live n8n**)
- Claude prompt now outputs `headline`, `stat`, `stat_label` (+ few-shot example)
- `Assign Image URL` (hardcoded 3-JPG map) replaced with: Build Image Request → Generate Flow OS Image (HTTP, Bearer auth via agentboardroom.flowos.tech) → Merge Image URL, with error-output fallback that saves the draft with `image_url: null` and alerts Telegram
- Telegram draft-ID bug fixed (`{{ $json[0].id }}` → `{{ $json.id }}`)
- `Awo65rdSe5BvDHtC.before-image-gen.json` = pre-change backup

## Testing
- CLI render of all three card types — visually verified
- Endpoint: success paths (editorial/stat/feature), 422 validation (bad card_type, missing headline, missing stat_label), 401 unauthenticated, Crete regression (still green)
- Cross-host: POST from the n8n droplet through agentboardroom.flowos.tech with Bearer token — success
- Public URL delivery via media.flowos.tech confirmed (200)

## Not in this PR
- Live PUT to n8n workflow `Awo65rdSe5BvDHtC` — pending explicit sign-off
- Draft until adversarial review passes (new HTTP endpoint = security-relevant)