### PR TITLE
feat(trade-engine): Session 2 — port Market Scanner from n8n to Python

### DIFF
--- a/n8n-workflows/trading-executor.json
+++ b/n8n-workflows/trading-executor.json
@@ -1,5 +1,5 @@
 {
-    "updatedAt": "2026-07-28T12:18:28.315Z",
+    "updatedAt": "2026-07-28T12:29:03.709Z",
     "createdAt": "2026-04-03T11:49:20.217Z",
     "id": "fq7spfyiNcpt8Mf7",
     "name": "Trading - Trade Executor",
@@ -387,7 +387,7 @@
     "settings": {
         "executionOrder": "v1",
         "callerPolicy": "workflowsFromSameOwner",
-        "availableInMCP": true,
+        "availableInMCP": false,
         "errorWorkflow": "7kpNnMtnuDWXgWcX",
         "timeSavedMode": "fixed"
     },
@@ -396,7 +396,7 @@
     "pinData": {},
     "versionId": "0e6e5856-a7a8-49f0-b4fb-d2f797f347af",
     "activeVersionId": "0e6e5856-a7a8-49f0-b4fb-d2f797f347af",
-    "versionCounter": 88,
+    "versionCounter": 91,
     "triggerCount": 1,
     "shared": [
         {

--- a/src/trade_engine/config.py
+++ b/src/trade_engine/config.py
@@ -42,6 +42,14 @@ DEFAULT_TRADE_ENGINE_PORT = 4003
 DEFAULT_MONTE_CARLO_HOST = "http://localhost:4001"
 DEFAULT_LOG_LEVEL = "INFO"
 
+# Scanner thresholds. Defaults mirror the live n8n Build Run Summary node
+# (3YahxqOguET3pifj) as calibrated in Brief B on 2026-07-23 — NO_EDGE was
+# widened from -0.10 to -0.20 there. Overridable by env so the Python scanner
+# can be retuned without a deploy while it runs alongside n8n.
+DEFAULT_HIGH_EDGE_THRESHOLD = 0.07
+DEFAULT_NO_EDGE_THRESHOLD = -0.20
+DEFAULT_MIN_ALERT_VOLUME = 5000.0
+
 VERSION = "0.1.0"
 
 
@@ -82,7 +90,27 @@ class Config:
         ).rstrip("/")
         self.log_level: str = os.environ.get("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
 
+        self.high_edge_threshold: float = self._float_env(
+            "HIGH_EDGE_THRESHOLD", DEFAULT_HIGH_EDGE_THRESHOLD
+        )
+        self.no_edge_threshold: float = self._float_env(
+            "NO_EDGE_THRESHOLD", DEFAULT_NO_EDGE_THRESHOLD
+        )
+        self.min_alert_volume: float = self._float_env(
+            "MIN_ALERT_VOLUME", DEFAULT_MIN_ALERT_VOLUME
+        )
+
         self.version: str = VERSION
+
+    @staticmethod
+    def _float_env(key: str, default: float) -> float:
+        raw = os.environ.get(key)
+        if raw is None or not raw.strip():
+            return default
+        try:
+            return float(raw)
+        except ValueError as exc:
+            raise ConfigError(f"{key} must be a number, got {raw!r}") from exc
 
     @staticmethod
     def _int_env(key: str, default: int) -> int:

--- a/src/trade_engine/database.py
+++ b/src/trade_engine/database.py
@@ -169,6 +169,28 @@ async def update_position(
     return rows[0]
 
 
+async def write_simulation(sim: dict[str, Any]) -> dict[str, Any]:
+    """Insert one trading_simulations row and return it.
+
+    Callers must NOT set `market_id`: the column is uuid with an FK to
+    trading_markets.id, while Polymarket ids are numeric strings and
+    conditionIds are 66-char hex. The Polymarket identifier belongs in
+    raw_output.polymarket_market_id, which is what every existing row does.
+    """
+    if "market_id" in sim:
+        raise ValueError(
+            "market_id must not be set on trading_simulations — it is a uuid FK "
+            "to trading_markets.id; put the Polymarket id in "
+            "raw_output.polymarket_market_id instead"
+        )
+    rows = await _request("POST", "/trading_simulations", json_body=sim, write=True)
+    if not rows:
+        raise SupabaseError(
+            "POST", "/trading_simulations", 200, "insert returned no representation"
+        )
+    return rows[0]
+
+
 async def get_daily_pnl() -> float:
     """Sum pnl over positions closed since UTC midnight.
 

--- a/src/trade_engine/main.py
+++ b/src/trade_engine/main.py
@@ -24,6 +24,7 @@ from contextlib import asynccontextmanager  # noqa: E402
 
 import uvicorn  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
+from fastapi.encoders import jsonable_encoder  # noqa: E402
 from fastapi.responses import JSONResponse  # noqa: E402
 
 from src.trade_engine.config import config, configure_logging  # noqa: E402
@@ -32,8 +33,19 @@ from src.trade_engine.database import (  # noqa: E402
     close_client,
     count_open_positions,
     get_trading_config,
+    write_simulation,
 )
-from src.trade_engine.models import HealthResponse, TradingConfig  # noqa: E402
+from src.trade_engine.models import (  # noqa: E402
+    HealthResponse,
+    ScannerRunSummary,
+    TradingConfig,
+)
+from src.trade_engine.scanner import (  # noqa: E402
+    PolymarketScanner,
+    last_run_state,
+    record_run,
+    simulation_rows,
+)
 from src.trade_engine.scheduler import (  # noqa: E402
     is_running,
     shutdown_scheduler,
@@ -68,6 +80,7 @@ async def health() -> JSONResponse:
     500 — the error is reported, never swallowed, but a DB blip should read as
     'degraded' to a health check instead of an unhandled exception.
     """
+    scan_state = last_run_state()
     try:
         cfg = await get_trading_config()
         open_count = await count_open_positions()
@@ -75,22 +88,26 @@ async def health() -> JSONResponse:
         log.error("health check failed: %s", exc)
         return JSONResponse(
             status_code=503,
-            content=HealthResponse(
+            content=jsonable_encoder(HealthResponse(
                 status="degraded",
                 version=config.version,
                 scheduler_running=is_running(),
+                last_scan_at=scan_state["at"],
+                last_scan_high_edge_count=scan_state["high_edge_count"],
                 error=str(exc),
-            ).model_dump(),
+            )),
         )
 
     return JSONResponse(
-        content=HealthResponse(
+        content=jsonable_encoder(HealthResponse(
             status="ok",
             version=config.version,
             trading_enabled=cfg.trading_enabled,
             open_positions=open_count,
             scheduler_running=is_running(),
-        ).model_dump()
+            last_scan_at=scan_state["at"],
+            last_scan_high_edge_count=scan_state["high_edge_count"],
+        ))
     )
 
 
@@ -98,6 +115,63 @@ async def health() -> JSONResponse:
 async def read_config() -> TradingConfig:
     """Current trading_config. No auth — loopback-bound, internal only."""
     return await get_trading_config()
+
+
+@app.post("/scan", response_model=ScannerRunSummary)
+async def scan() -> JSONResponse:
+    """Run the scanner once, on demand.
+
+    No cron is registered yet (Session 4 wires the schedule), so this is the
+    only trigger. No auth — loopback-bound, internal only. Nothing here places
+    a trade: best_trade is a suggestion, and execution lands in Session 5.
+
+    A full pass makes up to 30 sequential /simulate calls at ~0.5s apart plus
+    yfinance latency, so this can take a couple of minutes.
+    """
+    try:
+        open_count = await count_open_positions()
+    except SupabaseError as exc:
+        log.error("scan aborted, could not read open positions: %s", exc)
+        return JSONResponse(
+            status_code=503,
+            content={"error": "could not read open positions", "detail": str(exc)},
+        )
+
+    try:
+        async with PolymarketScanner() as scanner:
+            markets = await scanner.fetch_markets()
+            candidates = await scanner.analyse_edge(markets)
+            simulated, sim_errors = await scanner.run_simulations(candidates)
+            summary = await scanner.build_run_summary(
+                simulated,
+                markets_fetched=len(markets),
+                candidates_analysed=len(candidates),
+                sim_errors=sim_errors,
+                open_positions=open_count,
+            )
+            summary.best_trade = scanner.select_best_trade(summary)
+            record_run(summary)
+    except Exception as exc:  # noqa: BLE001 - surface a clean message, not a stack
+        log.exception("scan failed")
+        return JSONResponse(
+            status_code=500,
+            content={"error": "scan failed", "detail": f"{type(exc).__name__}: {exc}"},
+        )
+
+    # Persist every simulation, not just the high-edge ones — the neutral and
+    # no-edge rows are what make calibration analysis possible later.
+    written, write_errors = 0, 0
+    for row in simulation_rows(simulated):
+        try:
+            await write_simulation(row)
+            written += 1
+        except (SupabaseError, ValueError) as exc:
+            write_errors += 1
+            log.error("failed to persist simulation for %s: %s", row.get("asset"), exc)
+    log.info("persisted %d/%d simulations (%d failed)",
+             written, len(simulated), write_errors)
+
+    return JSONResponse(content=jsonable_encoder(summary))
 
 
 if __name__ == "__main__":

--- a/src/trade_engine/models.py
+++ b/src/trade_engine/models.py
@@ -110,10 +110,52 @@ class MonteCarloResponse(BaseModel):
     macro_factors: Optional[dict[str, Any]] = None
 
 
+class ScannerCandidate(BaseModel):
+    """One market that survived filtering and simulation.
+
+    `edge` is a raw fraction (0.07 == 7 percentage points), NOT the *100 form
+    the n8n Build Run Summary node writes into its summary rows. Position
+    sizing depends on this unit.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    market_id: str
+    question: str
+    asset: str
+    direction: str  # 'YES' or 'NO'
+    edge: float
+    sim_probability: float
+    market_probability: float
+    volume: float
+    horizon_days: int
+    market_url: str
+    amount_usdc: float
+
+
+class ScannerRunSummary(BaseModel):
+    """Result of one scanner pass."""
+
+    model_config = ConfigDict(extra="allow")
+
+    run_at: datetime
+    markets_fetched: int
+    candidates_analysed: int
+    simulations_run: int
+    sim_errors: int
+    high_edge: list[ScannerCandidate] = []
+    no_edge: list[ScannerCandidate] = []
+    neutral_count: int = 0
+    best_trade: Optional[ScannerCandidate] = None
+    open_positions: int = 0
+
+
 class HealthResponse(BaseModel):
     status: str
     version: str
     trading_enabled: Optional[bool] = None
     open_positions: Optional[int] = None
     scheduler_running: bool
+    last_scan_at: Optional[datetime] = None
+    last_scan_high_edge_count: Optional[int] = None
     error: Optional[str] = None

--- a/src/trade_engine/scanner.py
+++ b/src/trade_engine/scanner.py
@@ -1,0 +1,653 @@
+#!/usr/bin/env python3
+"""Market Scanner — Python port of the n8n workflow 3YahxqOguET3pifj.
+
+Ported from the live workflow's three JavaScript nodes, read 2026-07-28:
+`Analyse Edge` (filtering + rung selection), `Run Market Simulations`
+(Monte Carlo dispatch) and `Build Run Summary` (bucketing). The filter logic
+below is a deliberate line-by-line port — where a rule looks odd, it is odd in
+the same way n8n is, because the two run side by side and must agree.
+
+Four places this intentionally does NOT match n8n, all agreed before build:
+
+1. `/markets?limit=200` silently returns 100 — Gamma caps limit at 100, so the
+   n8n node has been under-fetching by half. This paginates to the intended 200.
+2. `edge` is a raw fraction everywhere here. n8n is inconsistent: it buckets on
+   the fraction but writes `edge * 100` into its summary rows. Position sizing
+   is fraction-based, so a percent leak would misprice by 100x.
+3. Deduplication happens on BOTH `conditionId` (at fetch) and n8n's original
+   `id || conditionId` seen-set (inside analyse_edge).
+4. `market_url` is constructed here; n8n never produced one.
+
+The n8n scanner keeps running throughout — nothing here touches it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import re
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import httpx
+
+from src.trade_engine.config import config
+from src.trade_engine.models import ScannerCandidate, ScannerRunSummary
+
+log = logging.getLogger("trade_engine.scanner")
+
+GAMMA_MARKETS_URL = "https://gamma-api.polymarket.com/markets"
+GAMMA_EVENTS_URL = "https://gamma-api.polymarket.com/events"
+POLYMARKET_MARKET_URL = "https://polymarket.com/market/{slug}"
+
+# tag_id 1312 is the crypto/commodities event tag the n8n scanner targets.
+EVENTS_TAG_ID = "1312"
+GAMMA_PAGE_LIMIT = 100          # hard cap enforced by the Gamma API
+MARKETS_TARGET_COUNT = 200      # what the n8n node asks for and never gets
+EVENTS_PAGES = 2                # p1 offset=0, p2 offset=100
+USER_AGENT = "Mozilla/5.0"
+
+# Matches the n8n httpRequest node: timeout 60000, batchSize 1, batchInterval 500.
+SIM_TIMEOUT_SECONDS = 60.0
+SIM_INTERVAL_SECONDS = 0.5
+
+# --- Analyse Edge constants, verbatim from the n8n node ----------------------
+
+ASSET_KEYWORDS: dict[str, list[str]] = {
+    "btc": ["bitcoin", "btc"],
+    "eth": ["ethereum", "eth price", "ether ", "eth hit", "eth reach", "eth above",
+            "eth to ", "eth at ", "eth cross", "ethereum hit", "ethereum reach",
+            "ethereum above"],
+    "sol": ["solana", "sol price", "sol hit", "sol reach", "sol above", "sol to ",
+            "sol at "],
+    "xrp": ["xrp", "ripple"],
+    "gold": ["gold price", "gold hit", "price of gold", "xau", "gold above",
+             "gold reach", "gold to ", "gold at ", "gold cross", "gold exceed",
+             "gold surpass", "gold breaks", "gold past"],
+    "silver": ["silver price", "silver hit", "price of silver", "xag",
+               "silver above", "silver reach", "silver to ", "silver at ",
+               "silver cross", "silver exceed", "silver surpass"],
+    "wti": ["wti", "crude oil price", "west texas", "crude oil", "oil price",
+            "oil above", "oil reach", "oil hit"],
+    "brent": ["brent", "brent crude", "brent oil"],
+    "natgas": ["natural gas", "nat gas", "natgas", "henry hub"],
+}
+
+SPORTS_EXCLUDE = re.compile(
+    r"stanley cup|nba|nfl|nhl|warriors|knights|oilers|lakers|nuggets|cavaliers|"
+    r"celtics|76ers|super bowl|world cup|premier league|championship|playoffs|"
+    r"olympics|finals|win the|grand prix|gold medal|gold cards|golden globe|"
+    r"golden bachelor|olympic gold",
+    re.IGNORECASE,
+)
+
+# Per-asset sanity floor — rejects a parsed "target" that is implausibly small
+# for the asset (e.g. "bitcoin to 5" is a percentage, not a price).
+MIN_PRICE: dict[str, float] = {
+    "btc": 10000, "eth": 500, "sol": 5, "xrp": 0.1, "gold": 1000,
+    "silver": 10, "wti": 30, "brent": 30, "natgas": 1,
+}
+
+TRIGGER_REGEX = re.compile(
+    r"(?:above|over|reach(?:es|ed)?|hit(?:s|ting)?|cross(?:es|ed)?|"
+    r"exceed(?:s|ed)?|surpass(?:es|ed)?|past|to|at)\s+\$?([\d,]+\.?\d*[kmb]?)",
+    re.IGNORECASE,
+)
+DOLLAR_REGEX = re.compile(r"\$[\d,]+\.?\d*[kmb]?", re.IGNORECASE)
+
+# Crypto trades at weekends; commodities do not.
+WEEKEND_ASSETS = {"btc", "eth", "sol", "xrp"}
+
+MIN_PRESIM_VOLUME = 20000
+HORIZON_MAX_DAYS = 35
+YES_PRICE_MIN = 0.01
+YES_PRICE_MAX = 0.99
+RUNGS_PER_EVENT = 3
+GLOBAL_CAP = 30
+
+# Position sizing: $3 at the high-edge threshold, $10 at edge 0.15+.
+AMOUNT_MIN_USDC = 3.0
+AMOUNT_MAX_USDC = 10.0
+AMOUNT_EDGE_FLOOR = 0.07
+AMOUNT_EDGE_CEILING = 0.15
+
+# Session 5 will enforce this before any execution; here it only gates the
+# best_trade suggestion.
+MAX_CONCURRENT_POSITIONS = 2
+
+# Populated after each run so /health can report scanner freshness.
+_last_run: dict[str, Any] = {"at": None, "high_edge_count": None}
+
+
+def last_run_state() -> dict[str, Any]:
+    return dict(_last_run)
+
+
+def record_run(summary: "ScannerRunSummary") -> None:
+    """Stash run freshness for /health. Called by run() and by the /scan route,
+    which drives the stages individually so it can persist the raw simulations."""
+    _last_run["at"] = summary.run_at
+    _last_run["high_edge_count"] = len(summary.high_edge)
+
+
+def _js_parse_float(text: str) -> Optional[float]:
+    """Mimic JavaScript parseFloat: read the leading numeric prefix, ignore the
+    rest, return None where JS returns NaN. Python's float() raises on trailing
+    junk, which would change which markets survive the filter."""
+    match = re.match(r"\s*[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?", text)
+    if not match or not match.group(0).strip():
+        return None
+    try:
+        value = float(match.group(0))
+    except ValueError:
+        return None
+    return value if math.isfinite(value) else None
+
+
+def _parse_numeric(raw: str) -> Optional[float]:
+    """Port of the n8n `parseNumeric` helper: k/m/b suffix expansion."""
+    if not raw:
+        return None
+    suffix = raw[-1].lower()
+    clean = re.sub(r"[,kmb]", "", raw, flags=re.IGNORECASE)
+    value = _js_parse_float(clean)
+    if value is None:
+        return None
+    if suffix == "k":
+        return value * 1_000
+    if suffix == "m":
+        return value * 1_000_000
+    if suffix == "b":
+        return value * 1_000_000_000
+    return value
+
+
+def _outcome_yes_price(market: dict[str, Any]) -> Optional[float]:
+    """outcomePrices arrives as a JSON *string* like '["0.505", "0.495"]'."""
+    raw = market.get("outcomePrices")
+    try:
+        prices = raw
+        if isinstance(raw, str):
+            import json
+
+            prices = json.loads(raw)
+        if prices and prices[0] is not None:
+            return float(prices[0])
+    except Exception:
+        return None
+    return None
+
+
+def _amount_usdc(edge: float) -> float:
+    """Linear $3-$10 on edge magnitude, clamped.
+
+    Uses abs(edge) so a NO-side candidate sizes on conviction too. For the
+    high-edge bucket (edge > 0) this is identical to the briefed formula; only
+    best_trade ever drives money, and best_trade only comes from high_edge.
+    """
+    span = AMOUNT_EDGE_CEILING - AMOUNT_EDGE_FLOOR
+    scaled = AMOUNT_MIN_USDC + (abs(edge) - AMOUNT_EDGE_FLOOR) / span * (
+        AMOUNT_MAX_USDC - AMOUNT_MIN_USDC
+    )
+    return round(max(AMOUNT_MIN_USDC, min(AMOUNT_MAX_USDC, scaled)), 2)
+
+
+class PolymarketScanner:
+    """Fetch → filter → simulate → bucket → pick, matching the n8n pipeline."""
+
+    def __init__(self, client: Optional[httpx.AsyncClient] = None) -> None:
+        self._client = client
+        self._owns_client = client is None
+
+    async def __aenter__(self) -> "PolymarketScanner":
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=httpx.Timeout(30.0, connect=10.0),
+                headers={"User-Agent": USER_AGENT},
+                follow_redirects=True,
+            )
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    # --- fetch ------------------------------------------------------------
+
+    async def fetch_markets(self) -> list[dict[str, Any]]:
+        """Flat /markets plus /events sub-markets, merged and deduplicated.
+
+        Deduplication keys on conditionId first, falling back to id — event
+        ladders repeat the same conditionId across pages.
+        """
+        assert self._client is not None, "use PolymarketScanner as an async context manager"
+
+        flat = await self._fetch_flat_markets()
+        events = await self._fetch_event_markets()
+
+        merged: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for market in [*flat, *events]:
+            key = str(market.get("conditionId") or market.get("id") or "")
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            merged.append(market)
+
+        log.info(
+            "fetched %d markets (%d flat, %d event sub-markets, %d after dedup)",
+            len(merged), len(flat), len(events), len(merged),
+        )
+        return merged
+
+    async def _fetch_flat_markets(self) -> list[dict[str, Any]]:
+        """Paginate to MARKETS_TARGET_COUNT. The n8n node asks for limit=200 in
+        one call and silently receives 100 — Gamma caps limit at 100."""
+        out: list[dict[str, Any]] = []
+        offset = 0
+        while len(out) < MARKETS_TARGET_COUNT:
+            batch = await self._get_json(
+                GAMMA_MARKETS_URL,
+                {"closed": "false", "limit": str(GAMMA_PAGE_LIMIT), "offset": str(offset)},
+            )
+            if not batch:
+                break
+            out.extend(batch)
+            if len(batch) < GAMMA_PAGE_LIMIT:
+                break
+            offset += GAMMA_PAGE_LIMIT
+        return out[:MARKETS_TARGET_COUNT]
+
+    async def _fetch_event_markets(self) -> list[dict[str, Any]]:
+        """Port of `Fetch Events p1/p2` + `Flatten Events`: each event's
+        sub-markets become standalone markets carrying event context."""
+        out: list[dict[str, Any]] = []
+        for page in range(EVENTS_PAGES):
+            events = await self._get_json(
+                GAMMA_EVENTS_URL,
+                {
+                    "closed": "false",
+                    "tag_id": EVENTS_TAG_ID,
+                    "order": "volume24hr",
+                    "ascending": "false",
+                    "limit": str(GAMMA_PAGE_LIMIT),
+                    "offset": str(page * GAMMA_PAGE_LIMIT),
+                },
+            )
+            for event in events or []:
+                for sub in event.get("markets") or []:
+                    out.append({
+                        **sub,
+                        "event_title": event.get("title"),
+                        "event_slug": event.get("slug"),
+                        "source": "polymarket",
+                    })
+        return out
+
+    async def _get_json(self, url: str, params: dict[str, str]) -> list[dict[str, Any]]:
+        assert self._client is not None
+        try:
+            response = await self._client.get(url, params=params)
+        except httpx.HTTPError as exc:
+            log.error("polymarket fetch failed %s params=%s: %s", url, params, exc)
+            return []
+        if response.status_code >= 300:
+            log.error(
+                "polymarket fetch %s params=%s -> HTTP %s: %s",
+                url, params, response.status_code, response.text[:300],
+            )
+            return []
+        payload = response.json()
+        return payload if isinstance(payload, list) else []
+
+    # --- analyse ----------------------------------------------------------
+
+    async def analyse_edge(self, markets: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Port of the `Analyse Edge` node.
+
+        Weekend is evaluated in UTC. n8n used the container's local `getDay()`;
+        both hosts run UTC, so this matches while being explicit about it.
+        """
+        now = datetime.now(timezone.utc)
+        is_weekend = now.weekday() in (5, 6)  # JS getDay() 0=Sun,6=Sat
+
+        results: list[dict[str, Any]] = []
+        seen: set[str] = set()
+
+        for market in markets:
+            question = (market.get("question") or "").lower()
+            description = (market.get("description") or "").lower()
+            full_text = question + " " + description
+            end_date = market.get("endDate") or market.get("end_date_iso")
+            market_id = market.get("id") or market.get("conditionId")
+
+            if market_id in seen:
+                continue
+            seen.add(market_id)
+
+            if SPORTS_EXCLUDE.search(market.get("question") or ""):
+                continue
+
+            asset = None
+            for candidate_asset, keywords in ASSET_KEYWORDS.items():
+                if any(k in full_text for k in keywords):
+                    asset = candidate_asset
+                    break
+            if not asset:
+                continue
+            if is_weekend and asset not in WEEKEND_ASSETS:
+                continue
+
+            dollar_matches = [m.replace("$", "", 1) for m in DOLLAR_REGEX.findall(question)]
+            trigger_matches = TRIGGER_REGEX.findall(question)
+            prices = [
+                p for p in (_parse_numeric(m) for m in [*dollar_matches, *trigger_matches])
+                if p is not None and p > 0
+            ]
+
+            floor = MIN_PRICE.get(asset, 1)
+            valid = [p for p in prices if p >= floor]
+            if not valid:
+                continue
+
+            horizon_days = self._horizon_days(end_date, now)
+            if horizon_days <= 0 or horizon_days > HORIZON_MAX_DAYS:
+                continue
+
+            yes_price = _outcome_yes_price(market)
+            if yes_price is None or yes_price < YES_PRICE_MIN or yes_price > YES_PRICE_MAX:
+                continue
+
+            volume = _js_parse_float(str(market.get("volume") or 0)) or 0.0
+            if volume < MIN_PRESIM_VOLUME:
+                continue
+
+            results.append({
+                "market_id": market_id,
+                "condition_id": market.get("conditionId"),
+                "slug": market.get("slug"),
+                "question": market.get("question"),
+                "asset": asset,
+                "target": max(valid),
+                "yes_price": yes_price,
+                "horizon_days": horizon_days,
+                "end_date": end_date,
+                "volume": volume,
+                "needs_simulation": True,
+                "source": market.get("source") or "polymarket",
+                "event_slug": market.get("event_slug"),
+                "event_title": market.get("event_title"),
+            })
+
+        selected = self._select_rungs(results)
+        log.info(
+            "analyse_edge: %d markets in, %d passed filters, %d after rung/cap selection",
+            len(markets), len(results), len(selected),
+        )
+        return selected
+
+    @staticmethod
+    def _horizon_days(end_date: Optional[str], now: datetime) -> int:
+        """Math.ceil((endDate - now) / 86400000); absent endDate defaults to 30."""
+        if not end_date:
+            return 30
+        try:
+            parsed = datetime.fromisoformat(str(end_date).replace("Z", "+00:00"))
+        except ValueError:
+            return 30
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return math.ceil((parsed - now).total_seconds() / 86400.0)
+
+    @staticmethod
+    def _select_rungs(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Keep <=3 rungs nearest yes~0.5 per event ladder, then global top-30 by
+        volume. Bounds the number of /simulate calls per run."""
+        by_event: dict[str, list[dict[str, Any]]] = {}
+        for row in results:
+            key = row.get("event_slug") or ("single:" + str(row["market_id"]))
+            by_event.setdefault(key, []).append(row)
+
+        selected: list[dict[str, Any]] = []
+        for rungs in by_event.values():
+            rungs.sort(key=lambda r: abs(r["yes_price"] - 0.5))
+            selected.extend(rungs[:RUNGS_PER_EVENT])
+
+        selected.sort(key=lambda r: r["volume"], reverse=True)
+        return selected[:GLOBAL_CAP]
+
+    # --- simulate ---------------------------------------------------------
+
+    async def run_simulations(
+        self, candidates: list[dict[str, Any]]
+    ) -> tuple[list[dict[str, Any]], int]:
+        """POST each candidate to the Monte Carlo worker, sequentially.
+
+        Sequential by design — yfinance is not thread-safe, and the n8n node
+        pins batchSize=1 with a 500ms interval for the same reason. A failed or
+        non-finite simulation drops that market and increments the error count;
+        it never aborts the run (the continueOnFail equivalent).
+
+        Returns (candidates with `simulation` attached, sim_error_count).
+        """
+        assert self._client is not None
+        simulated: list[dict[str, Any]] = []
+        errors = 0
+        url = f"{config.monte_carlo_host}/simulate"
+
+        for index, candidate in enumerate(candidates):
+            if index:
+                await asyncio.sleep(SIM_INTERVAL_SECONDS)
+            body = {
+                "asset": candidate["asset"],
+                "target": candidate["target"],
+                "question": candidate["question"],
+                "horizon_days": candidate["horizon_days"],
+            }
+            try:
+                response = await self._client.post(
+                    url, json=body, timeout=SIM_TIMEOUT_SECONDS
+                )
+            except httpx.TimeoutException:
+                errors += 1
+                log.warning(
+                    "simulate timeout after %ss, skipping market %s (%s)",
+                    SIM_TIMEOUT_SECONDS, candidate["market_id"], candidate["asset"],
+                )
+                continue
+            except httpx.HTTPError as exc:
+                errors += 1
+                log.warning(
+                    "simulate transport error for market %s: %s",
+                    candidate["market_id"], exc,
+                )
+                continue
+
+            if response.status_code >= 300:
+                errors += 1
+                log.warning(
+                    "simulate HTTP %s for market %s (%s): %s",
+                    response.status_code, candidate["market_id"],
+                    candidate["asset"], response.text[:300],
+                )
+                continue
+
+            try:
+                sim = response.json()
+            except ValueError:
+                errors += 1
+                log.warning("simulate returned non-JSON for market %s", candidate["market_id"])
+                continue
+
+            probability = sim.get("probability")
+            if probability is None or not isinstance(probability, (int, float)) \
+                    or not math.isfinite(float(probability)):
+                # monte_carlo sanitises non-finite floats to null before jsonify.
+                errors += 1
+                log.warning(
+                    "simulate returned non-finite probability for market %s (%s): %r",
+                    candidate["market_id"], candidate["asset"], probability,
+                )
+                continue
+
+            simulated.append({**candidate, "simulation": sim})
+
+        log.info("run_simulations: %d ok, %d skipped", len(simulated), errors)
+        return simulated, errors
+
+    # --- summarise --------------------------------------------------------
+
+    async def build_run_summary(
+        self,
+        simulated: list[dict[str, Any]],
+        *,
+        markets_fetched: int,
+        candidates_analysed: int,
+        sim_errors: int,
+        open_positions: int,
+    ) -> ScannerRunSummary:
+        """Port of `Build Run Summary`. edge = sim probability - market YES price,
+        kept as a raw fraction throughout (n8n multiplies by 100 in its summary
+        rows but buckets on the fraction; the fraction is the correct unit)."""
+        high_edge: list[ScannerCandidate] = []
+        no_edge: list[ScannerCandidate] = []
+        neutral_count = 0
+
+        for row in simulated:
+            sim = row["simulation"]
+            sim_probability = float(sim["probability"])
+            edge = sim_probability - row["yes_price"]
+            volume = row["volume"]
+
+            if edge >= config.high_edge_threshold and volume >= config.min_alert_volume:
+                high_edge.append(self._to_candidate(row, edge, sim_probability))
+            elif edge <= config.no_edge_threshold and volume >= config.min_alert_volume:
+                no_edge.append(self._to_candidate(row, edge, sim_probability))
+            else:
+                neutral_count += 1
+
+        summary = ScannerRunSummary(
+            run_at=datetime.now(timezone.utc),
+            markets_fetched=markets_fetched,
+            candidates_analysed=candidates_analysed,
+            simulations_run=len(simulated),
+            sim_errors=sim_errors,
+            high_edge=high_edge,
+            no_edge=no_edge,
+            neutral_count=neutral_count,
+            best_trade=None,
+            open_positions=open_positions,
+        )
+        log.info(
+            "build_run_summary: %d high-edge, %d no-edge, %d neutral",
+            len(high_edge), len(no_edge), neutral_count,
+        )
+        return summary
+
+    @staticmethod
+    def _to_candidate(
+        row: dict[str, Any], edge: float, sim_probability: float
+    ) -> ScannerCandidate:
+        slug = row.get("slug") or ""
+        return ScannerCandidate(
+            market_id=str(row["market_id"]),
+            question=row["question"] or "",
+            asset=row["asset"],
+            direction="YES" if edge > 0 else "NO",
+            edge=edge,
+            sim_probability=sim_probability,
+            market_probability=row["yes_price"],
+            volume=row["volume"],
+            horizon_days=row["horizon_days"],
+            market_url=POLYMARKET_MARKET_URL.format(slug=slug) if slug else "",
+            amount_usdc=_amount_usdc(edge),
+        )
+
+    # --- select -----------------------------------------------------------
+
+    def select_best_trade(self, summary: ScannerRunSummary) -> Optional[ScannerCandidate]:
+        """Highest-conviction high-edge market, subject to the position cap.
+
+        Not present in n8n — the n8n scanner only notifies. Returns None when
+        there is nothing to trade or when the cap is already reached, so a
+        caller can treat None as 'stand down' without inspecting counts.
+        """
+        if not summary.high_edge:
+            return None
+        if summary.open_positions >= MAX_CONCURRENT_POSITIONS:
+            log.info(
+                "position cap reached (%d open >= %d), no best_trade selected",
+                summary.open_positions, MAX_CONCURRENT_POSITIONS,
+            )
+            return None
+        return max(summary.high_edge, key=lambda c: abs(c.edge))
+
+    # --- orchestration ----------------------------------------------------
+
+    async def run(self, *, open_positions: int = 0) -> ScannerRunSummary:
+        """fetch → analyse → simulate → summarise → select."""
+        markets = await self.fetch_markets()
+        candidates = await self.analyse_edge(markets)
+        simulated, sim_errors = await self.run_simulations(candidates)
+        summary = await self.build_run_summary(
+            simulated,
+            markets_fetched=len(markets),
+            candidates_analysed=len(candidates),
+            sim_errors=sim_errors,
+            open_positions=open_positions,
+        )
+        summary.best_trade = self.select_best_trade(summary)
+        record_run(summary)
+
+        if summary.best_trade:
+            log.info(
+                "best_trade: %s %s edge=%.4f amount=$%.2f",
+                summary.best_trade.asset, summary.best_trade.direction,
+                summary.best_trade.edge, summary.best_trade.amount_usdc,
+            )
+        return summary
+
+
+def simulation_rows(summary_source: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Map simulated candidates onto trading_simulations rows.
+
+    `market_id` is deliberately omitted. The column is uuid with an FK to
+    trading_markets.id; Polymarket ids are numeric strings and conditionIds are
+    66-char hex, neither of which is a UUID, and trading_markets is empty so
+    there is nothing to map to. All 5,649 existing rows have market_id NULL and
+    carry the Polymarket id at raw_output.polymarket_market_id — this follows
+    that convention rather than inventing a second one.
+    """
+    rows: list[dict[str, Any]] = []
+    for row in summary_source:
+        sim = row["simulation"]
+        sim_probability = float(sim["probability"])
+        rows.append({
+            "asset": row["asset"],
+            "simulation_count": sim.get("simulations") or 10000,
+            "probability": sim_probability,
+            "current_price": sim.get("current_price"),
+            "edge": sim_probability - row["yes_price"],
+            "implied_odds": row["yes_price"],
+            "macro_factors": sim.get("macro_factors"),
+            "confidence_lower": sim.get("confidence_lower"),
+            "confidence_upper": sim.get("confidence_upper"),
+            "raw_output": {
+                "polymarket_market_id": row["market_id"],
+                "polymarket_condition_id": row.get("condition_id"),
+                "question": row["question"],
+                "target": row["target"],
+                "horizon_days": row["horizon_days"],
+                "end_date": row["end_date"],
+                "volume": row["volume"],
+                "source": row["source"],
+                "event_slug": row.get("event_slug"),
+                "daily_mu": sim.get("daily_mu"),
+                "daily_sigma": sim.get("daily_sigma"),
+                "macro_adjustment": sim.get("macro_adjustment"),
+                "market_type": sim.get("market_type"),
+            },
+        })
+    return rows


### PR DESCRIPTION
Session 2 of 6. Ports the n8n Market Scanner (`3YahxqOguET3pifj`) into `src/trade_engine/`.

The n8n workflow **keeps running and is untouched** — still `active: true`. The Python scanner runs alongside it, triggered manually via `POST /scan`. No cron registered (Session 4). No execution path (Session 5). `trading_config` and both brakes untouched.

## What's here

| File | Change |
|---|---|
| `src/trade_engine/scanner.py` | **new** — `PolymarketScanner`: fetch → analyse → simulate → summarise → select |
| `src/trade_engine/models.py` | `ScannerCandidate`, `ScannerRunSummary` |
| `src/trade_engine/database.py` | `write_simulation` |
| `src/trade_engine/main.py` | `POST /scan`; `last_scan_at` + `last_scan_high_edge_count` on `/health` |
| `src/trade_engine/config.py` | `HIGH_EDGE` / `NO_EDGE` / `MIN_ALERT_VOLUME`, env-overridable |
| `n8n-workflows/trading-executor.json` | mirror sync for the `availableInMCP` housekeeping |

## Live verification

| # | Check | Result |
|---|---|---|
| 1 | `POST /scan` | `200` in **19.6s** — 1395 fetched, 18 candidates, 18 sims, **0 errors**, 2 high-edge, 3 no-edge, 13 neutral |
| 2 | `trading_simulations` | **18 new rows**, matching `simulations_run` exactly |
| 3 | `best_trade` | is the max-`abs(edge)` market; all `amount_usdc` in `[3, 10]`; edge is a fraction |
| 4 | `npm test` | **49 passed, 0 failed** — no regression |
| 5 | `pm2 status` | `trade-engine` online after `/scan`, 0 unstable restarts |

```json
best_trade: { "asset": "eth", "direction": "YES", "edge": 0.1845,
  "sim_probability": 0.3595, "market_probability": 0.175, "amount_usdc": 10.0,
  "question": "Will the price of Ethereum be above $1,900 on July 28?" }
```

Sizing curve end to end: edge `0.07`→`$3.00`, `0.11`→`$7.30`, `0.15`→`$10.00`, `0.40`→`$10.00` (clamped).

## Ported faithfully

`Analyse Edge` and `Build Run Summary` are line-by-line ports of the live JavaScript: **9 assets** (not the 6 in the brief — `silver`, `wti` and `brent` are in the live node too), per-asset `minPrice` sanity floors, sports exclusion, weekend commodity skip, YES bounds `0.01–0.99`, pre-sim volume floor `20,000`, horizon `0 < d <= 35`, target parsing across both `$`-matches and the trigger regex with k/m/b expansion and `Math.max`, `<=3` rungs per event ladder nearest `yes~0.5`, global top-30 by volume. Thresholds `0.07 / -0.20 / 5000`.

## Six deliberate divergences from n8n

1. **Paginates to 200 markets.** Gamma caps `limit` at 100, so `Fetch Polymarket` has been asking for 200 and silently receiving 100 since it was written. Mirroring that would bake in a defect.
2. **`edge` is a raw fraction throughout.** n8n buckets on the fraction but writes `edge * 100` into its summary rows. Position sizing is fraction-based — a percent leak would misprice by 100×. `ScannerCandidate.edge` therefore will not match n8n's `highEdge[].edge` numerically, though both describe the same quantity.
3. **Dedup on `conditionId` at fetch AND** n8n's original `id || conditionId` seen-set inside `analyse_edge`.
4. **`market_url`** constructed from `slug`; n8n never produced one.
5. **`_js_parse_float` mimics JavaScript `parseFloat`.** Python's `float()` raises on trailing junk where JS returns the leading numeric prefix. That difference changes which markets survive the filter, and the two scanners have to agree while running side by side.
6. **Weekend evaluated explicitly in UTC.** JS `getDay()` is 0=Sun/6=Sat; Python `weekday()` is 0=Mon/6=Sun. Ported as `weekday() in (5,6)` and confirmed live — today is Tuesday, `getDay()`=2, filter correctly inactive. The crypto-only result (btc 8, eth 5, sol 3, xrp 2) comes from the volume and horizon gates, not the weekend rule.

One smaller call: `_amount_usdc` uses `abs(edge)`. Identical to the briefed formula for the high-edge bucket where edge is positive — and `best_trade` only ever comes from `high_edge`, so that is the only path that could drive money. It just stops NO-side candidates from all displaying a meaningless flat `$3`.

## `trading_simulations.market_id` — left NULL, by evidence

The column is `uuid` with an FK to `trading_markets.id`. Polymarket `id` is a numeric string (`'540817'`), `conditionId` is 66-char hex (`'0x1fad72…'`) — neither is a UUID, and `trading_markets` is empty so there is nothing to map to. Decisive:

```
total 5649 | with_market_id 0 | with_raw_pm_id 4719
```

All 5,649 existing rows have `market_id` NULL and carry the id at `raw_output.polymarket_market_id` — which is what `Build Run Summary` writes. This follows that convention rather than inventing a second one, and `write_simulation` **raises** if a caller sets `market_id`, so it cannot drift silently. All 18 new rows verified NULL with `raw_output.polymarket_market_id` set.

## Housekeeping

`availableInMCP` → `false` on Trade Executor `fq7spfyiNcpt8Mf7`, done before anything else: `active: true` preserved, all 12 nodes preserved, `errorWorkflow` preserved, **zero nodes changed**, settings delta exactly `{availableInMCP: True → False}`. Repo mirror synced.

This closes out the item flagged at the end of Session 1 — that flag exposed the Trade Executor as an agent-callable MCP tool on a live financial path.

## Follow-ups (unchanged, still open)

1. `trading-worker` publicly reachable on `0.0.0.0:4001`, unauthenticated — needs its own brief to rebind to `127.0.0.1:4001`.
2. Position Monitor `UYA0JppH7eqyI7fQ` PATCHes `current_price` / `close_reason`; real columns are `exit_price` / `exit_reason`. Triggers on the first position close.
3. `src/trading/polymarket_scanner.py` is dead **and** broken — not imported anywhere, not in PM2 or cron, and its `save_to_supabase` writes six columns that don't exist on `trading_markets`. Candidate for deletion once the port is proven.
4. The n8n `Fetch Polymarket` `limit=200` under-fetch (divergence 1) is still live in n8n.

## 7 Pillars

- **P1 Frontend** — n/a
- **P2 Backend** — sim failures (HTTP error, timeout, non-JSON, non-finite probability) are logged, counted into `sim_errors` and skipped; never abort the run. `/scan` returns clean JSON errors, no stack traces ✓
- **P3 Database** — `write_simulation` goes through the shared PostgREST helper with `service_role`; `market_id` UUID handling confirmed against live data and guarded in code ✓
- **P4 Auth** — `/scan` unauthenticated but loopback-only (`127.0.0.1:4003`, verified externally unreachable in Session 1) ✓
- **P5 Financial** — no execution path; `select_best_trade` returns `None` at `open_positions >= 2`; brakes untouched ✓
- **P6 Security** — no secrets in scanner code; `MONTE_CARLO_HOST` and all thresholds from config ✓
- **P7 Infrastructure** — PM2 process unchanged; n8n Market Scanner untouched and still active; no cron registered ✓
