### PR TITLE
docs(delegation): repo n8n snapshots are not canonical until diffed a…

### DIFF
--- a/src/agents/skills/delegation.md
+++ b/src/agents/skills/delegation.md
@@ -43,9 +43,10 @@ When dispatching to Claude Code:
 
 1. **Audit first.** No write/infra brief without a Claude Code audit landing first. The audit is a separate dispatch with `task_type: audit`. Wait for the report. Read it. Then write the implementation brief.
 2. **Include full context.** Claude Code has no memory between sessions. Every dispatch carries: target paths, objective, constraints (security, credential locations, patterns to follow), verification step, commit + push instructions.
-3. **Authorisation scopes.** Audit + read-only dispatches: autonomous. Write / infra / merge dispatches: Tyson authorisation in the same conversation, then proceed.
-4. **Track via Supabase** (Slice 5 onwards). Dispatch row in `claude_code_dispatches`, result written back, gate integration verifies completion before close.
-5. **Never sit on a result.** When CC reports back, surface to Tyson immediately — not on the next morning brief.
+3. **Repo snapshots are not canonical.** `n8n-workflows/*.json` in this repo is a snapshot, not the source of truth — live n8n can be edited out-of-band, and has been. Any brief that applies a workflow from repo to live MUST diff repo against the live **published** version first (`workflow_history` row at `workflow_entity.activeVersionId`, not the draft) and report the delta before applying. Never apply-from-repo blind: on 2026-08-04 the dormancy alerter snapshot was 5 entries ahead of live, and a blind apply would have re-armed a churned client's workflow into a live alert.
+4. **Authorisation scopes.** Audit + read-only dispatches: autonomous. Write / infra / merge dispatches: Tyson authorisation in the same conversation, then proceed.
+5. **Track via Supabase** (Slice 5 onwards). Dispatch row in `claude_code_dispatches`, result written back, gate integration verifies completion before close.
+6. **Never sit on a result.** When CC reports back, surface to Tyson immediately — not on the next morning brief.
 
 ## Sub-agent coordination
 


### PR DESCRIPTION
…gainst live

Adds dispatch rule 3. Any brief that applies a workflow from repo to live must diff against the live PUBLISHED version first (workflow_history at activeVersionId, not the draft) and report the delta before applying.

Prompted by the 2026-08-04 dormancy alerter finding: the repo snapshot was 5 entries ahead of live because the 2026-05-13 trading deactivation was applied live only, never committed. A blind apply-from-repo would have re-armed Morning Light (churned client, 84 days silent) into a live hourly Telegram alert.

## What does this PR do?

<!-- One paragraph. Link to issue if applicable. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New skill
- [ ] Documentation
- [ ] Refactor (no behaviour change)

## Checklist

- [ ] I've tested this locally
- [ ] I've updated docs if needed
- [ ] British English used in docs/comments
- [ ] No new dependencies added (or justified why)
