### PR TITLE
feat(trade-engine): Session 1 foundation — FastAPI + scheduler + Supabase layer

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,32 @@
+// PM2 process definitions.
+//
+// Scope: trade-engine only. The five processes already running on this host
+// (agex-hub, trading-worker, quantumclaw, clipper-worker,
+// claude-code-dispatcher) were each started ad-hoc via the PM2 CLI and are
+// managed through ~/.pm2/dump.pm2. They are deliberately NOT reconstructed
+// here — reconstructed definitions would risk changing their behaviour on the
+// next restart. Backfilling them is a separate piece of work.
+//
+// No `env_file` entry: it does not work on this host. PM2 6.0.14 does not
+// inject /root/.quantumclaw/.env into child processes (verified with a probe
+// process that saw neither SUPABASE_URL nor ANTHROPIC_API_KEY, and confirmed
+// against the live trading-worker process environment). The trade engine loads
+// that file itself via python-dotenv in src/trade_engine/config.py, matching
+// what src/trading/execute_trade.py already does.
+
+module.exports = {
+  apps: [
+    {
+      name: 'trade-engine',
+      script: 'src/trade_engine/main.py',
+      interpreter: 'python3',
+      cwd: '/root/QClaw',
+      restart_delay: 5000,
+      max_restarts: 10,
+      autorestart: true,
+      env: {
+        PYTHONUNBUFFERED: '1',
+      },
+    },
+  ],
+}

--- a/src/agents/skills/trading.md
+++ b/src/agents/skills/trading.md
@@ -24,11 +24,16 @@ Live execution requires BOTH `trading_config.trading_enabled = true` AND the
 Trade Executor workflow active. Never enable either without explicit
 confirmation from Tyson in the current conversation.
 
-Status snapshot (2026-07-23, verify via the n8n API before acting):
+Status snapshot (2026-07-28, verify via the n8n API before acting):
 - Position Monitor, Market Scanner, Weekly Analyst — ACTIVE (monitoring /
   analysis / notification only; none of these place trades).
-- Trade Executor — INACTIVE by design. Live execution is OFF.
-- `trading_config.trading_enabled` = false.
+- Trade Executor — **ACTIVE**. Both execution brakes are currently OFF.
+- `trading_config.trading_enabled` = **true**.
+
+  Live execution is ARMED as of this snapshot. `trading_positions` is still
+  empty (no trade has ever been placed), so nothing has fired yet — but the
+  gate described above is open, not closed. Both brakes were previously
+  documented as off on 2026-07-23; that snapshot was stale.
 
 ## System Architecture
 
@@ -56,8 +61,9 @@ convenience — always verify active-state via the API before acting.
 
 Supabase table `trading_config` — a single-row table (id=1) with columns
 (NOT a key/value store):
-- trading_enabled (boolean): false — the live execution gate. ALWAYS confirm
-  with Tyson before setting true.
+- trading_enabled (boolean): **true** as of 2026-07-28 — the live execution
+  gate, currently OPEN. ALWAYS confirm with Tyson before changing it in
+  either direction.
 - max_position_usdc: 10
 - min_edge_threshold: 7 — whole-number percent (7 = 7%). Mirrors the
   scanner's high-edge threshold for reference ONLY; nothing enforces it

--- a/src/trade_engine/config.py
+++ b/src/trade_engine/config.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Environment loading and validation for the trade engine.
+
+Secrets live in /root/.quantumclaw/.env. PM2's `env_file` option does NOT
+inject that file into child processes on this host (verified empirically
+against PM2 6.0.14 — a probe process saw neither SUPABASE_URL nor
+ANTHROPIC_API_KEY, and the live `trading-worker` process environment
+contains no QClaw secrets either). So we load it here with python-dotenv,
+matching the pattern src/trading/execute_trade.py already uses.
+
+`override=False` means anything already exported into the real process
+environment wins over the file — so PM2 `env:` blocks, systemd, or a shell
+export can still take precedence for local overrides.
+
+Validation is fail-fast: a missing required key raises at import time, which
+surfaces as an immediate PM2 crash rather than a service that runs and then
+400s on its first Supabase call.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+ENV_PATH = Path("/root/.quantumclaw/.env")
+
+# Required — no defaults, no fallbacks. Absence is a startup failure.
+REQUIRED_KEYS = (
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "ANTHROPIC_API_KEY",
+    "TELEGRAM_BOT_TOKEN",
+    "OWNER_TELEGRAM_CHAT_ID",
+    "POLYMARKET_PRIVATE_KEY",
+    "POLYMARKET_FUNDER_ADDRESS",
+)
+
+# Optional — safe defaults. See DEFAULTS notes in the PR for why 4003.
+DEFAULT_TRADE_ENGINE_HOST = "127.0.0.1"
+DEFAULT_TRADE_ENGINE_PORT = 4003
+DEFAULT_MONTE_CARLO_HOST = "http://localhost:4001"
+DEFAULT_LOG_LEVEL = "INFO"
+
+VERSION = "0.1.0"
+
+
+class ConfigError(RuntimeError):
+    """Raised when required configuration is missing or malformed."""
+
+
+class Config:
+    """Validated runtime configuration. Instantiating validates."""
+
+    def __init__(self) -> None:
+        load_dotenv(ENV_PATH, override=False)
+
+        missing = [k for k in REQUIRED_KEYS if not os.environ.get(k, "").strip()]
+        if missing:
+            raise ConfigError(
+                "Missing required environment variable(s): "
+                + ", ".join(missing)
+                + f". Expected them in {ENV_PATH} or the process environment."
+            )
+
+        self.supabase_url: str = os.environ["SUPABASE_URL"].rstrip("/")
+        self.supabase_service_role_key: str = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+        self.anthropic_api_key: str = os.environ["ANTHROPIC_API_KEY"]
+        self.telegram_bot_token: str = os.environ["TELEGRAM_BOT_TOKEN"]
+        self.owner_telegram_chat_id: str = os.environ["OWNER_TELEGRAM_CHAT_ID"]
+        self.polymarket_private_key: str = os.environ["POLYMARKET_PRIVATE_KEY"]
+        self.polymarket_funder_address: str = os.environ["POLYMARKET_FUNDER_ADDRESS"]
+
+        self.trade_engine_host: str = os.environ.get(
+            "TRADE_ENGINE_HOST", DEFAULT_TRADE_ENGINE_HOST
+        )
+        self.trade_engine_port: int = self._int_env(
+            "TRADE_ENGINE_PORT", DEFAULT_TRADE_ENGINE_PORT
+        )
+        self.monte_carlo_host: str = os.environ.get(
+            "MONTE_CARLO_HOST", DEFAULT_MONTE_CARLO_HOST
+        ).rstrip("/")
+        self.log_level: str = os.environ.get("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
+
+        self.version: str = VERSION
+
+    @staticmethod
+    def _int_env(key: str, default: int) -> int:
+        raw = os.environ.get(key)
+        if raw is None or not raw.strip():
+            return default
+        try:
+            return int(raw)
+        except ValueError as exc:
+            raise ConfigError(f"{key} must be an integer, got {raw!r}") from exc
+
+    @property
+    def supabase_rest_url(self) -> str:
+        return f"{self.supabase_url}/rest/v1"
+
+    def supabase_headers(self, *, write: bool = False) -> dict[str, str]:
+        """PostgREST auth headers. service_role — these tables are RLS-locked
+        to service_role (policy `service_role_all`), so anon will 401."""
+        headers = {
+            "apikey": self.supabase_service_role_key,
+            "Authorization": f"Bearer {self.supabase_service_role_key}",
+            "Accept": "application/json",
+        }
+        if write:
+            headers["Content-Type"] = "application/json"
+            headers["Prefer"] = "return=representation"
+        return headers
+
+    def __repr__(self) -> str:
+        # Never render secrets.
+        return (
+            f"<Config version={self.version} host={self.trade_engine_host} "
+            f"port={self.trade_engine_port} log_level={self.log_level} "
+            f"supabase_url={self.supabase_url}>"
+        )
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level, logging.INFO),
+        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+    )
+
+
+# Module-level singleton. Import failure here is intentional and fatal.
+config = Config()

--- a/src/trade_engine/database.py
+++ b/src/trade_engine/database.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Supabase access via direct PostgREST calls over httpx.
+
+Deliberately not supabase-py: httpx is already installed on this host and
+used elsewhere, and PostgREST is a plain REST surface. Fewer dependencies,
+no sync/async client split to reason about.
+
+Every request carries the service_role key. All four trading_* tables have
+RLS enabled with a single `service_role_all` policy, so anon credentials get
+zero rows (not an error) — using service_role is required, not optional.
+
+Errors are never swallowed: any non-2xx raises SupabaseError carrying the
+status code and response body.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import httpx
+
+from src.trade_engine.config import config
+from src.trade_engine.models import TradingConfig, TradePosition
+
+log = logging.getLogger("trade_engine.database")
+
+REQUEST_TIMEOUT = httpx.Timeout(20.0, connect=10.0)
+
+_client: Optional[httpx.AsyncClient] = None
+
+
+class SupabaseError(RuntimeError):
+    """Non-2xx from PostgREST, or a malformed/absent expected row."""
+
+    def __init__(self, method: str, path: str, status_code: int, body: str) -> None:
+        self.method = method
+        self.path = path
+        self.status_code = status_code
+        self.body = body
+        super().__init__(f"{method} {path} -> HTTP {status_code}: {body[:500]}")
+
+
+def get_client() -> httpx.AsyncClient:
+    """Lazily create the shared async client. Reused across requests so we
+    keep connections warm rather than reconnecting per call."""
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(
+            base_url=config.supabase_rest_url, timeout=REQUEST_TIMEOUT
+        )
+    return _client
+
+
+async def close_client() -> None:
+    global _client
+    if _client is not None and not _client.is_closed:
+        await _client.aclose()
+    _client = None
+
+
+async def _request(
+    method: str,
+    path: str,
+    *,
+    params: Optional[dict[str, Any]] = None,
+    json_body: Any = None,
+    write: bool = False,
+) -> Any:
+    """Issue a PostgREST request and return the decoded JSON body.
+
+    Logs request and response at DEBUG. Headers are never logged — they carry
+    the service_role key.
+    """
+    client = get_client()
+    log.debug("-> %s %s params=%s body=%s", method, path, params, json_body)
+
+    response = await client.request(
+        method,
+        path,
+        params=params,
+        json=json_body,
+        headers=config.supabase_headers(write=write),
+    )
+
+    log.debug(
+        "<- %s %s HTTP %s body=%s",
+        method,
+        path,
+        response.status_code,
+        response.text[:1000],
+    )
+
+    if response.status_code >= 300:
+        raise SupabaseError(method, path, response.status_code, response.text)
+
+    if response.status_code == 204 or not response.content:
+        return None
+    return response.json()
+
+
+async def get_trading_config() -> TradingConfig:
+    """Read the single trading_config row (id=1). Raises if absent."""
+    rows = await _request("GET", "/trading_config", params={"id": "eq.1"})
+    if not rows:
+        raise SupabaseError("GET", "/trading_config", 200, "no row with id=1")
+    return TradingConfig.model_validate(rows[0])
+
+
+async def get_open_positions() -> list[TradePosition]:
+    """All positions with status='open', newest first."""
+    rows = await _request(
+        "GET",
+        "/trading_positions",
+        params={"status": "eq.open", "order": "opened_at.desc"},
+    )
+    return [TradePosition.model_validate(r) for r in (rows or [])]
+
+
+async def get_resolved_positions(limit: int = 20) -> list[TradePosition]:
+    """Most recently closed positions — context for the Analyst (Session 4)."""
+    rows = await _request(
+        "GET",
+        "/trading_positions",
+        params={
+            "status": "eq.closed",
+            "order": "closed_at.desc",
+            "limit": str(limit),
+        },
+    )
+    return [TradePosition.model_validate(r) for r in (rows or [])]
+
+
+async def write_position(position: dict[str, Any]) -> dict[str, Any]:
+    """Insert a position and return the created row.
+
+    Untested against live data in Session 1 — trading_positions is empty and
+    nothing in this session calls it. First real exercise is Session 5.
+    """
+    rows = await _request(
+        "POST", "/trading_positions", json_body=position, write=True
+    )
+    if not rows:
+        raise SupabaseError(
+            "POST", "/trading_positions", 200, "insert returned no representation"
+        )
+    return rows[0]
+
+
+async def update_position(
+    position_id: str, updates: dict[str, Any]
+) -> dict[str, Any]:
+    """Patch one position by id and return the updated row."""
+    rows = await _request(
+        "PATCH",
+        "/trading_positions",
+        params={"id": f"eq.{position_id}"},
+        json_body=updates,
+        write=True,
+    )
+    if not rows:
+        raise SupabaseError(
+            "PATCH",
+            "/trading_positions",
+            200,
+            f"no row updated for id={position_id}",
+        )
+    return rows[0]
+
+
+async def get_daily_pnl() -> float:
+    """Sum pnl over positions closed since UTC midnight.
+
+    Summed in Python because PostgREST aggregate functions are disabled on
+    this project. Rows with a NULL pnl count as 0. Negative result = loss,
+    which is what the daily_loss_limit brake compares against.
+    """
+    midnight = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    rows = await _request(
+        "GET",
+        "/trading_positions",
+        params={
+            "status": "eq.closed",
+            "closed_at": f"gte.{midnight.isoformat()}",
+            "select": "pnl",
+        },
+    )
+    return float(sum((r.get("pnl") or 0) for r in (rows or [])))
+
+
+async def count_open_positions() -> int:
+    """Cheap count for /health — asks PostgREST for the count header only."""
+    client = get_client()
+    response = await client.get(
+        "/trading_positions",
+        params={"status": "eq.open", "select": "id"},
+        headers={**config.supabase_headers(), "Prefer": "count=exact", "Range": "0-0"},
+    )
+    log.debug("<- GET /trading_positions (count) HTTP %s", response.status_code)
+    if response.status_code >= 300:
+        raise SupabaseError(
+            "GET", "/trading_positions", response.status_code, response.text
+        )
+    # Content-Range looks like "0-0/12", or "*/0" when the table is empty.
+    content_range = response.headers.get("content-range", "")
+    total = content_range.split("/")[-1] if "/" in content_range else ""
+    if not total.isdigit():
+        raise SupabaseError(
+            "GET",
+            "/trading_positions",
+            response.status_code,
+            f"unparseable content-range: {content_range!r}",
+        )
+    return int(total)

--- a/src/trade_engine/main.py
+++ b/src/trade_engine/main.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Trade engine entry point — FastAPI app plus the uvicorn runner.
+
+Bound to 127.0.0.1:4003. Loopback because /health and /config are unauthenticated
+internal endpoints. 4003 rather than 4002 because PM2's clipper-worker already
+owns 0.0.0.0:4002 and answers /health there — binding 4002 would have produced a
+health check that passed while hitting the wrong service.
+
+Run directly (`python3 src/trade_engine/main.py`) under PM2. The sys.path
+insert below makes the absolute `src.trade_engine.*` imports resolve when the
+file is executed as a script rather than imported as a module; `src` resolves
+as a PEP 420 namespace package, so no src/__init__.py is needed.
+"""
+
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+)
+
+import logging  # noqa: E402
+from contextlib import asynccontextmanager  # noqa: E402
+
+import uvicorn  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.responses import JSONResponse  # noqa: E402
+
+from src.trade_engine.config import config, configure_logging  # noqa: E402
+from src.trade_engine.database import (  # noqa: E402
+    SupabaseError,
+    close_client,
+    count_open_positions,
+    get_trading_config,
+)
+from src.trade_engine.models import HealthResponse, TradingConfig  # noqa: E402
+from src.trade_engine.scheduler import (  # noqa: E402
+    is_running,
+    shutdown_scheduler,
+    start_scheduler,
+)
+
+configure_logging(config.log_level)
+log = logging.getLogger("trade_engine.main")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    log.info("trade-engine %s starting on %s:%s", config.version,
+             config.trade_engine_host, config.trade_engine_port)
+    start_scheduler()
+    try:
+        yield
+    finally:
+        shutdown_scheduler()
+        await close_client()
+        log.info("trade-engine stopped")
+
+
+app = FastAPI(title="trade-engine", version=config.version, lifespan=lifespan)
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health() -> JSONResponse:
+    """Liveness plus a live read of trading state.
+
+    A Supabase failure returns 503 with the error text rather than raising a
+    500 — the error is reported, never swallowed, but a DB blip should read as
+    'degraded' to a health check instead of an unhandled exception.
+    """
+    try:
+        cfg = await get_trading_config()
+        open_count = await count_open_positions()
+    except SupabaseError as exc:
+        log.error("health check failed: %s", exc)
+        return JSONResponse(
+            status_code=503,
+            content=HealthResponse(
+                status="degraded",
+                version=config.version,
+                scheduler_running=is_running(),
+                error=str(exc),
+            ).model_dump(),
+        )
+
+    return JSONResponse(
+        content=HealthResponse(
+            status="ok",
+            version=config.version,
+            trading_enabled=cfg.trading_enabled,
+            open_positions=open_count,
+            scheduler_running=is_running(),
+        ).model_dump()
+    )
+
+
+@app.get("/config", response_model=TradingConfig)
+async def read_config() -> TradingConfig:
+    """Current trading_config. No auth — loopback-bound, internal only."""
+    return await get_trading_config()
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        app,
+        host=config.trade_engine_host,
+        port=config.trade_engine_port,
+        log_level=config.log_level.lower(),
+    )

--- a/src/trade_engine/models.py
+++ b/src/trade_engine/models.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Pydantic models mirroring the live Supabase schema.
+
+Column names, types and nullability were read from the PostgREST OpenAPI
+document on 2026-07-28 (both trading_positions and trading_markets are
+currently empty, so a sample row was not available). Fields are Optional
+wherever the column is nullable — that is most of them, since these tables
+were created without NOT NULL on the value columns.
+
+`extra="allow"` is deliberate: if a column is added to Supabase before this
+model is updated, we surface the new field rather than silently dropping it.
+"""
+
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class TradingConfig(BaseModel):
+    """public.trading_config — single row, id=1. NOT a key/value store."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int
+    trading_enabled: Optional[bool] = None
+    max_position_usdc: Optional[float] = None
+    min_edge_threshold: Optional[float] = None
+    daily_loss_limit: Optional[float] = None
+
+
+class TradePosition(BaseModel):
+    """public.trading_positions.
+
+    `status` has no CHECK constraint in Postgres; 'open' is the column default
+    and 'closed' is what the n8n Position Monitor writes on exit. Treat those
+    two as the convention, not as an enforced enum.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    market_id: Optional[str] = None
+    simulation_id: Optional[str] = None
+    direction: str
+    entry_price: Optional[float] = None
+    shares: Optional[float] = None
+    usdc_amount: Optional[float] = None
+    entry_simulation_probability: Optional[float] = None
+    entry_implied_odds: Optional[float] = None
+    entry_edge: Optional[float] = None
+    status: Optional[str] = None
+    exit_price: Optional[float] = None
+    exit_usdc: Optional[float] = None
+    pnl: Optional[float] = None
+    exit_reason: Optional[str] = None
+    opened_at: Optional[datetime] = None
+    closed_at: Optional[datetime] = None
+    tx_hash: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+
+class SimulationResult(BaseModel):
+    """public.trading_simulations — persisted Monte Carlo output.
+
+    Unused in Session 1; the Scanner (Session 2) writes these. Kept aligned
+    with the table rather than with the Monte Carlo worker's HTTP response,
+    which is a wider shape (see MonteCarloResponse).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: Optional[str] = None
+    market_id: Optional[str] = None
+    asset: Optional[str] = None
+    simulation_count: Optional[int] = None
+    probability: Optional[float] = None
+    confidence_lower: Optional[float] = None
+    confidence_upper: Optional[float] = None
+    implied_odds: Optional[float] = None
+    edge: Optional[float] = None
+    macro_factors: Optional[dict[str, Any]] = None
+    raw_output: Optional[dict[str, Any]] = None
+    current_price: Optional[float] = None
+    created_at: Optional[datetime] = None
+
+
+class MonteCarloResponse(BaseModel):
+    """POST /simulate response from src/trading/monte_carlo.py (port 4001).
+
+    Not a table. Session 2 posts to the worker and maps this onto
+    SimulationResult before persisting.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    probability: float
+    confidence_lower: float
+    confidence_upper: float
+    current_price: float
+    target: float
+    asset: str
+    horizon_days: int
+    market_type: str
+    question: Optional[str] = None
+    simulations: Optional[int] = None
+    daily_mu: Optional[float] = None
+    daily_sigma: Optional[float] = None
+    macro_adjustment: Optional[float] = None
+    macro_factors: Optional[dict[str, Any]] = None
+
+
+class HealthResponse(BaseModel):
+    status: str
+    version: str
+    trading_enabled: Optional[bool] = None
+    open_positions: Optional[int] = None
+    scheduler_running: bool
+    error: Optional[str] = None

--- a/src/trade_engine/requirements.txt
+++ b/src/trade_engine/requirements.txt
@@ -1,0 +1,13 @@
+# trade-engine dependencies.
+# Only apscheduler was absent from the host at Session 1; the rest are already
+# installed system-wide and pinned here as lower bounds so a fresh host works.
+# Install: pip3 install -r src/trade_engine/requirements.txt --break-system-packages
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0
+apscheduler>=3.10.0
+httpx>=0.27.0
+pydantic>=2.0.0
+anthropic>=0.25.0
+# Required because PM2 env_file does not inject /root/.quantumclaw/.env on this
+# host — config.py loads it with python-dotenv instead. See config.py docstring.
+python-dotenv>=1.0.0

--- a/src/trade_engine/scheduler.py
+++ b/src/trade_engine/scheduler.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""APScheduler instance for the trade engine.
+
+No jobs are registered in Session 1 — the scheduler starts empty and idle.
+The cron constants below are the agreed cadence for Session 2's Scanner and
+Session 3's Position Monitor; they live here so the schedule is defined in
+one place before anything consumes it.
+
+The cadence is asymmetric on purpose: Polymarket resolution activity clusters
+early in the week, so Monday is scanned hourly and the weekend every four
+hours rather than running a flat interval and burning yfinance calls on quiet
+days.
+"""
+
+import logging
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+log = logging.getLogger("trade_engine.scheduler")
+
+# Scanner cadence — cron day-of-week: 0=Sun, 1=Mon ... 6=Sat.
+SCANNER_CRON_MONDAY = "0 */1 * * 1"
+SCANNER_CRON_WEEKDAY = "0 */2 * * 2-5"
+SCANNER_CRON_WEEKEND = "0 */4 * * 0,6"
+
+# Position Monitor cadence — matches the current n8n workflow's 15 minutes.
+MONITOR_INTERVAL_MINUTES = 15
+
+scheduler = AsyncIOScheduler(timezone="UTC")
+
+
+def start_scheduler() -> None:
+    if scheduler.running:
+        log.info("scheduler already running")
+        return
+    scheduler.start()
+    log.info("scheduler started (jobs registered: %d)", len(scheduler.get_jobs()))
+
+
+def shutdown_scheduler() -> None:
+    if not scheduler.running:
+        return
+    # wait=False: nothing long-running is registered yet, and we do not want
+    # shutdown to block PM2's stop timeout once jobs do exist.
+    scheduler.shutdown(wait=False)
+    log.info("scheduler stopped")
+
+
+def is_running() -> bool:
+    return bool(scheduler.running)


### PR DESCRIPTION
Session 1 of 6 for the standalone Python trade engine that will replace the n8n trading workflow cluster.

**Scaffold only.** No scanner, no analyst, no executor, no jobs registered. The n8n trading workflows are untouched and still running. `trading_config` was not modified.

## What's here

| File | Purpose |
|---|---|
| `src/trade_engine/config.py` | Env loading + fail-fast validation |
| `src/trade_engine/models.py` | Pydantic models matching the live Supabase schema |
| `src/trade_engine/database.py` | PostgREST helpers over `httpx` |
| `src/trade_engine/scheduler.py` | `AsyncIOScheduler` + cron constants, no jobs yet |
| `src/trade_engine/main.py` | FastAPI app, `/health` and `/config` |
| `src/trade_engine/requirements.txt` | Trade-engine dependencies |
| `ecosystem.config.cjs` | PM2 registration, trade-engine only |
| `src/agents/skills/trading.md` | Corrects a stale brake snapshot — see below |

## Verification (live, on qclaw)

| # | Check | Result |
|---|---|---|
| 1 | `pm2 status` | `trade-engine` online, 0 restarts, 0 unstable |
| 2 | `curl :4003/health` | `200` · `{"status":"ok","version":"0.1.0","trading_enabled":true,"open_positions":0,"scheduler_running":true}` |
| 3 | `curl :4003/config` | `200` · `{"id":1,"trading_enabled":true,"max_position_usdc":10.0,"min_edge_threshold":7.0,"daily_loss_limit":20.0}` |
| 4 | after 75s | still online, 0 restarts |
| 5 | `from src.trade_engine.database import get_trading_config` | `id=1 trading_enabled=True max_position_usdc=10.0 …` |

Every read helper was also exercised against the live DB: `get_open_positions()` → `[]`, `get_resolved_positions(5)` → `[]`, `get_daily_pnl()` → `0.0`, `count_open_positions()` → `0`. `pm2 save` written. An external probe of `138.68.138.214:4003` gets no response, confirming loopback-only.

`apscheduler` was the only missing dependency (3.11.3 installed, plus the `uvicorn[standard]` extras). Nothing existing was upgraded or downgraded.

## Four corrections against the brief

All four were caught in the audit and confirmed empirically before building.

**1. Port 4003, not 4002.** `clipper-worker` has owned `0.0.0.0:4002` for 55 days (0 restarts) and serves its own `/health` returning **200**. Binding 4002 would have produced a health check that passed while hitting the wrong service. Bound to `127.0.0.1` so `/health` and `/config` stay loopback-only, per P4.

**2. `src/trade_engine/`, not `src/trade-engine/`.** A hyphen is not valid in a Python module path — `from src.trade-engine.database import …` is a `SyntaxError`, so the brief's `__init__.py` and its own verification step could not both have worked.

**3. Secrets load via `python-dotenv`, not PM2 `env_file`.** PM2 6.0.14 does **not** inject `/root/.quantumclaw/.env` into child processes on this host. Verified with a throwaway probe:

```
SUPABASE_URL_PRESENT=false
ANTHROPIC_PRESENT=false
TOTAL_ENV_KEYS=57
```

Corroborated against the live `trading-worker` process environment, which contains none of the QClaw secrets. The `.env` is standard `KEY=value` (56 lines, no `export` prefix), so this is a PM2 limitation, not a parse failure. As briefed, this would have been a guaranteed crash loop: fail-fast validation raises on every required var, PM2 burns `max_restarts: 10`, process stops. `config.py` now uses `load_dotenv(ENV_PATH, override=False)` — matching `src/trading/execute_trade.py` — so a real exported env still takes precedence.

**4. `ecosystem.config.cjs`, not `.js`.** `package.json` sets `"type": "module"`, so PM2 parsed the `.js` file as ESM: `ReferenceError: module is not defined in ES module scope`.

Two smaller deviations: `/health` returns **503 with the error text in the body** on a Supabase failure rather than an unhandled 500 — reported, never swallowed, but a DB blip reads as `degraded` to a health check. And `python-dotenv` was added to `requirements.txt` as a consequence of #3.

## ⚠️ Both trading brakes are currently OFF

The brief stated both brakes were on. Live state contradicts that:

- `trading_config.trading_enabled` = **`true`**
- Trade Executor `fq7spfyiNcpt8Mf7` on n8n = **`active: true`**

`src/agents/skills/trading.md` still documented both as off (snapshot dated 2026-07-23), and `n8n-workflows/trading-executor.json` has `"active": false` — the repo was stale against live. **Live execution is armed.** `trading_positions` is empty (0 rows — no trade has ever been placed), so nothing has fired yet, likely blocked by go-live blockers 9–10 from the Brief B work.

This PR updates `trading.md` to reflect live state. It does **not** change `trading_config` or any workflow state — that's your call.

## Follow-ups (deliberately not done here)

**1. `trading-worker` is publicly exposed.** `http://138.68.138.214:4001/health` returns 200 from the open internet, unauthenticated; `/simulate` is reachable too. No `ufw` on the host. Needs a separate brief: change the bind from `0.0.0.0:4001` to `127.0.0.1:4001`.

**2. Position Monitor writes columns that don't exist.** [`trading-position-monitor.json`](n8n-workflows/trading-position-monitor.json) PATCHes `current_price` and `close_reason`; the real columns are `exit_price` and `exit_reason`. Every close would 400. Latent only because `trading_positions` is empty — it triggers on the first position close.

**3. PM2 `env_file` is broken host-wide.** Worth knowing before any future process is registered assuming it works.

**4. `ecosystem.config.cjs` covers trade-engine only.** The other five processes were each started ad-hoc via the PM2 CLI and live in `~/.pm2/dump.pm2`. Reconstructing them risks changing their behaviour on next restart; backfilling is separate work.

## 7 Pillars

- **P1 Frontend** — n/a
- **P2 Backend** — fail-fast on missing env vars naming every missing key; all DB errors raise `SupabaseError` carrying status and body ✓
- **P3 Database** — read helpers exercised live; write helpers present but untested until Session 5, and documented as such in the docstrings ✓
- **P4 Auth** — `service_role` in all Supabase requests (all four `trading_*` tables are RLS-locked to a single `service_role_all` policy); `/health` and `/config` bound to `127.0.0.1`, confirmed unreachable externally ✓
- **P5 Financial** — no execution path in this session; trading brakes untouched (and their true state now documented) ✓
- **P6 Security** — no secrets in code, all from env; `Config.__repr__` never renders them; request logging deliberately excludes headers ✓
- **P7 Infrastructure** — PM2 managed, `autorestart: true`, `pm2 save` written ✓
