### PR TITLE
docs: LinkedIn Engagement Automation OpenAI→Anthropic migration + n8n resource audit tooling

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -18005,3 +18005,115 @@ PR #80 `649ff14`, CI fix `4475b71`. `src/trade_engine/{config,models,database,sc
 Memory: `project_trade_engine`, `project_qclaw_pm2_host_gotchas`,
 `project_trading_scanner_calibration`. Build-log entry committed direct to main via
 an isolated git worktree at `origin/main`, keeping the live checkout untouched.
+
+---
+
+## 2026-08-03 — n8n `LinkedIn Engagement Automation` (VMqrrhecG2hrpn4C): OpenAI → Anthropic migration
+
+Workflow `VMqrrhecG2hrpn4C` on `webhook.flowos.tech` (n8n **2.4.8**). Two PUTs via the public REST API.
+Left **deactivated** throughout (Tyson deactivated it at 19:33:40Z; `active` never sent in any payload).
+
+### Why now
+Every scheduled run had been failing since **2026-08-01T00:00:00Z**. Last success `1191096` @ 2026-07-31T20:00:00Z.
+Verbatim from execution `1200096`:
+
+```
+lastNodeExecuted: AI Content Analyzer
+error.name: NodeApiError
+error.message: The service is receiving too many requests from you
+error.description: You have no credits remaining. Add credits to continue using the API at
+                   https://platform.openai.com/settings/organization/billing/.
+httpCode: 429
+```
+
+### PUT 1 — provider swap (versionId 83790237-4c68-4544-ac35-8c0dd7b217bd, counter 126→127)
+Both `@n8n/n8n-nodes-langchain.openAi` v1.8 nodes (resource `text` / operation `message`) →
+`n8n-nodes-base.httpRequest` v4.2 → `https://api.anthropic.com/v1/messages`, header `anthropic-version: 2023-06-01`,
+credential `anthropicApi` `1yrpJ3S4Gw6YSUSJ`, `retryOnFail` 3× / 5000ms. Model `claude-sonnet-4-5`,
+`max_tokens` 1024, temperature 0.2 (Analyzer) / 0.8 (Generator). Node names, ids, positions and the
+main-only connection graph preserved byte-identically; node count stayed 22; zero `ai_*` edges introduced.
+
+Chose the HTTP Request route over Basic LLM Chain + Anthropic Chat Model sub-node specifically to keep the
+connection graph identical (the sub-node route is 22→24 nodes plus two `ai_languageModel` edges).
+
+**Temperature asserted live, not assumed:**
+```
+claude-sonnet-4-5  temp=0.2   -> HTTP 200
+claude-sonnet-4-5  temp=0.8   -> HTTP 200
+claude-sonnet-4-5  temp=1.5   -> HTTP 400  temperature: range: 0..1
+claude-sonnet-4-5  temp=-0.1  -> HTTP 400  temperature: range: 0..1
+claude-sonnet-5    temp=0.2   -> HTTP 400  `temperature` is deprecated for this model.
+```
+Hence `claude-sonnet-4-5`, not `claude-sonnet-5`: sonnet-5 would force dropping both temperatures.
+
+**First PUT attempt rejected** — the instance stores a settings key the public-API schema rejects:
+```
+HTTP 400  {"message":"request/body/settings must NOT have additional properties"}
+```
+Allowed set read from the instance itself (`dist/public-api/v1/openapi.yml` → `workflowSettings`):
+`availableInMCP, callerIds, callerPolicy, errorWorkflow, executionOrder, executionTimeout,
+saveDataErrorExecution, saveDataSuccessExecution, saveExecutionProgress, saveManualExecutions,
+timeSavedPerExecution, timezone`. Only `timeSavedMode` is rejected. **n8n MERGES `settings` rather than
+replacing it — `timeSavedMode` survived a PUT that omitted it.** Nothing lost.
+
+**Model ignores the JSON-only instruction.** Live-fire of the generated body before writing returned valid
+scoring JSON *wrapped in ```json fences* despite an explicit "no markdown code fences" system instruction.
+The defensive fence-stripper in `Parse Content Analysis` is load-bearing, not belt-and-braces.
+
+Downstream `Parse Content Analysis` / `Response Quality Gate` moved from `message.content` /
+`choices[0].message.content` to `content[0].text`. Silent `{score:0, engagement_type:'skip'}` fallback replaced
+with a thrown error. Verified no node anywhere reads `usage` / `finish_reason` / token counts.
+
+### PUT 2 — hygiene + bugfix (versionId 417882f6-893e-4493-973f-a6c843a433d7, counter 135→136)
+1. Four `{{ }}` placeholders in the Analyzer system prompt now evaluate. Pre-migration they lacked the leading
+   `=` so n8n passed them to the model as literal mustache text; post-migration the equivalent is live JS
+   interpolation inside the `jsonBody` expression. All other braces (the JSON example block) are `{`/`}`
+   escaped so they can never be read as expression delimiters.
+2. `settings.errorWorkflow` → `7kpNnMtnuDWXgWcX` (`Shared Error Handler`, active, has an `errorTrigger`).
+3. `Parse Content Analysis` no longer leaks the provider envelope downstream (`model`/`id`/`type`/`role`/
+   `content`/`stop_reason`/`stop_sequence`/`stop_details`/`usage` filtered; legacy keys filtered defensively).
+4. **HELD** — `analysis_reason` on `Engagement Logger`. `public.engagement_activities` has no such column;
+   shipping it would return `400 PGRST204` the moment the engage path becomes reachable. One-line migration
+   pending Tyson's approval.
+5. **BUGFIX (not migration scope)** — `Merge Engagement Context` dropped its `Array.isArray(weightsRaw)` guard.
+   n8n's HTTP Request node already splits a Supabase array response into items, so `.first().json` is the row
+   *object* and the guard always failed, silently discarding the row and reporting `has_weight_data:false`.
+   **Masked**: the discarded row's values (`7, [], 0, 0`) coincide exactly with the hardcoded defaults, so the
+   bug was invisible until the row gains real data.
+
+### `errorWorkflow` and the publish model
+`workflow_history` columns are `versionId, workflowId, authors, createdAt, updatedAt, nodes, connections, name,
+autosaved, description` — **no `settings`**. Settings live only on `workflow_entity`, so `errorWorkflow` is not a
+versioned property and the draft/published distinction does not apply to it. Confirmed in Postgres:
+`active=f | activeVersionId='' | settings={... "errorWorkflow":"7kpNnMtnuDWXgWcX"}`. Node changes *are* versioned —
+history row `417882f6` @ 20:06:24Z is what publishes on reactivation.
+
+### Root cause of the empty-post analysis (pre-existing, NOT introduced by this migration)
+`LinkedIn Feed Monitor` is `n8n-nodes-base.linkedIn` with `operation: "getAll"`. Loading the compiled node class
+inside the container shows it declares **resources `[post]`, operations `[create]`** — `getAll` does not exist.
+n8n emits `{}` instead of erroring. Both providers independently reported an empty post and scored 1/skip:
+
+```
+1191096 (2026-07-31, gpt-4.1-mini): "The post contains no content, making it irrelevant and unengaging..."
+1200573 (2026-08-03, claude-sonnet-4-5): "Empty post with no content, author information, or engagement metrics."
+```
+
+`LinkedIn Comment Creator` (`resource: comment`) and `LinkedIn Like Action` (`resource: reaction`) reference
+resources that likewise do not exist. The workflow has never read a LinkedIn post. Scoped as a separate brief.
+
+### Instance-wide audit (script-driven, not a manual pass)
+`extract_nodedefs.js` loads every installed node class inside the container (core + community roots, every package
+declaring `n8n.nodes`) and reads `description.properties`; `audit_resources.py` cross-references every workflow.
+**1248/1248 nodes across 81 workflows, 544 node types, 0 unrecognised types, 0 load errors → 3 defects, all in
+`LinkedIn Engagement Automation`, all in `n8n-nodes-base.linkedIn`.** The defect class is not widespread.
+(Node-type lookup must be case-insensitive: workflows store `n8n-nodes-base.youtube`, the node declares `youTube`.)
+
+### Open
+- Credential `I9np0X3gCWfXpKEf` (OpenAI) is dead and still referenced by **22 nodes across 15 workflows,
+  8 of them active**. Not touched.
+- `N8N_API_KEY` in `n8n-project/n8n-dashboard-server/.env` returns 401 (JWT `iat` 2025-09-25, no `exp`).
+  Orphan — `server.js` never reads it. Working key stays in `/root/.quantumclaw/.env` on qclaw.
+
+Backups + payloads + audit data: `/root/n8n-artifacts/2026-08-03-linkedin-migration/` (root, 0600).
+Audit scripts (CI-destined): `/root/QClaw/tools/n8n-audit/`.
+Generated on the local Mac; copied here 2026-08-03.

--- a/tools/n8n-audit/README.md
+++ b/tools/n8n-audit/README.md
@@ -1,0 +1,45 @@
+# n8n invalid resource/operation audit
+
+n8n emits `{}` instead of erroring when a node is configured with a `resource` or
+`operation` value that does not exist on its node type. The failure is silent at
+runtime, so this defect class is invisible by default. Found 2026-08-03 via
+`LinkedIn Feed Monitor` (`operation: "getAll"` on a node that only declares
+`operation: create`), which had been returning `{}` for the life of the workflow.
+
+## Usage
+
+1. Extract ground truth from the running container (loads every installed node
+   class and reads `description.properties` — core packages *and* community
+   nodes under `~/.n8n/nodes/node_modules`):
+
+   ```sh
+   docker cp extract_nodedefs.js <n8n-container>:/tmp/
+   docker exec <n8n-container> node /tmp/extract_nodedefs.js > nodedefs.json
+   ```
+
+2. Dump all workflows next to it as `all_wf.json`:
+
+   ```sh
+   curl -sS -H "X-N8N-API-KEY: $N8N_API_KEY" \
+     'https://webhook.flowos.tech/api/v1/workflows?limit=250' > all_wf.json
+   ```
+
+3. Audit:
+
+   ```sh
+   python3 audit_resources.py          # writes audit_findings.json
+   ```
+
+## Notes
+
+- Node-type lookup **must** be case-insensitive: workflows store
+  `n8n-nodes-base.youtube` while the node declares itself `youTube`.
+- Nodes whose `resource`/`operation` is an n8n expression (`=...`) are skipped —
+  they cannot be resolved statically.
+- Severity keys off `workflow.active`: a defect in an active workflow is CRITICAL.
+- Exit is informational; wire a non-zero exit on CRITICAL if used as a CI gate.
+
+## Baseline (2026-08-03)
+
+1248 nodes / 81 workflows / 544 node types / 0 unrecognised types / 0 load errors
+→ 3 defects, all in `LinkedIn Engagement Automation`, all `n8n-nodes-base.linkedIn`.

--- a/tools/n8n-audit/audit_resources.py
+++ b/tools/n8n-audit/audit_resources.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Finding C — instance-wide audit for nodes whose resource/operation values
+do not exist on their node type.
+
+n8n emits {} instead of erroring for an unknown operation, so this defect class
+is invisible at runtime. Ground truth comes from extract_nodedefs.js, which
+loads the compiled node classes inside the container and reads
+description.properties — not from a hand-maintained list.
+
+Reports counts and severity only.
+"""
+import json, os, collections
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_RAW = json.load(open(os.path.join(_HERE, 'nodedefs.json')))['nodeTypes']
+# n8n resolves node types case-insensitively (workflows store
+# 'n8n-nodes-base.youtube'; the node declares itself as 'youTube').
+DEFS_CI = {k.lower(): v for k, v in _RAW.items()}
+DEFS = _RAW
+WFS = json.load(open(os.path.join(_HERE, 'all_wf.json')))['data']
+
+
+def is_expr(v):
+    return isinstance(v, str) and v.startswith('=')
+
+
+findings = []
+skipped_expr = 0
+unknown_type = collections.Counter()
+
+for wf in WFS:
+    for n in wf.get('nodes') or []:
+        t = n.get('type', '')
+        d = DEFS_CI.get(t.lower())
+        if d is None:
+            unknown_type[t] += 1
+            continue
+        # node type has no resource/operation concept at all
+        if not d['resources'] and not d['operations']:
+            continue
+
+        p = n.get('parameters') or {}
+        res, op = p.get('resource'), p.get('operation')
+        if is_expr(res) or is_expr(op):
+            skipped_expr += 1
+            continue
+        eff_res = res if res is not None else d.get('defaultResource')
+
+        problems = []
+        if res is not None and d['resources'] and res not in d['resources']:
+            problems.append(('invalid_resource', res, d['resources']))
+        if op is not None and d['operations'] and op not in d['operations']:
+            problems.append(('invalid_operation', op, d['operations']))
+        # operation exists somewhere on the node but not under this resource
+        if (op is not None and not any(k == 'invalid_operation' for k, _, _ in problems)
+                and eff_res and d['opsByResource']):
+            allowed = set(d['opsByResource'].get(eff_res, [])) | set(d['opsByResource'].get('*', []))
+            if allowed and op not in allowed:
+                problems.append(('operation_wrong_resource', f'{eff_res}/{op}', sorted(allowed)))
+
+        for kind, bad, valid in problems:
+            sev = ('CRITICAL' if (wf.get('active') and kind != 'operation_wrong_resource')
+                   else 'HIGH' if wf.get('active')
+                   else 'MEDIUM')
+            findings.append({'severity': sev, 'kind': kind, 'workflow': wf.get('name'),
+                             'workflow_id': wf.get('id'), 'active': bool(wf.get('active')),
+                             'node': n.get('name'), 'type': t, 'bad': bad, 'valid': valid})
+
+json.dump(findings, open(os.path.join(_HERE, 'audit_findings.json'), 'w'), indent=2)
+
+print(f"workflows scanned      : {len(WFS)}")
+print(f"nodes scanned          : {sum(len(w.get('nodes') or []) for w in WFS)}")
+print(f"node types with defs   : {len(DEFS)}")
+print(f"skipped (expression)   : {skipped_expr}")
+print(f"unrecognised node types: {len(unknown_type)} distinct"
+      + (f"  e.g. {list(unknown_type)[:3]}" if unknown_type else ""))
+print()
+print(f"TOTAL DEFECTS          : {len(findings)}")
+by_sev = collections.Counter(f['severity'] for f in findings)
+for s in ('CRITICAL', 'HIGH', 'MEDIUM'):
+    if by_sev.get(s):
+        print(f"  {s:9s}: {by_sev[s]}")
+print()
+by_kind = collections.Counter(f['kind'] for f in findings)
+for k, c in by_kind.most_common():
+    print(f"  {k:26s}: {c}")
+print()
+aw = {f['workflow'] for f in findings if f['active']}
+iw = {f['workflow'] for f in findings if not f['active']}
+print(f"distinct workflows affected: {len(aw | iw)}  ({len(aw)} active, {len(iw)} inactive)")
+print(f"distinct node types affected: {len({f['type'] for f in findings})}")

--- a/tools/n8n-audit/extract_nodedefs.js
+++ b/tools/n8n-audit/extract_nodedefs.js
@@ -1,0 +1,97 @@
+/* Runs INSIDE the n8n container.
+ * Loads every installed node's compiled description and emits, per node type,
+ * the declared `resource` values and the declared `operation` values together
+ * with the resources each operation is scoped to via displayOptions.
+ * Output: single JSON blob on stdout.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOTS = ['/usr/local/lib/node_modules/n8n/node_modules', '/home/node/.n8n/nodes/node_modules'];
+// discover every package that declares n8n nodes, core + community
+const PKGS = [];
+for (const R of ROOTS) {
+  let tops = [];
+  try { tops = fs.readdirSync(R); } catch (e) { continue; }
+  for (const t of tops) {
+    if (t.startsWith('@')) {
+      let subs = []; try { subs = fs.readdirSync(path.join(R, t)); } catch (e) {}
+      for (const s2 of subs) PKGS.push([R, `${t}/${s2}`]);
+    } else PKGS.push([R, t]);
+  }
+}
+
+const out = {};
+const errors = [];
+
+function collect(desc, typeName) {
+  if (!desc || !Array.isArray(desc.properties)) return;
+  const entry = out[typeName] || { resources: new Set(), operations: new Set(), opsByResource: {} };
+  for (const p of desc.properties) {
+    if (p.name !== 'resource' && p.name !== 'operation') continue;
+    const opts = Array.isArray(p.options) ? p.options : [];
+    const vals = opts.map(o => o.value).filter(v => typeof v === 'string');
+    if (p.name === 'resource') {
+      vals.forEach(v => entry.resources.add(v));
+    } else {
+      vals.forEach(v => entry.operations.add(v));
+      // which resource(s) is this operation block shown for?
+      const show = p.displayOptions && p.displayOptions.show;
+      const forRes = (show && Array.isArray(show.resource)) ? show.resource : ['*'];
+      for (const r of forRes) {
+        entry.opsByResource[r] = entry.opsByResource[r] || new Set();
+        vals.forEach(v => entry.opsByResource[r].add(v));
+      }
+    }
+  }
+  // default resource (used when a workflow node omits `resource`)
+  const rp = desc.properties.find(p => p.name === 'resource');
+  if (rp && typeof rp.default === 'string') entry.defaultResource = rp.default;
+  out[typeName] = entry;
+}
+
+for (const [ROOT, pkg] of PKGS) {
+  let pj;
+  try { pj = JSON.parse(fs.readFileSync(path.join(ROOT, pkg, 'package.json'), 'utf8')); }
+  catch (e) { continue; }
+  const nodeFiles = (pj.n8n && pj.n8n.nodes) || [];
+  if (!nodeFiles.length) continue;
+  for (const rel of nodeFiles) {
+    const abs = path.join(ROOT, pkg, rel);
+    let mod;
+    try { mod = require(abs); }
+    catch (e) { errors.push(`${rel}: ${e.message.slice(0, 90)}`); continue; }
+    for (const key of Object.keys(mod)) {
+      const Cls = mod[key];
+      if (typeof Cls !== 'function') continue;
+      let inst;
+      try { inst = new Cls(); } catch (e) { continue; }
+      // plain node
+      if (inst.description && inst.description.name) {
+        const t = `${pkg}.${inst.description.name}`;
+        collect(inst.description, t);
+      }
+      // versioned node: description on the wrapper, real descs in nodeVersions
+      if (inst.nodeVersions) {
+        const base = inst.baseDescription || inst.description || {};
+        const t = `${pkg}.${base.name}`;
+        for (const v of Object.keys(inst.nodeVersions)) {
+          const nv = inst.nodeVersions[v];
+          if (nv && nv.description) collect(nv.description, t);
+        }
+      }
+    }
+  }
+}
+
+const ser = {};
+for (const [k, v] of Object.entries(out)) {
+  ser[k] = {
+    resources: [...v.resources].sort(),
+    operations: [...v.operations].sort(),
+    defaultResource: v.defaultResource || null,
+    opsByResource: Object.fromEntries(
+      Object.entries(v.opsByResource).map(([r, s]) => [r, [...s].sort()])),
+  };
+}
+process.stdout.write(JSON.stringify({ nodeTypes: ser, loadErrors: errors.slice(0, 15) }));


### PR DESCRIPTION
… migration [2026-08-03]

Two PUTs against workflow VMqrrhecG2hrpn4C on n8n 2.4.8: provider swap to api.anthropic.com (claude-sonnet-4-5), then hygiene + a Merge Engagement Context bugfix. Workflow left deactivated. Adds tools/n8n-audit — instance-wide scan for nodes configured with resource/operation values that do not exist on their node type, which n8n silently answers with {}.

## What does this PR do?

Build log entry for the 2026-08-03 session (PUT 1 + PUT 2, verified on instance).
Adds tools/n8n-audit/ — instance-wide invalid resource/operation scanner.
81 workflows / 1248 nodes / 544 node types, complete coverage. Intended for CI.