### PR TITLE
gates: consolidate the soft hedge instead of substituting it per sentence

### DIFF
--- a/src/agents/gates.js
+++ b/src/agents/gates.js
@@ -954,19 +954,118 @@ export function runGates(response, auditLog, toolRegistry, opts = {}) {
 
 // ── Regeneration loop (Unit 3) ────────────────────────────────────────────
 
-const SOFT_HEDGE = "[Unverified — I don't have a confirmed tool result for that this turn; let me check and confirm before stating it.]";
+/**
+ * 2026-08-14: the hedge is CONSOLIDATED, not substituted per sentence.
+ *
+ * The original implementation replaced every soft-failed sentence in place with
+ * one fixed bracketed template. That was only ever safe under two assumptions
+ * that do not hold: that at most one sentence hedges per reply, and that a
+ * "sentence" is prose. Both broke live at 2026-08-14 11:33:21Z, when seven state
+ * claims soft-failed in one reply. splitSentences() splits on newlines, so each
+ * markdown table ROW is a sentence, and STATE_RE matches the bare word "Live" in
+ * a Status cell. Six body rows were each replaced by the full template, leaving
+ * an orphaned table header and separator above six identical bracketed lines
+ * (gate.log, 7 × gate:"state" soft_fail at that timestamp). A quieter variant one
+ * turn earlier spliced the template mid-paragraph, gluing it onto the next
+ * sentence.
+ *
+ * So: drop the unbacked sentences and state ONCE, in Charlie's own voice, that
+ * they were left out. That is strictly no more leaky than substitution (the raw
+ * claim still never reaches the user), and it cannot mangle surrounding markup.
+ * None of this changes WHEN a gate fires; only what the user reads afterwards.
+ */
 
-/** Replace each SOFT-fired claim sentence with a fixed hedge (no surgical leak). */
-export function hedgeResponse(response, gateOut) {
-  let out = response;
+/** Anything left when a soft-failed sentence is stripped out of its line. */
+const _scaffoldOnly = (line) => !/[A-Za-z0-9]/.test(
+  String(line).replace(/[|>#*_~`•–—:.\-]/g, ' '));
+
+const _isTableRow = (l) => /^\s*\|.*\|\s*$/.test(l);
+const _isTableSep = (l) => /^\s*\|?[\s:|-]*-[\s:|-]*\|[\s:|-]*$/.test(l);
+
+/** The soft-fired claim sentences, deduplicated, in gate order. */
+function softClaims(gateOut) {
+  const seen = new Set();
   for (const g of (gateOut.gates || [])) {
     if (!g.fired || g.severity !== 'soft') continue;
     for (const c of (g.claims || [])) {
-      const t = c.text || '';
-      if (t && out.includes(t)) out = out.split(t).join(SOFT_HEDGE);
+      const t = String(c.text || '').trim();
+      if (t) seen.add(t);
     }
   }
+  return [...seen];
+}
+
+/**
+ * A table whose every body row was an unbacked claim is left as a bare header
+ * plus separator, which renders as an empty grid. Drop the skeleton too.
+ */
+function dropEmptyTables(lines) {
+  const out = [...lines];
+  for (let i = out.length - 1; i >= 1; i--) {
+    if (!_isTableSep(out[i]) || !_isTableRow(out[i - 1])) continue;
+    let body = 0;
+    for (let j = i + 1; j < out.length && _isTableRow(out[j]) && !_isTableSep(out[j]); j++) body++;
+    if (body === 0) out.splice(i - 1, 2);
+  }
   return out;
+}
+
+/** Collapse the blank-line runs that removal opens up; trim the ends. */
+function tidyBlanks(lines) {
+  const out = [];
+  for (const l of lines) {
+    if (l.trim() === '' && (out.length === 0 || out[out.length - 1].trim() === '')) continue;
+    out.push(l);
+  }
+  while (out.length && out[out.length - 1].trim() === '') out.pop();
+  return out;
+}
+
+/**
+ * Single consolidated caveat. Deliberately a plain sentence in first person,
+ * never a bracketed system-internal token: this string IS user-facing text.
+ * Both sentences are suppressed by isSuppressed ("couldn't" → NEG_RE, "I'll" →
+ * FUTURE_RE), so the post-hedge re-check cannot fire on the caveat itself.
+ */
+export function hedgeNote(n) {
+  return n === 1
+    ? "Note: I left out one statement I couldn't confirm with a tool result this turn. I'll verify it and come back with evidence."
+    : `Note: I left out ${n} statements I couldn't confirm with a tool result this turn. I'll verify them and come back with evidence.`;
+}
+
+/**
+ * Shown when EVERY substantive line was an unbacked claim. Without this the
+ * reply degrades to bare scaffolding plus a caveat, which reads as a glitch
+ * rather than as an answer.
+ */
+export const NO_VERIFIED_ANSWER =
+  "I don't have verified information to answer that right now. Let me run the checks and come back with evidence.";
+
+/** Remove SOFT-fired claim sentences and replace them with ONE caveat. */
+export function hedgeResponse(response, gateOut) {
+  const claims = softClaims(gateOut);
+  const src = String(response ?? '');
+  const present = claims.filter(t => src.includes(t));
+  if (!present.length) return response;
+
+  const kept = [];
+  for (const line of src.split('\n')) {
+    let text = line;
+    let hit = false;
+    for (const t of present) {
+      if (text.includes(t)) { text = text.split(t).join(' '); hit = true; }
+    }
+    if (!hit) { kept.push(line); continue; }
+    // The line was the claim (or is now only markdown punctuation) → drop it.
+    // Anything genuinely left over is kept, with its indentation, so a nested
+    // list item that also held an unbacked sentence does not lose its nesting.
+    const rest = text.replace(/[ \t]+/g, ' ').trim();
+    if (rest && !_scaffoldOnly(rest)) kept.push((line.match(/^[ \t]*/) || [''])[0] + rest);
+  }
+
+  const body = tidyBlanks(dropEmptyTables(kept));
+  if (!body.some(l => !_scaffoldOnly(l))) return NO_VERIFIED_ANSWER;
+  return `${body.join('\n')}\n\n${hedgeNote(present.length)}`;
 }
 
 // Slice 4.1 (V3): describe the VIOLATION by gate, never echo the claim text.

--- a/tests/verification-gates.test.js
+++ b/tests/verification-gates.test.js
@@ -234,7 +234,7 @@ check('runGates: Claude Code "completed" backed by a real result → pass',
   runGates(`Claude Code completed the audit of task ${T1}.`, mkAudit(ccResult(T1)), reg, { now: Date.now(), turnStartMs: Date.now() - 60000 }).result === 'pass');
 
 console.log('Unit 3 — regeneration loop:');
-import { regenerateWithGates, isGatedAgent } from '../src/agents/gates.js';
+import { regenerateWithGates, isGatedAgent, hedgeResponse, hedgeNote, NO_VERIFIED_ANSWER } from '../src/agents/gates.js';
 // P0 scoping: gates apply to charlie only by default; background agents skip them.
 check('U3: isGatedAgent("charlie") default true', isGatedAgent('charlie') === true);
 check('U3: isGatedAgent("echo") default false (background agent skips gates)', isGatedAgent('echo') === false);
@@ -277,12 +277,15 @@ check('U3: cleanupTools fires exactly once AFTER the loop', registered === false
 // sentence now escalates instead of hedging (asserted directly below). The
 // hedge mechanism itself is unchanged and still applies to the common state
 // claim, which names a process/service rather than an opaque id.
+// 2026-08-14: the reply here is a SINGLE unbacked sentence, so removing it
+// leaves nothing — the all-hedged fallback answers instead of an empty body.
 let n4 = 0;
 const r4 = await regenerateWithGates({
   generate: async () => { n4++; return { content: 'The dormancy alerter is running.', model: 'm' }; },
   auditLog: mkAudit([]), toolRegistry: reg, turnStart: past, baseMessages: BM,
 });
-check('U3: soft_fail hedged without a second generate call', n4 === 1 && r4.content.includes('Unverified') && r4.gateOutcome === 'pass');
+check('U3: soft_fail hedged without a second generate call',
+  n4 === 1 && r4.content === NO_VERIFIED_ANSWER && r4.gateOutcome === 'pass');
 // Deliberate severity change when the claim cites an UNSOURCED UUID: soft hedge
 // → hard_fail + escalation. Strengthening, not weakening, and recorded here so
 // the interaction is explicit rather than incidental.
@@ -301,8 +304,9 @@ const r4c = await regenerateWithGates({
   generate: async () => { n4c++; return { content: 'The workflow Qf39NEOEgz2W0uls is running.', model: 'm' }; },
   auditLog: mkAudit([]), toolRegistry: reg, turnStart: past, baseMessages: BM,
 });
-check('U3 (G5): unsourced non-UUID id → hedged in place, no regeneration',
-  n4c === 1 && r4c.gateOutcome === 'pass' && r4c.content.includes('Unverified'));
+check('U3 (G5): unsourced non-UUID id → hedged, no regeneration',
+  n4c === 1 && r4c.gateOutcome === 'pass' && r4c.content === NO_VERIFIED_ANSWER
+  && !r4c.content.includes('Qf39NEOEgz2W0uls'));
 check('U3 (G5): same claim WITH a this-turn probe for that id → pass, unhedged', (() => {
   const r = mkAudit(readPair('shared__n8n-api__n8n-api__get_workflows_id', 'Qf39NEOEgz2W0uls'));
   return runGates('The workflow Qf39NEOEgz2W0uls is running.', r, reg, { now: Date.now(), turnStart: past }).result === 'pass';
@@ -322,6 +326,96 @@ const r6 = await regenerateWithGates({
   auditLog: mkAudit([]), toolRegistry: reg, turnStart: past, baseMessages: BM,
 });
 check('U3: hard_fail then corrected re-prompt → pass, not escalated', r6.gateOutcome === 'pass' && n6 === 2 && !r6.gateEscalated);
+
+// ── Hedge presentation (2026-08-14 placeholder-leak incident) ──────────────
+// Live at 11:33:21Z: seven state claims soft-failed in one reply, six of them
+// markdown table rows whose Status cell read "Live". Each was substituted with
+// the same bracketed template, so the internal placeholder printed six times
+// inside a wrecked table. These assertions pin the PRESENTATION contract only —
+// the gate-firing assertions above are untouched.
+console.log('Hedge presentation (2026-08-14 leak):');
+const softOut = (text) => {
+  const g = runGates(text, mkAudit([]), reg, { now: Date.now(), turnStart: past });
+  return { gate: g, out: hedgeResponse(text, g) };
+};
+
+const INCIDENT_REPLY = [
+  '**Community Manager — FSC is a live specialist** (as of Slice 6d, 2026-07-01).',
+  '',
+  '**Defined capability:**',
+  '',
+  '| Capability | Status |',
+  '|---|---|',
+  '| Member welcome sequences | Live |',
+  '| Live event planning support | Live |',
+  '| Community announcements drafting | Live |',
+  '| Gamification recommendations | Live |',
+  '',
+  '**Out of scope:**',
+  '- Direct posting without review, drafts only',
+  '- Member account-level changes (access, billing)',
+  '',
+  'Want me to delegate a specific community task to them?',
+].join('\n');
+
+const inc = softOut(INCIDENT_REPLY);
+check('HEDGE: incident reply still soft_fails (detection unchanged)', inc.gate.result === 'soft_fail');
+check('HEDGE: no bracketed placeholder reaches the user', !inc.out.includes('[Unverified'));
+check('HEDGE: exactly one caveat, not one per claim',
+  inc.out.split('Note: I left out').length - 1 === 1);
+check('HEDGE: caveat counts every soft claim', (() => {
+  const n = inc.gate.gates.filter(g => g.fired && g.severity === 'soft')
+    .reduce((a, g) => a + g.claims.length, 0);
+  return n >= 4 && inc.out.includes(hedgeNote(n));
+})());
+check('HEDGE: unbacked claim text is gone, not surfaced',
+  !inc.out.includes('Member welcome sequences') && !inc.out.includes('Gamification recommendations'));
+check('HEDGE: surviving prose is preserved verbatim',
+  inc.out.includes('**Out of scope:**')
+  && inc.out.includes('- Member account-level changes (access, billing)')
+  && inc.out.includes('Want me to delegate a specific community task to them?'));
+check('HEDGE: table with no surviving body rows is dropped whole (no orphan header)',
+  !inc.out.includes('| Capability | Status |') && !inc.out.includes('|---|---|'));
+check('HEDGE: hedged output re-checks clean (caveat never self-fires)',
+  runGates(inc.out, mkAudit([]), reg, { now: Date.now(), turnStart: past }).result === 'pass');
+
+// A table that keeps at least one backed row must stay a table.
+const MIXED = [
+  '| Capability | Status |',
+  '|---|---|',
+  '| Member welcome sequences | Live |',
+  '| Draft review queue | Manual for now |',
+].join('\n');
+const mixed = softOut(MIXED);
+check('HEDGE: partially-hedged table keeps its header, separator and backed rows',
+  mixed.out.includes('| Capability | Status |') && mixed.out.includes('|---|---|')
+  && mixed.out.includes('| Draft review queue | Manual for now |')
+  && !mixed.out.includes('Member welcome sequences'));
+
+// Every substantive line unbacked → distinct fallback, not scaffolding + caveat.
+const allSoft = softOut('The dormancy alerter is running.\nThe scanner is live and healthy.');
+check('HEDGE: all-substance-hedged → distinct fallback message',
+  allSoft.out === NO_VERIFIED_ANSWER && !allSoft.out.includes('Note: I left out'));
+check('HEDGE: fallback re-checks clean',
+  runGates(allSoft.out, mkAudit([]), reg, { now: Date.now(), turnStart: past }).result === 'pass');
+
+// Mid-paragraph splice (the 11:32:47Z variant) must not glue text together.
+const midPara = softOut('The alerter is running. The skill file exists on disk.');
+check('HEDGE: mid-paragraph claim removed cleanly, neighbour sentence intact',
+  midPara.out.startsWith('The skill file exists on disk.')
+  && !midPara.out.includes('[Unverified')
+  && midPara.out.includes(hedgeNote(1)));
+
+check('HEDGE: singular caveat reads naturally', hedgeNote(1).includes('one statement')
+  && hedgeNote(2).includes('2 statements'));
+check('HEDGE: no soft claims → response returned untouched', (() => {
+  const t = 'Nothing to see here.';
+  return hedgeResponse(t, { gates: [] }) === t;
+})());
+check('HEDGE: hard-fired claims are never hedged away (reprompt path owns them)', (() => {
+  const t = 'Deployed workflow Zz000000zz11 successfully.';
+  return hedgeResponse(t, runGates(t, mkAudit([]), reg, { now: Date.now(), turnStart: past })) === t;
+})());
 
 console.log('Slice 4.1 — bootstrap-as-evidence + recitation scoping:');
 import { isFirstPersonAction, isGatedTurn, bootstrapCorpus, buildRepromptNote } from '../src/agents/gates.js';


### PR DESCRIPTION
## Incident

2026-08-14 11:33:21Z. Charlie sent Tyson a Telegram reply in which the internal hedge placeholder printed six times inside a wrecked markdown table:

> `[Unverified — I don't have a confirmed tool result for that this turn; let me check and confirm before stating it.]`

## Root cause

`hedgeResponse` replaced every soft-failed sentence in place with one fixed bracketed template. Two assumptions behind that were false:

1. **At most one sentence hedges per reply.** `gate.log` records **7 × `gate:"state"` soft_fail** at that timestamp, all `attempt:1`. The template was pasted seven times.
2. **A "sentence" is prose.** `splitSentences` splits on `\n+`, so each markdown table **row** is a sentence, and `STATE_RE` matches the bare word `Live` in a Status cell. Six body rows were each swapped for the template, leaving an orphaned header and `|---|---|` separator above six identical bracketed lines.

The `11:32:47Z` turn shows the quieter variant: the template spliced mid-paragraph and glued onto the next sentence.

## Fix (presentation only)

- Unbacked sentences are **dropped**, and a single caveat is stated **once**, in first person, at the end.
- A table left with no surviving body rows has its header and separator dropped too, so no empty grid renders.
- When every substantive line was unbacked, a **distinct fallback** answers instead of bare scaffolding plus a caveat.
- Both new strings are plain sentences rather than bracketed system tokens, and both are suppressed by `isSuppressed`, so the post-hedge re-check cannot fire on the caveat itself.

**No gate detection, severity, or firing condition changes.** The incident reply still `soft_fail`s on the same claims, and the raw claim text still never reaches the user.

## Not a PR #88 regression

`git log -S` shows `SOFT_HEDGE` and `hedgeResponse` unchanged since PR #43 (`8698e06`, Slice 4). `gate.log` shows the same shape on 2026-07-08 (soft-failed table row) and 2026-07-09 (six soft state fires in one turn). PR #88 did add a second soft-severity producer (Gate 5 degrades an unsourced non-UUID id to a hedge), which widened exposure, but it did not fire on the incident turn.

## Verification

- Incident reply replayed through `runGates` + `hedgeResponse`: still `soft_fail`, output clean, re-check `pass`, no `[Unverified` anywhere.
- 15 new assertions covering: single caveat, claim text removed, surviving prose verbatim, empty table dropped, partially-hedged table preserved, all-hedged fallback, mid-paragraph splice, hard claims untouched.
- `verification-gates.test.js`: **231/231** (was 216).
- Full JS suite green. `probes.test.js` (pm2) and the two Python imports fail identically on clean `main` in this environment.

## Not deployed

Live host is on `main @ d4aeb62`, clean tree. Deploy is a separate checkout + `pm2 restart`.