### PR TITLE
fix(trade-engine): monitor flags exits instead of claiming closes it never made

### DIFF
--- a/n8n-workflows/migrations/2026_08_20_trading_position_alerts.sql
+++ b/n8n-workflows/migrations/2026_08_20_trading_position_alerts.sql
@@ -1,0 +1,109 @@
+-- 2026-08-20 — Position Monitor exit-side fix: alert state + manual hold.
+--
+-- WHY THIS EXISTS
+-- ---------------
+-- monitor.py::_close() wrote status='closed' whenever a take-profit or
+-- stop-loss threshold fired, but never placed a sell order. On 2026-08-19 a BTC
+-- position's stop loss fired, the DB recorded a closed position with a phantom
+-- -9.27 pnl, and the real Polymarket position stayed open for another 17 hours.
+-- The database and reality diverged with no automatic detection.
+--
+-- Polymarket execution (BUY and SELL alike) is blocked by an unresolved
+-- signer/maker-address issue, so exits are MANUAL for now. The monitor must
+-- therefore FLAG a threshold crossing, not claim a close.
+--
+-- Two objects:
+--   1. trading_position_alerts — one row per unresolved threshold crossing.
+--   2. trading_positions.manual_hold — suppress alerts on a position Tyson is
+--      already managing by hand.
+--
+-- NOT touched: trading_positions' money columns. A threshold crossing never
+-- writes exit_price/exit_usdc/pnl/status. Only a real, manually-confirmed close
+-- populates those. The unrealized estimate lives here, clearly named, so it can
+-- never be mistaken for a realised figure by a reader or by get_daily_pnl().
+--
+-- The RESOLUTION path (resolved_win / resolved_loss) is deliberately unchanged:
+-- a settled market really is closed and really does pay out, so the monitor
+-- still writes status='closed' for those. Only TP/SL/weakening route here.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Alert table
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.trading_position_alerts (
+  id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  position_id             uuid NOT NULL
+                            REFERENCES public.trading_positions(id)
+                            ON DELETE CASCADE,
+  alert_type              text NOT NULL
+                            CHECK (alert_type IN ('weakening', 'stop_loss', 'take_profit')),
+  triggered_at            timestamptz NOT NULL DEFAULT now(),
+  trigger_price           numeric NOT NULL,
+  entry_price             numeric,
+  -- ESTIMATE ONLY. Marked-to-market from trigger_price at alert time. This is
+  -- NOT a realised pnl and must never be copied into trading_positions.pnl,
+  -- which get_daily_pnl() sums into the executor's daily-loss gate.
+  unrealized_pnl_estimate numeric,
+  -- NULL means the Telegram send has not succeeded yet. The row is written
+  -- BEFORE the send so a notification failure can never lose the alert.
+  notified_at             timestamptz,
+  -- Set when a real close is logged for the position. NULL = still live.
+  resolved_at             timestamptz,
+  resolution_note         text
+);
+
+COMMENT ON TABLE public.trading_position_alerts IS
+  'Threshold crossings detected by the Position Monitor. An alert is NOT a close: '
+  'Polymarket exits are manual while the signer/maker-address issue is open.';
+COMMENT ON COLUMN public.trading_position_alerts.unrealized_pnl_estimate IS
+  'Mark-to-market ESTIMATE at trigger time. Never a realised pnl. Never copy to trading_positions.pnl.';
+
+-- Dedup, enforced by the database rather than by monitor logic.
+-- At most one UNRESOLVED alert of a given type per position, so a 15-minute
+-- sweep that re-detects the same condition conflicts instead of re-alerting.
+-- Enforced here (not in Python) so it survives process restarts, concurrent
+-- sweeps, and any future caller.
+CREATE UNIQUE INDEX IF NOT EXISTS trading_position_alerts_live_uniq
+  ON public.trading_position_alerts (position_id, alert_type)
+  WHERE resolved_at IS NULL;
+
+-- Read paths: "what needs attention" and "this position's history".
+CREATE INDEX IF NOT EXISTS trading_position_alerts_unresolved_idx
+  ON public.trading_position_alerts (triggered_at DESC)
+  WHERE resolved_at IS NULL;
+CREATE INDEX IF NOT EXISTS trading_position_alerts_position_idx
+  ON public.trading_position_alerts (position_id, triggered_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- 2. Manual hold flag
+-- ---------------------------------------------------------------------------
+-- A property of the position, not of any one alert: when Tyson is already
+-- handling an exit by hand, the monitor keeps pricing the position (so the
+-- Analyst and dashboard stay accurate) but stops alerting on it.
+ALTER TABLE public.trading_positions
+  ADD COLUMN IF NOT EXISTS manual_hold boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.trading_positions.manual_hold IS
+  'true = Tyson is managing this exit manually; monitor still prices it but emits no alerts.';
+
+-- ---------------------------------------------------------------------------
+-- 3. RLS — service_role only, matching the rest of the trading cluster
+-- ---------------------------------------------------------------------------
+-- Same posture as the 2026-07-15 anon-exposure lockdown: no anon policy, and
+-- FORCE so the table owner is subject to RLS too.
+ALTER TABLE public.trading_position_alerts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.trading_position_alerts FORCE ROW LEVEL SECURITY;
+REVOKE ALL ON public.trading_position_alerts FROM anon, authenticated;
+GRANT ALL ON public.trading_position_alerts TO service_role;
+
+DROP POLICY IF EXISTS trading_position_alerts_service_role
+  ON public.trading_position_alerts;
+CREATE POLICY trading_position_alerts_service_role
+  ON public.trading_position_alerts
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMIT;

--- a/src/agents/skills/trading-api.md
+++ b/src/agents/skills/trading-api.md
@@ -23,6 +23,10 @@ GET /positions - Returns open trading positions
 POST /simulate - Runs one Monte Carlo simulation (body: asset, target, horizon_days, question)
 POST /positions/manual - Log a manually-executed trade so it is tracked and the Analyst learns from its outcome (body: market_url or condition_id, direction YES or NO, entry_price, usdc_amount, optional shares)
 POST /monitor/run - Run the Position Monitor sweep once, on demand
+GET /positions/alerts - Live threshold alerts needing attention; an alert is NOT a close, the position is still open
+GET /positions/{{position_id}}/alerts - Full alert history for one position, resolved ones included
+POST /positions/{{position_id}}/hold - Mark a position manually managed so alerts stop; body hold true or false
+POST /positions/manual-close - Log a position Tyson closed by hand; body position_id, exit_price, optional exit_usdc, exit_reason, note
 
 ## Permissions
 - http: [localhost:4003]
@@ -39,3 +43,14 @@ POST /monitor/run - Run the Position Monitor sweep once, on demand
 - After logging, confirm back to Tyson exactly what was recorded, including whether it linked to a recent scan (simulation_id_linked true/false)
 - A trade on a market the scanner never simulated still logs fine with simulation_id_linked false - that only means less context for the Analyst
 - POST calls here are skill HTTP writes, so the ApprovalGate will ask Tyson for a Telegram approval tap before they execute - tell him to expect it
+
+## Exit alerts and manual closes
+
+- The Position Monitor CANNOT sell. Polymarket execution is manual-only while the signer/maker-address issue is open, so when a take-profit, stop-loss or weakening threshold fires the monitor raises an ALERT and leaves the position OPEN
+- An alert is never a close. If you see an alert, the correct statement is "the stop-loss threshold was hit and it is still open, you need to close it on Polymarket" - never "the position was closed" or "it stopped out"
+- unrealized_pnl_estimate on an alert is an ESTIMATE marked to the trigger price, not a realised loss. Say "estimated unrealized" every time you quote it. The real number only exists after Tyson closes and it is logged
+- When Tyson mentions closing a position: FIRST call GET /positions/alerts (or GET /positions/{{position_id}}/alerts) to see whether an alert already exists for it, THEN call POST /positions/manual-close, THEN tell him which alert it resolved - e.g. "logged, that resolves the stop-loss alert from 15:39". Do not log a close without checking, and do not claim an alert preceded it unless the response says so
+- The manual-close response carries preceded_by_alert. If it is empty, say the close was logged with no prior alert rather than implying one existed
+- exit_usdc is the USDC actually received. Ask Tyson for it. If you omit it the engine derives shares times exit_price and returns exit_usdc_estimated true, which you must surface to him as an approximation rather than reporting it as the settled figure
+- If Tyson says he is already handling an exit himself and does not want repeated alerts, call POST /positions/{{position_id}}/hold with hold true. Alerts stop, price tracking continues. Clear it with hold false
+- A held position still appears in GET /positions with manual_hold true, so never read "no alerts" on a held position as "nothing is wrong"

--- a/src/agents/skills/trading.md
+++ b/src/agents/skills/trading.md
@@ -120,6 +120,13 @@ Tyson a trade "will" go through:
 | 1 | trading_disabled | `trading_config.trading_enabled` is not true | — |
 | 2 | position_cap | too many positions already open | **MAX_CONCURRENT_POSITIONS = 2** (hardcoded in executor.py, NOT in trading_config) |
 | 3 | daily_loss_limit | today's realised loss meets the limit | `daily_loss_limit` (20 USDC) |
+| 4 | edge_below_threshold | `candidate.edge < min_edge_threshold / 100` | 7% |
+| 5 | invalid_amount | size ≤ 0, above config, or above a hard ceiling | `max_position_usdc` (10) AND **ABSOLUTE_MAX_POSITION_USDC = 25.0** (hardcoded ceiling that config cannot raise) |
+| 6 | invalid_market_identifier | no well-formed Polymarket conditionId | — |
+
+Gates 2 and 5's hard limits are code constants, not database config: raising
+`max_position_usdc` above 25 does NOT raise the real ceiling, and there is no
+config key for the 2-position cap.
 
 **Gate 3 depends on manual logging (changed 2026-08-20).** The Position Monitor
 no longer writes a close when a stop-loss or take-profit threshold fires: it
@@ -135,13 +142,7 @@ close that never happened, but it means logging a manual close promptly is now
 load-bearing for risk control, not just for the Analyst's learning loop.
 
 If Tyson mentions closing a position, log it the same session.
-| 4 | edge_below_threshold | `candidate.edge < min_edge_threshold / 100` | 7% |
-| 5 | invalid_amount | size ≤ 0, above config, or above a hard ceiling | `max_position_usdc` (10) AND **ABSOLUTE_MAX_POSITION_USDC = 25.0** (hardcoded ceiling that config cannot raise) |
-| 6 | invalid_market_identifier | no well-formed Polymarket conditionId | — |
 
-Gates 2 and 5's hard limits are code constants, not database config: raising
-`max_position_usdc` above 25 does NOT raise the real ceiling, and there is no
-config key for the 2-position cap.
 
 There is NO HTTP execution route any more. The dashboard's
 POST /api/trading/execute was removed on 2026-08-14. It bypassed the edge

--- a/src/agents/skills/trading.md
+++ b/src/agents/skills/trading.md
@@ -120,6 +120,21 @@ Tyson a trade "will" go through:
 | 1 | trading_disabled | `trading_config.trading_enabled` is not true | — |
 | 2 | position_cap | too many positions already open | **MAX_CONCURRENT_POSITIONS = 2** (hardcoded in executor.py, NOT in trading_config) |
 | 3 | daily_loss_limit | today's realised loss meets the limit | `daily_loss_limit` (20 USDC) |
+
+**Gate 3 depends on manual logging (changed 2026-08-20).** The Position Monitor
+no longer writes a close when a stop-loss or take-profit threshold fires: it
+cannot sell, so it raises an alert and leaves the position open. `get_daily_pnl`
+sums `pnl` over positions closed since UTC midnight, and only a real close
+logged via `POST /positions/manual-close` populates that field.
+
+The tradeoff, stated plainly: **a real loss on a position closed by hand and not
+yet logged is invisible to the daily-loss brake.** Gate 3 will under-count and
+may allow an entry it would otherwise have blocked. This is deliberate and is
+better than the previous behaviour, which fed the gate a *phantom* loss from a
+close that never happened, but it means logging a manual close promptly is now
+load-bearing for risk control, not just for the Analyst's learning loop.
+
+If Tyson mentions closing a position, log it the same session.
 | 4 | edge_below_threshold | `candidate.edge < min_edge_threshold / 100` | 7% |
 | 5 | invalid_amount | size ≤ 0, above config, or above a hard ceiling | `max_position_usdc` (10) AND **ABSOLUTE_MAX_POSITION_USDC = 25.0** (hardcoded ceiling that config cannot raise) |
 | 6 | invalid_market_identifier | no well-formed Polymarket conditionId | — |

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -1537,6 +1537,7 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
         // An alert is NOT a close: the monitor cannot sell, so a flagged
         // position is still open and awaiting a manual exit.
         let alertsByPosition = {};
+        let alertsFetchOk = true;
         try {
           const aRes = await fetch(
             `${SB_URL}/rest/v1/trading_position_alerts?resolved_at=is.null&select=position_id,alert_type,trigger_price,triggered_at,unrealized_pnl_estimate&order=triggered_at.desc`,
@@ -1547,10 +1548,17 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
             for (const a of aRows) {
               (alertsByPosition[a.position_id] ||= []).push(a);
             }
+          } else {
+            // PostgREST error bodies are objects, not arrays. Without this
+            // branch a permissions or schema error rendered as "no alerts",
+            // which is indistinguishable from genuinely-nothing-wrong on the
+            // one panel built to surface what needs attention.
+            alertsFetchOk = false;
+            console.error('[trading] alert fetch returned non-array:', JSON.stringify(aRows).slice(0, 300));
           }
-        } catch {
-          // Alert lookup is additive: positions still render without it. The
-          // table shows no badge rather than failing the whole panel.
+        } catch (e) {
+          alertsFetchOk = false;
+          console.error('[trading] alert fetch failed:', e.message);
         }
         const RANK = { stop_loss: 3, take_profit: 2, weakening: 1 };
         res.json(rows.map(({ trading_simulations: sim, ...p }) => {
@@ -1566,7 +1574,10 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
             has_alert: live.length > 0,
             top_alert: top?.alert_type ?? null,
             top_alert_at: top?.triggered_at ?? null,
-            top_alert_estimate: top?.unrealized_pnl_estimate ?? null
+            top_alert_estimate: top?.unrealized_pnl_estimate ?? null,
+            // false = the alert lookup failed, so absence of a badge means
+            // "unknown", not "clear". The UI renders this distinctly.
+            alerts_fetch_ok: alertsFetchOk
           };
         }));
       } catch (err) { res.status(500).json({ error: err.message }); }

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -1532,11 +1532,43 @@ ${error ? '<p class="err">Invalid token. Please try again.</p>' : ''}
         // No is_paper flag: see the note on /api/trading/balance. tx_hash is
         // NULL on every real position right now, so it says nothing about
         // whether a trade happened.
-        res.json(rows.map(({ trading_simulations: sim, ...p }) => ({
-          ...p,
-          question: sim?.question ?? null,
-          asset: sim?.asset ?? null
-        })));
+        // Live (unresolved) threshold alerts, joined in so the table can show
+        // "this position needs attention" without a second client round-trip.
+        // An alert is NOT a close: the monitor cannot sell, so a flagged
+        // position is still open and awaiting a manual exit.
+        let alertsByPosition = {};
+        try {
+          const aRes = await fetch(
+            `${SB_URL}/rest/v1/trading_position_alerts?resolved_at=is.null&select=position_id,alert_type,trigger_price,triggered_at,unrealized_pnl_estimate&order=triggered_at.desc`,
+            { headers: { apikey: sbKey, Authorization: `Bearer ${sbKey}` } }
+          );
+          const aRows = await aRes.json();
+          if (Array.isArray(aRows)) {
+            for (const a of aRows) {
+              (alertsByPosition[a.position_id] ||= []).push(a);
+            }
+          }
+        } catch {
+          // Alert lookup is additive: positions still render without it. The
+          // table shows no badge rather than failing the whole panel.
+        }
+        const RANK = { stop_loss: 3, take_profit: 2, weakening: 1 };
+        res.json(rows.map(({ trading_simulations: sim, ...p }) => {
+          const live = alertsByPosition[p.id] || [];
+          const top = live.length
+            ? live.reduce((a, b) => ((RANK[b.alert_type] || 0) > (RANK[a.alert_type] || 0) ? b : a))
+            : null;
+          return {
+            ...p,
+            question: sim?.question ?? null,
+            asset: sim?.asset ?? null,
+            alerts: live,
+            has_alert: live.length > 0,
+            top_alert: top?.alert_type ?? null,
+            top_alert_at: top?.triggered_at ?? null,
+            top_alert_estimate: top?.unrealized_pnl_estimate ?? null
+          };
+        }));
       } catch (err) { res.status(500).json({ error: err.message }); }
     });
 

--- a/src/dashboard/ui.html
+++ b/src/dashboard/ui.html
@@ -947,8 +947,8 @@
           <div class="section-title" style="font-size:.9rem">Live Positions</div>
           <div class="table-wrap">
             <table>
-              <thead><tr><th>Market</th><th>Direction</th><th>Entry Price</th><th>Amount</th><th>Status</th></tr></thead>
-              <tbody id="tr-positions-body"><tr><td colspan="5" style="color:var(--text-dim)">Loading...</td></tr></tbody>
+              <thead><tr><th>Market</th><th>Direction</th><th>Entry Price</th><th>Amount</th><th>Status</th><th>Alert</th></tr></thead>
+              <tbody id="tr-positions-body"><tr><td colspan="6" style="color:var(--text-dim)">Loading...</td></tr></tbody>
             </table>
           </div>
         </div>
@@ -2522,13 +2522,28 @@ async function trLoadPositions() {
   try {
     const positions = await (await fetch(API('/api/trading/positions'))).json();
     if (!Array.isArray(positions) || !positions.length) {
-      $('tr-positions-body').innerHTML = '<tr><td colspan="5" style="color:var(--text-dim)">No open positions</td></tr>';
+      $('tr-positions-body').innerHTML = '<tr><td colspan="6" style="color:var(--text-dim)">No open positions</td></tr>';
       return;
     }
     $('tr-positions-body').innerHTML = positions.map(p => {
       const statusBadge = p.status === 'open' ? '<span class="badge badge-green">open</span>'
         : p.status === 'closed' ? '<span class="badge">closed</span>'
         : '<span class="badge badge-yellow">' + trEsc(p.status || '—') + '</span>';
+      // Alert badge. A flagged position is STILL OPEN and awaiting a manual
+      // exit — the monitor cannot sell, so this is a call to action, never a
+      // record that something was closed.
+      const est = p.top_alert_estimate != null
+        ? ' ' + (Number(p.top_alert_estimate) >= 0 ? '+' : '-') + '$' + Math.abs(Number(p.top_alert_estimate)).toFixed(2)
+        : '';
+      const alertCell = p.manual_hold
+        ? '<span class="badge" title="Manually managed: alerts suppressed, price tracking continues">held</span>'
+        : p.top_alert === 'stop_loss'
+          ? '<span class="badge badge-red" title="Stop-loss threshold hit. NOT closed — close on Polymarket, then log it.">stop-loss' + est + '</span>'
+        : p.top_alert === 'take_profit'
+          ? '<span class="badge badge-green" title="Take-profit threshold hit. NOT closed — close on Polymarket, then log it.">take-profit' + est + '</span>'
+        : p.top_alert === 'weakening'
+          ? '<span class="badge badge-yellow" title="Position weakening. Nothing closed.">weakening</span>'
+          : '<span style="color:var(--text-dim)">—</span>';
       // question resolves via simulation_id -> trading_simulations.raw_output.
       // Positions carry no market name of their own.
       const market = p.question || (p.asset ? p.asset.toUpperCase() + ' (unnamed market)' : null);
@@ -2537,9 +2552,10 @@ async function trLoadPositions() {
         + '<td><span class="badge ' + (p.direction === 'YES' ? 'badge-green' : 'badge-red') + '">' + trEsc(p.direction || '—') + '</span></td>'
         + '<td style="font-size:.78rem">' + (p.entry_price != null ? '$' + Number(p.entry_price).toFixed(2) : '—') + '</td>'
         + '<td style="font-size:.78rem">' + (p.usdc_amount != null ? '$' + Number(p.usdc_amount).toFixed(2) : '—') + '</td>'
-        + '<td style="white-space:nowrap">' + statusBadge + '</td></tr>';
+        + '<td style="white-space:nowrap">' + statusBadge + '</td>'
+        + '<td style="white-space:nowrap">' + alertCell + '</td></tr>';
     }).join('');
-  } catch { $('tr-positions-body').innerHTML = '<tr><td colspan="5" style="color:var(--text-dim)">Failed to load</td></tr>'; }
+  } catch { $('tr-positions-body').innerHTML = '<tr><td colspan="6" style="color:var(--text-dim)">Failed to load</td></tr>'; }
 }
 
 async function trLoadSimulations() {

--- a/src/dashboard/ui.html
+++ b/src/dashboard/ui.html
@@ -2535,15 +2535,26 @@ async function trLoadPositions() {
       const est = p.top_alert_estimate != null
         ? ' ' + (Number(p.top_alert_estimate) >= 0 ? '+' : '-') + '$' + Math.abs(Number(p.top_alert_estimate)).toFixed(2)
         : '';
-      const alertCell = p.manual_hold
-        ? '<span class="badge" title="Manually managed: alerts suppressed, price tracking continues">held</span>'
-        : p.top_alert === 'stop_loss'
-          ? '<span class="badge badge-red" title="Stop-loss threshold hit. NOT closed — close on Polymarket, then log it.">stop-loss' + est + '</span>'
+      // held and a live alert are INDEPENDENT states. A position can be both:
+      // Tyson marked it manually-managed AND the stop loss has since fired.
+      // Showing only one would hide live state, which is the exact trap this
+      // panel exists to close, so both badges render when both are true.
+      const alertBadge = p.top_alert === 'stop_loss'
+        ? '<span class="badge badge-red" title="Stop-loss threshold hit. NOT closed — close on Polymarket, then log it.">stop-loss' + est + '</span>'
         : p.top_alert === 'take_profit'
           ? '<span class="badge badge-green" title="Take-profit threshold hit. NOT closed — close on Polymarket, then log it.">take-profit' + est + '</span>'
         : p.top_alert === 'weakening'
           ? '<span class="badge badge-yellow" title="Position weakening. Nothing closed.">weakening</span>'
-          : '<span style="color:var(--text-dim)">—</span>';
+          : '';
+      const heldBadge = p.manual_hold
+        ? '<span class="badge" title="Manually managed: alerts suppressed, price tracking continues">held</span>'
+        : '';
+      // An alert lookup failure must not read as "no alerts".
+      const unknownBadge = (p.alerts_fetch_ok === false && !alertBadge)
+        ? '<span class="badge badge-yellow" title="Alert lookup failed — alert state is UNKNOWN, not clear. Check dashboard logs.">alerts ?</span>'
+        : '';
+      const badges = [heldBadge, alertBadge, unknownBadge].filter(Boolean).join(' ');
+      const alertCell = badges || '<span style="color:var(--text-dim)">—</span>';
       // question resolves via simulation_id -> trading_simulations.raw_output.
       // Positions carry no market name of their own.
       const market = p.question || (p.asset ? p.asset.toUpperCase() + ' (unnamed market)' : null);

--- a/src/trade_engine/database.py
+++ b/src/trade_engine/database.py
@@ -313,3 +313,119 @@ async def _count_positions(params: dict[str, Any]) -> int:
             f"unparseable content-range: {content_range!r}",
         )
     return int(total)
+
+
+# ---------------------------------------------------------------------------
+# Position alerts (2026-08-20 exit-side fix)
+# ---------------------------------------------------------------------------
+# An alert records that the monitor detected a take-profit / stop-loss /
+# weakening threshold crossing. It is NOT a close: Polymarket exits are manual
+# while the signer/maker-address issue is open, so the monitor flags and the
+# human closes. Nothing here writes to trading_positions' money columns.
+
+
+class AlertExistsError(Exception):
+    """A live (unresolved) alert of this type already exists for the position.
+
+    Raised on the partial-unique-index conflict. This is the DEDUP signal, not a
+    failure: the monitor treats it as "already alerted, stay quiet" so a
+    15-minute sweep that re-detects the same condition does not re-notify.
+    """
+
+
+async def insert_alert(alert: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """Insert one alert. Returns the row, or None if one is already live.
+
+    Dedup is enforced by `trading_position_alerts_live_uniq`, a partial unique
+    index on (position_id, alert_type) WHERE resolved_at IS NULL. Enforcing it
+    in Postgres rather than in monitor logic means it survives process restarts
+    and concurrent sweeps, which an in-memory guard would not.
+
+    PostgREST surfaces a unique violation as HTTP 409 with SQLSTATE 23505.
+    """
+    try:
+        rows = await _request(
+            "POST", "/trading_position_alerts", json_body=alert, write=True
+        )
+    except SupabaseError as exc:
+        if exc.status_code == 409 or "23505" in str(exc):
+            log.info(
+                "alert already live for position %s type %s — not re-alerting",
+                alert.get("position_id"), alert.get("alert_type"),
+            )
+            return None
+        raise
+    return rows[0] if rows else None
+
+
+async def mark_alert_notified(alert_id: str) -> None:
+    """Stamp notified_at after a successful Telegram send.
+
+    Best effort: the alert row is written BEFORE the send, so a failure here
+    loses the timestamp, never the alert.
+    """
+    await _request(
+        "PATCH",
+        "/trading_position_alerts",
+        params={"id": f"eq.{alert_id}"},
+        json_body={"notified_at": datetime.now(timezone.utc).isoformat()},
+        write=True,
+    )
+
+
+async def get_unresolved_alerts(
+    position_id: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """Live alerts, newest first. Optionally scoped to one position."""
+    params: dict[str, Any] = {
+        "resolved_at": "is.null",
+        "order": "triggered_at.desc",
+    }
+    if position_id:
+        params["position_id"] = f"eq.{position_id}"
+    rows = await _request("GET", "/trading_position_alerts", params=params)
+    return rows or []
+
+
+async def get_alerts_for_position(position_id: str) -> list[dict[str, Any]]:
+    """Full alert history for one position, newest first (resolved included)."""
+    rows = await _request(
+        "GET",
+        "/trading_position_alerts",
+        params={
+            "position_id": f"eq.{position_id}",
+            "order": "triggered_at.desc",
+        },
+    )
+    return rows or []
+
+
+async def resolve_alerts_for_position(
+    position_id: str, note: str
+) -> list[dict[str, Any]]:
+    """Resolve every live alert on a position. Returns the rows resolved.
+
+    Called when a real close is logged, so the caller can report which alerts
+    the close answered ("this followed the stop-loss alert from 15:39") instead
+    of taking the operator's word with no cross-reference.
+    """
+    rows = await _request(
+        "PATCH",
+        "/trading_position_alerts",
+        params={"position_id": f"eq.{position_id}", "resolved_at": "is.null"},
+        json_body={
+            "resolved_at": datetime.now(timezone.utc).isoformat(),
+            "resolution_note": note,
+        },
+        write=True,
+    )
+    return rows or []
+
+
+async def set_manual_hold(position_id: str, hold: bool) -> dict[str, Any]:
+    """Set/clear manual_hold on a position.
+
+    manual_hold suppresses alerting only. The monitor still prices the position
+    every sweep so the dashboard and Analyst stay accurate.
+    """
+    return await update_position(position_id, {"manual_hold": bool(hold)})

--- a/src/trade_engine/main.py
+++ b/src/trade_engine/main.py
@@ -22,6 +22,7 @@ sys.path.insert(
 import asyncio  # noqa: E402
 import logging  # noqa: E402
 from contextlib import asynccontextmanager  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
 from typing import Any, Optional  # noqa: E402
 
 import httpx  # noqa: E402
@@ -39,10 +40,15 @@ from src.trade_engine.database import (  # noqa: E402
     close_client,
     count_all_positions,
     count_open_positions,
+    get_alerts_for_position,
     get_daily_pnl,
     get_open_positions,
     get_recent_simulations,
     get_trading_config,
+    get_unresolved_alerts,
+    resolve_alerts_for_position,
+    set_manual_hold,
+    update_position,
 )
 from src.trade_engine.manual import (  # noqa: E402
     ManualPositionError,
@@ -54,6 +60,8 @@ from src.trade_engine.models import (  # noqa: E402
     ApprovalResult,
     ApprovalStatus,
     HealthResponse,
+    HoldRequest,
+    ManualCloseRequest,
     ManualPositionRequest,
     MonitorRunResult,
     ScannerCandidate,
@@ -298,14 +306,41 @@ async def positions() -> JSONResponse:
     """
     try:
         rows = await get_open_positions()
+        alerts = await get_unresolved_alerts()
     except SupabaseError as exc:
         log.error("/positions failed: %s", exc)
         return JSONResponse(
             status_code=503,
             content={"error": "could not read positions", "detail": str(exc)},
         )
+
+    # Embed live alerts on their position rather than making every caller do a
+    # second round-trip and a join. The dashboard renders straight off this.
+    by_position: dict[str, list] = {}
+    for a in alerts:
+        by_position.setdefault(str(a.get("position_id")), []).append(a)
+
+    enriched = []
+    for row in rows:
+        item = row.model_dump() if hasattr(row, "model_dump") else dict(row)
+        live = by_position.get(str(item.get("id")), [])
+        item["alerts"] = live
+        item["has_alert"] = bool(live)
+        # Most severe live alert, for a single badge in a table cell.
+        # stop_loss outranks take_profit outranks weakening.
+        rank = {"stop_loss": 3, "take_profit": 2, "weakening": 1}
+        item["top_alert"] = (
+            max(live, key=lambda a: rank.get(a.get("alert_type"), 0)).get("alert_type")
+            if live else None
+        )
+        enriched.append(item)
+
     return JSONResponse(
-        content=jsonable_encoder({"count": len(rows), "positions": rows})
+        content=jsonable_encoder({
+            "count": len(enriched),
+            "positions": enriched,
+            "unresolved_alert_count": len(alerts),
+        })
     )
 
 
@@ -370,6 +405,218 @@ async def positions_manual(request: Request) -> JSONResponse:
             content={"error": "could not write position", "detail": str(exc)},
         )
     return JSONResponse(content=jsonable_encoder(result))
+
+
+@app.get("/positions/alerts")
+async def positions_alerts() -> JSONResponse:
+    """Live (unresolved) threshold alerts, newest first.
+
+    An alert means the monitor saw a take-profit / stop-loss / weakening
+    threshold cross. It does NOT mean anything was closed: Polymarket exits are
+    manual while the signer/maker-address issue is open. This is the endpoint
+    Charlie reads to answer "does anything need my attention", which he
+    previously could not do at all because alerts only existed as Telegram
+    messages on a bot he cannot see.
+    """
+    try:
+        rows = await get_unresolved_alerts()
+    except SupabaseError as exc:
+        log.error("/positions/alerts failed: %s", exc)
+        return JSONResponse(
+            status_code=503,
+            content={"error": "could not read alerts", "detail": str(exc)},
+        )
+    return JSONResponse(content=jsonable_encoder({
+        "count": len(rows),
+        "alerts": rows,
+        "note": (
+            "An alert is a threshold crossing, not a close. Positions stay open "
+            "until a real close is logged via POST /positions/manual-close."
+        ),
+    }))
+
+
+@app.get("/positions/{position_id}/alerts")
+async def position_alert_history(position_id: str) -> JSONResponse:
+    """Full alert history for one position, resolved ones included."""
+    try:
+        rows = await get_alerts_for_position(position_id)
+    except SupabaseError as exc:
+        log.error("/positions/%s/alerts failed: %s", position_id, exc)
+        return JSONResponse(
+            status_code=503,
+            content={"error": "could not read alerts", "detail": str(exc)},
+        )
+    return JSONResponse(content=jsonable_encoder({
+        "position_id": position_id,
+        "count": len(rows),
+        "alerts": rows,
+        "unresolved": [r for r in rows if r.get("resolved_at") is None],
+    }))
+
+
+@app.post("/positions/{position_id}/hold")
+async def position_hold(position_id: str, request: Request) -> JSONResponse:
+    """Mark a position as manually managed (or clear the mark).
+
+    While held, the monitor still prices the position every sweep — the
+    dashboard and Analyst stay accurate — but emits no alerts for it. This is
+    the "I am already dealing with it, stop telling me" control that did not
+    exist on 2026-08-19 and would have prevented repeat alerting then.
+
+    Holding does NOT close anything and does not touch any money column.
+    """
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        body = {}
+    try:
+        req = HoldRequest.model_validate(body or {})
+    except ValidationError as exc:
+        detail = "; ".join(
+            f"{'.'.join(str(loc) for loc in err['loc'])}: {err['msg']}"
+            for err in exc.errors()
+        )
+        return JSONResponse(status_code=400, content={"error": detail})
+
+    try:
+        row = await set_manual_hold(position_id, req.hold)
+    except SupabaseError as exc:
+        log.error("/positions/%s/hold failed: %s", position_id, exc)
+        return JSONResponse(
+            status_code=503,
+            content={"error": "could not set manual_hold", "detail": str(exc)},
+        )
+    log.info("position %s manual_hold set to %s", position_id, req.hold)
+    return JSONResponse(content=jsonable_encoder({
+        "position_id": position_id,
+        "manual_hold": req.hold,
+        "position": row,
+        "note": (
+            "Alerts suppressed; price tracking continues."
+            if req.hold else "Alerting resumed."
+        ),
+    }))
+
+
+@app.post("/positions/manual-close")
+async def positions_manual_close(request: Request) -> JSONResponse:
+    """Log a position that was closed BY HAND in the Polymarket UI.
+
+    This is the only path permitted to write exit_price / exit_usdc / pnl /
+    status onto trading_positions. The monitor cannot, because it never sells;
+    writing a close it had not performed is exactly the 2026-08-19 defect.
+
+    Any live alerts on the position are resolved here and returned, so the
+    caller can cross-reference ("this close answers the stop-loss alert from
+    15:39") instead of accepting an unverified assertion.
+
+    exit_usdc: supply the real proceeds. If omitted it is derived as
+    shares * exit_price and flagged `exit_usdc_estimated: true` — an
+    approximation labelled as one, never presented as the settled figure.
+    """
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        return JSONResponse(
+            status_code=400, content={"error": "body must be valid JSON"}
+        )
+    try:
+        req = ManualCloseRequest.model_validate(body)
+    except ValidationError as exc:
+        detail = "; ".join(
+            f"{'.'.join(str(loc) for loc in err['loc'])}: {err['msg']}"
+            for err in exc.errors()
+        )
+        return JSONResponse(status_code=400, content={"error": detail})
+
+    if not (0.0 <= req.exit_price <= 1.0):
+        return JSONResponse(
+            status_code=400,
+            content={"error": f"exit_price must be between 0 and 1, got {req.exit_price}"},
+        )
+
+    # Read the position first: refuse to close what is not open, and derive
+    # exit_usdc from its shares when the caller did not supply proceeds.
+    try:
+        open_rows = await get_open_positions()
+    except SupabaseError as exc:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "could not read positions", "detail": str(exc)},
+        )
+    match = next((p for p in open_rows if str(p.id) == req.position_id), None)
+    if match is None:
+        # Fail closed: an id that is not currently open is either already
+        # closed or wrong, and guessing which would risk a double-write.
+        return JSONResponse(status_code=404, content={
+            "error": f"no OPEN position with id {req.position_id}",
+            "hint": "check GET /positions; an already-closed position cannot be re-closed here",
+        })
+
+    exit_usdc = req.exit_usdc
+    estimated = False
+    if exit_usdc is None:
+        if match.shares is None:
+            return JSONResponse(status_code=400, content={
+                "error": "exit_usdc omitted and position has no shares to derive it from",
+                "hint": "supply exit_usdc (the USDC actually received)",
+            })
+        exit_usdc = round(float(match.shares) * req.exit_price, 6)
+        estimated = True
+
+    pnl = (
+        round(exit_usdc - float(match.usdc_amount), 6)
+        if match.usdc_amount is not None else None
+    )
+
+    updates = {
+        "status": "closed",
+        "exit_price": req.exit_price,
+        "exit_usdc": exit_usdc,
+        "pnl": pnl,
+        "exit_reason": req.exit_reason or "manual_close",
+        "closed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        row = await update_position(req.position_id, updates)
+    except SupabaseError as exc:
+        log.error("/positions/manual-close write failed: %s", exc)
+        return JSONResponse(
+            status_code=503,
+            content={"error": "could not write close", "detail": str(exc)},
+        )
+
+    # Resolve alerts AFTER the close is durable: an alert cleared against a
+    # close that failed to write would hide a still-live threshold crossing.
+    note = req.note or f"closed manually at {req.exit_price}"
+    try:
+        resolved = await resolve_alerts_for_position(req.position_id, note)
+    except SupabaseError as exc:
+        log.warning(
+            "close recorded for %s but alert resolution failed: %s",
+            req.position_id, exc,
+        )
+        resolved = []
+
+    log.info(
+        "manual close recorded for %s: exit %.4f pnl %s (resolved %d alert(s))",
+        req.position_id, req.exit_price, pnl, len(resolved),
+    )
+    return JSONResponse(content=jsonable_encoder({
+        "success": True,
+        "position": row,
+        "exit_usdc_estimated": estimated,
+        "resolved_alerts": resolved,
+        "preceded_by_alert": [
+            {
+                "alert_type": a.get("alert_type"),
+                "triggered_at": a.get("triggered_at"),
+                "trigger_price": a.get("trigger_price"),
+            }
+            for a in resolved
+        ],
+    }))
 
 
 @app.post("/simulate")

--- a/src/trade_engine/models.py
+++ b/src/trade_engine/models.py
@@ -59,6 +59,9 @@ class TradePosition(BaseModel):
     closed_at: Optional[datetime] = None
     tx_hash: Optional[str] = None
     created_at: Optional[datetime] = None
+    # 2026-08-20: true = Tyson is managing this exit by hand. The monitor keeps
+    # pricing the position but emits no alerts for it.
+    manual_hold: Optional[bool] = False
 
 
 class ManualPositionRequest(BaseModel):
@@ -79,6 +82,64 @@ class ManualPositionRequest(BaseModel):
     entry_price: float
     usdc_amount: float
     shares: Optional[float] = None
+
+
+class PositionAlert(BaseModel):
+    """public.trading_position_alerts — one unresolved threshold crossing.
+
+    An alert is NOT a close. The Position Monitor writes one when a take-profit,
+    stop-loss or weakening threshold fires; Polymarket exits are manual while the
+    signer/maker-address issue is open, so the human closes and then logs it.
+
+    unrealized_pnl_estimate is exactly that — an estimate marked to
+    trigger_price. It is never copied into trading_positions.pnl, which
+    get_daily_pnl() sums into the executor's daily-loss gate.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: Optional[str] = None
+    position_id: str
+    alert_type: str
+    triggered_at: Optional[datetime] = None
+    trigger_price: float
+    entry_price: Optional[float] = None
+    unrealized_pnl_estimate: Optional[float] = None
+    notified_at: Optional[datetime] = None
+    resolved_at: Optional[datetime] = None
+    resolution_note: Optional[str] = None
+
+
+class ManualCloseRequest(BaseModel):
+    """POST /positions/manual-close body — a position closed by hand.
+
+    This is the ONLY path that may write exit_price/exit_usdc/pnl/status onto
+    trading_positions. The monitor cannot, because it never sells anything.
+
+    extra="forbid" for the same reason as ManualPositionRequest: a typoed field
+    in a hand-built request must 400 rather than silently write a wrong close.
+
+    exit_usdc is what actually landed. Supply it when known; if omitted it is
+    computed as shares * exit_price, which is an approximation and is flagged as
+    such in the response rather than being presented as the real figure.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    position_id: str
+    exit_price: float
+    exit_usdc: Optional[float] = None
+    exit_reason: Optional[str] = "manual_close"
+    note: Optional[str] = None
+
+
+class HoldRequest(BaseModel):
+    """POST /positions/{id}/hold body. hold=false clears the flag."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    hold: bool = True
+    note: Optional[str] = None
 
 
 class SimulationResult(BaseModel):
@@ -290,9 +351,19 @@ class MonitorRunResult(BaseModel):
     """Result of one Position Monitor sweep.
 
     `positions_resolved` counts market-settlement closes (resolved_win /
-    resolved_loss) only; `positions_tp_sl` counts take_profit / stop_loss
-    closes, kept separate because settlement is ground truth for the learning
-    loop while a TP/SL exit is a rule firing on a live price.
+    resolved_loss) — the only closes this monitor writes, because settlement is
+    ground truth and Polymarket has actually paid out.
+
+    Since 2026-08-20 a take-profit / stop-loss / weakening crossing does NOT
+    close anything: it raises an alert and leaves the position open for a manual
+    exit. `alerts_raised` counts NEW alerts (a Telegram message was sent);
+    `alerts_deduped` counts crossings where an alert was already live, which is
+    the normal steady state while a condition persists across sweeps.
+    `positions_held` counts positions skipped for alerting via manual_hold.
+
+    `positions_tp_sl` is retained and now counts threshold crossings that
+    produced a NEW alert, so historical dashboards keep a meaningful series. It
+    no longer implies anything was closed.
     """
 
     run_at: datetime
@@ -301,6 +372,9 @@ class MonitorRunResult(BaseModel):
     positions_tp_sl: int = 0
     positions_unpriceable: int = 0
     alerts_sent: int = 0
+    alerts_raised: int = 0
+    alerts_deduped: int = 0
+    positions_held: int = 0
     errors: int = 0
 
 

--- a/src/trade_engine/monitor.py
+++ b/src/trade_engine/monitor.py
@@ -79,8 +79,10 @@ from src.trade_engine.database import (
     SupabaseError,
     get_open_positions,
     get_simulations_by_ids,
+    get_unresolved_alerts,
     insert_alert,
     mark_alert_notified,
+    resolve_alerts_for_position,
     update_position,
 )
 from src.trade_engine.models import MonitorRunResult, TradePosition
@@ -371,13 +373,34 @@ class PositionMonitor:
             return "error"
 
         if created is None:
-            # Live alert already exists for this (position, type). Silent by
-            # design — this is the anti-spam path, hit on every sweep for as
+            # A live alert already exists for this (position, type). Normally
+            # silent — this is the anti-spam path, hit on every sweep for as
             # long as the condition holds.
-            log.debug(
-                "monitor: %s alert already live for position %s — silent",
+            #
+            # H1: unless that alert was never actually delivered. notified_at is
+            # NULL when the Telegram send failed, and without this retry the
+            # dedup index would guarantee Tyson is never told again about a
+            # threshold that is still live. Delivery failure must not be
+            # permanent silence, so re-attempt while the condition persists.
+            undelivered = await self._undelivered_alert(position.id, alert_type)
+            if undelivered is None:
+                log.debug(
+                    "monitor: %s alert already live and delivered for position "
+                    "%s — silent", alert_type, position.id,
+                )
+                return "alert_dup"
+
+            log.info(
+                "monitor: %s alert for position %s exists but was never "
+                "delivered — retrying notification",
                 alert_type, position.id,
             )
+            if await self._notify(
+                self._alert_message(
+                    alert_type, question, trigger_price, entry_price, estimate
+                )
+            ):
+                await self._stamp_notified(undelivered.get("id"))
             return "alert_dup"
 
         log.info(
@@ -386,18 +409,58 @@ class PositionMonitor:
             alert_type, position.id, trigger_price, estimate,
         )
 
-        await self._notify(
+        # H1: notified_at must mean "Telegram accepted this message", not
+        # "we called _notify". Only stamp on a genuine 200; otherwise the row
+        # stays NULL and the dedup path above retries on the next sweep.
+        if await self._notify(
             self._alert_message(alert_type, question, trigger_price, entry_price, estimate)
-        )
-        try:
-            await mark_alert_notified(created["id"])
-        except (SupabaseError, KeyError, TypeError) as exc:
-            # Cosmetic only: the alert stands, notified_at is just unset.
+        ):
+            await self._stamp_notified(created.get("id"))
+        else:
             log.warning(
-                "monitor: could not stamp notified_at on alert %s: %s",
-                created.get("id") if isinstance(created, dict) else "?", exc,
+                "monitor: %s alert %s recorded but NOT delivered — notified_at "
+                "left NULL, next sweep will retry",
+                alert_type, created.get("id"),
             )
         return "alert"
+
+    async def _undelivered_alert(
+        self, position_id: str, alert_type: str
+    ) -> Optional[dict[str, Any]]:
+        """The live alert of this type IF it was never delivered, else None.
+
+        Reuses get_unresolved_alerts rather than adding a query: the set of live
+        alerts for one position is tiny, so filtering in Python is cheaper than
+        another round trip and keeps the DB surface unchanged.
+
+        A lookup failure returns None (stay silent) rather than raising: the
+        alert is already recorded, and a retry storm on a flaky read would be
+        worse than a delayed notification.
+        """
+        try:
+            live = await get_unresolved_alerts(position_id)
+        except SupabaseError as exc:
+            log.warning(
+                "monitor: could not check delivery state for position %s: %s",
+                position_id, exc,
+            )
+            return None
+        for a in live:
+            if a.get("alert_type") == alert_type and a.get("notified_at") is None:
+                return a
+        return None
+
+    async def _stamp_notified(self, alert_id: Optional[str]) -> None:
+        """Best-effort notified_at stamp. Cosmetic: the alert itself stands."""
+        if not alert_id:
+            return
+        try:
+            await mark_alert_notified(alert_id)
+        except (SupabaseError, KeyError, TypeError) as exc:
+            log.warning(
+                "monitor: could not stamp notified_at on alert %s: %s",
+                alert_id, exc,
+            )
 
     @staticmethod
     def _unrealized_estimate(
@@ -510,6 +573,32 @@ class PositionMonitor:
             "monitor: closed position %s %s exit_price=%.4f exit_usdc=%s pnl=%s",
             position.id, exit_reason, exit_price, exit_usdc, pnl,
         )
+
+        # H2: a settled position may carry a live TP/SL/weakening alert raised
+        # before the market resolved. Clear it, or it sits unresolved forever on
+        # GET /positions/alerts — the endpoint whose entire job is telling
+        # Charlie what still needs attention.
+        #
+        # Ordering mirrors POST /positions/manual-close: resolve only AFTER the
+        # close is durable. Clearing an alert against a close that failed to
+        # write would hide a threshold crossing that is still live.
+        try:
+            cleared = await resolve_alerts_for_position(
+                position.id, f"market settled ({exit_reason})"
+            )
+            if cleared:
+                log.info(
+                    "monitor: resolved %d alert(s) on settled position %s",
+                    len(cleared), position.id,
+                )
+        except SupabaseError as exc:
+            # The close stands; only the alert cleanup failed. Surfaced rather
+            # than swallowed because a stale alert is exactly the misleading
+            # state this PR exists to remove.
+            log.warning(
+                "monitor: position %s closed but alert resolution failed: %s",
+                position.id, exc,
+            )
         await self._notify(self._close_message(exit_reason, question, exit_price,
                                                exit_usdc, pnl))
         return "resolved" if exit_reason.startswith("resolved") else "tp_sl"
@@ -605,11 +694,19 @@ class PositionMonitor:
 
     # --- telegram ---------------------------------------------------------
 
-    async def _notify(self, text: str) -> None:
-        """Best-effort Telegram send. A notification failure never fails a close."""
+    async def _notify(self, text: str) -> bool:
+        """Best-effort Telegram send. Returns True ONLY on a genuine 200.
+
+        The return value is load-bearing: it gates whether notified_at is
+        stamped on an alert. False on an unconfigured token, a non-200, or any
+        exception, so a row is never marked delivered when it was not — that
+        would combine with the dedup index to silence a live threshold forever.
+
+        A notification failure still never fails a close.
+        """
         if not self._token or not self._chat_id:
             log.error("monitor: telegram notification skipped: not configured")
-            return
+            return False
         url = f"{TELEGRAM_API_BASE}/bot{self._token}/sendMessage"
         try:
             response = await self._get_client().post(url, json={
@@ -622,7 +719,10 @@ class PositionMonitor:
                     "monitor: telegram sendMessage returned HTTP %d",
                     response.status_code,
                 )
+                return False
+            return True
         except Exception as exc:  # noqa: BLE001
             log.error(
                 "monitor: telegram sendMessage failed: %s", type(exc).__name__
             )
+            return False

--- a/src/trade_engine/monitor.py
+++ b/src/trade_engine/monitor.py
@@ -15,10 +15,34 @@ Rule order per position — first match wins:
    resolved-YES market trips take_profit at 1.0) but mislabelled the exit and
    missed one case entirely: a position entered at <= 0.20 that resolves
    against us fails the stop-loss entry_price guard and stays open forever.
-2. TAKE PROFIT / STOP LOSS (verbatim port): currentPrice > 0.85 exits as
-   take_profit; entry_price > 0.20 and currentPrice < 0.08 exits as stop_loss.
-3. WEAKENING ALERT (verbatim port): entry_price > 0.50 and currentPrice < 0.30
-   sends a Telegram warning, no DB write.
+2. TAKE PROFIT / STOP LOSS: currentPrice > 0.85 flags take_profit;
+   entry_price > 0.20 and currentPrice < 0.08 flags stop_loss. **These no
+   longer close the position** — see EXIT MODEL below.
+3. WEAKENING ALERT: entry_price > 0.50 and currentPrice < 0.30 flags weakening.
+
+EXIT MODEL (changed 2026-08-20 — read this before touching _flag_for_exit)
+--------------------------------------------------------------------------
+This monitor CANNOT sell. It never could: _close() only ever wrote to Supabase,
+and Polymarket execution (BUY and SELL alike) is blocked by an unresolved
+signer/maker-address issue, so exits are performed by hand in the Polymarket UI.
+
+Until 2026-08-20 a TP/SL crossing wrote status='closed' with a computed pnl
+anyway. On 2026-08-19 that produced a real incident: a BTC stop loss fired, the
+DB recorded a closed position at -9.27, and the actual Polymarket position
+stayed open for another 17 hours. The database and reality diverged silently.
+
+So a threshold crossing now FLAGS, it does not close:
+  * an alert row goes into trading_position_alerts (deduped by a partial unique
+    index, so a re-detection on the next 15-minute sweep does not re-notify),
+  * Telegram tells Tyson to close it himself,
+  * trading_positions is NOT touched. status stays 'open', and pnl stays NULL
+    until a real close is logged via POST /positions/manual-close.
+
+RESOLUTION IS DIFFERENT AND IS UNCHANGED. A settled market (active=false and
+closed=true, or a finalised 1.0/0.0 price) really has closed and really does pay
+out, so _close() still writes status='closed' for resolved_win / resolved_loss.
+Do not route those through the alert path: they are real closes, not requests
+for a human to act.
 
 Prices are DIRECTION-SIDE throughout, matching the n8n `priceFor(conditionId,
 direction)` helper: for a NO position, currentPrice is outcomePrices[1] and a
@@ -55,6 +79,8 @@ from src.trade_engine.database import (
     SupabaseError,
     get_open_positions,
     get_simulations_by_ids,
+    insert_alert,
+    mark_alert_notified,
     update_position,
 )
 from src.trade_engine.models import MonitorRunResult, TradePosition
@@ -143,7 +169,10 @@ class PositionMonitor:
             record_monitor_run(result)
             return result
 
-        counts = {"resolved": 0, "tp_sl": 0, "alert": 0, "unpriceable": 0, "error": 0}
+        counts = {
+            "resolved": 0, "tp_sl": 0, "alert": 0, "unpriceable": 0, "error": 0,
+            "alert_dup": 0, "held": 0,
+        }
         for position in positions:
             try:
                 outcome = await self._check_one(position)
@@ -157,9 +186,15 @@ class PositionMonitor:
             run_at=run_at,
             positions_checked=len(positions),
             positions_resolved=counts["resolved"],
-            positions_tp_sl=counts["tp_sl"],
+            positions_tp_sl=counts["alert"],
             positions_unpriceable=counts["unpriceable"],
+            # alerts_sent counts NEW alerts only: a deduped crossing sends no
+            # Telegram message, so counting it here would misreport notification
+            # volume and hide whether the anti-spam path is working.
             alerts_sent=counts["alert"],
+            alerts_raised=counts["alert"],
+            alerts_deduped=counts["alert_dup"],
+            positions_held=counts["held"],
             errors=counts["error"],
         )
         log.info(
@@ -235,12 +270,26 @@ class PositionMonitor:
 
         entry_price = None if position.entry_price is None else float(position.entry_price)
 
+        # Rules 2 and 3 below are ALERTS, not closes (see EXIT MODEL). They are
+        # evaluated in the same first-match-wins order as before so behaviour is
+        # unchanged apart from what happens on a match.
+
+        # manual_hold suppresses alerting only. Pricing above still ran, so the
+        # dashboard and Analyst keep seeing a live, correctly-priced position;
+        # Tyson simply stops being told about something he is already handling.
+        if getattr(position, "manual_hold", False):
+            log.info(
+                "monitor: position %s is manual_hold — priced, alerts suppressed "
+                "(price %.4f)", position.id, current_price,
+            )
+            return "held"
+
         # 2. TAKE PROFIT — independent of entry price, so it still fires when
         # entry_price is NULL.
         if current_price > TAKE_PROFIT_PRICE:
-            return await self._close(
-                position, exit_price=current_price, exit_reason="take_profit",
-                question=question,
+            return await self._flag_for_exit(
+                position, alert_type="take_profit", trigger_price=current_price,
+                entry_price=entry_price, question=question,
             )
 
         # 2b. STOP LOSS — requires a real entry price.
@@ -249,23 +298,23 @@ class PositionMonitor:
             and current_price < STOP_LOSS_PRICE
             and entry_price > STOP_LOSS_MIN_ENTRY
         ):
-            return await self._close(
-                position, exit_price=current_price, exit_reason="stop_loss",
-                question=question,
+            return await self._flag_for_exit(
+                position, alert_type="stop_loss", trigger_price=current_price,
+                entry_price=entry_price, question=question,
             )
 
-        # 3. WEAKENING ALERT — notify only, no DB write.
+        # 3. WEAKENING — now deduped like the others. Previously this notified
+        # on EVERY sweep for as long as the condition held, which is why a
+        # weakening position produced a Telegram message every 15 minutes.
         if (
             entry_price is not None
             and current_price < WEAKENING_PRICE
             and entry_price > WEAKENING_MIN_ENTRY
         ):
-            await self._notify(
-                f"⚠️ Weakening: {question}\n"
-                f"now {current_price * 100:.0f}%"
-                f" (entered {entry_price * 100:.0f}%)"
+            return await self._flag_for_exit(
+                position, alert_type="weakening", trigger_price=current_price,
+                entry_price=entry_price, question=question,
             )
-            return "alert"
 
         if entry_price is None:
             log.warning(
@@ -277,7 +326,138 @@ class PositionMonitor:
         log.debug("Position %s still open (price %.4f)", position.id, current_price)
         return "open"
 
-    # --- close + notify ---------------------------------------------------
+    # --- flag for exit (TP / SL / weakening) ------------------------------
+
+    async def _flag_for_exit(
+        self,
+        position: TradePosition,
+        *,
+        alert_type: str,
+        trigger_price: float,
+        entry_price: Optional[float],
+        question: str,
+    ) -> str:
+        """Record a threshold crossing and tell Tyson. NEVER closes the position.
+
+        Order is deliberate: the alert row is written FIRST, then Telegram. A
+        notification failure therefore loses a message, not the alert — the row
+        is still there for the dashboard, for Charlie, and for the next sweep to
+        see as already-alerted. The inverse order would let a Telegram outage
+        produce silent, unrecorded threshold crossings.
+
+        Returns 'alert' when a new alert was raised, 'alert_dup' when one was
+        already live (deduped by the DB), 'error' when the write failed.
+        """
+        estimate = self._unrealized_estimate(position, trigger_price)
+
+        row = {
+            "position_id": position.id,
+            "alert_type": alert_type,
+            "trigger_price": trigger_price,
+            "entry_price": entry_price,
+            "unrealized_pnl_estimate": estimate,
+        }
+
+        try:
+            created = await insert_alert(row)
+        except (SupabaseError, ValueError) as exc:
+            # Do NOT notify: an alert Tyson can see but the system has no record
+            # of is worse than a missed sweep, because the next sweep would
+            # notify again with no dedup. Retry happens naturally in 15 minutes.
+            log.error(
+                "monitor: failed to record %s alert for position %s: %s",
+                alert_type, position.id, exc,
+            )
+            return "error"
+
+        if created is None:
+            # Live alert already exists for this (position, type). Silent by
+            # design — this is the anti-spam path, hit on every sweep for as
+            # long as the condition holds.
+            log.debug(
+                "monitor: %s alert already live for position %s — silent",
+                alert_type, position.id,
+            )
+            return "alert_dup"
+
+        log.info(
+            "monitor: %s ALERT raised for position %s at %.4f (estimate %s) — "
+            "position left OPEN, manual close required",
+            alert_type, position.id, trigger_price, estimate,
+        )
+
+        await self._notify(
+            self._alert_message(alert_type, question, trigger_price, entry_price, estimate)
+        )
+        try:
+            await mark_alert_notified(created["id"])
+        except (SupabaseError, KeyError, TypeError) as exc:
+            # Cosmetic only: the alert stands, notified_at is just unset.
+            log.warning(
+                "monitor: could not stamp notified_at on alert %s: %s",
+                created.get("id") if isinstance(created, dict) else "?", exc,
+            )
+        return "alert"
+
+    @staticmethod
+    def _unrealized_estimate(
+        position: TradePosition, trigger_price: float
+    ) -> Optional[float]:
+        """Mark-to-market ESTIMATE at trigger_price. Never a realised pnl.
+
+        NULL when shares or usdc_amount are missing, matching _close()'s rule
+        that a pnl is never guessed. This value is written only to
+        trading_position_alerts.unrealized_pnl_estimate and must never reach
+        trading_positions.pnl, which feeds the executor's daily-loss gate.
+        """
+        if position.shares is None or position.usdc_amount is None:
+            return None
+        return round(float(position.shares) * trigger_price - float(position.usdc_amount), 6)
+
+    @staticmethod
+    def _alert_message(
+        alert_type: str,
+        question: str,
+        trigger_price: float,
+        entry_price: Optional[float],
+        estimate: Optional[float],
+    ) -> str:
+        """Two tiers. Every tier states explicitly that nothing was closed.
+
+        The wording is load-bearing: the 2026-08-19 incident happened partly
+        because a message that reads like a completed action gets remembered as
+        one. These say what is true (a threshold was crossed) and what is
+        required (a human closes it).
+        """
+        entered = f" (entered {entry_price * 100:.0f}%)" if entry_price is not None else ""
+
+        if alert_type == "weakening":
+            return (
+                f"⚠️ Position weakening: {question}\n"
+                f"now {trigger_price * 100:.0f}%{entered}\n"
+                f"Nothing has been closed. Consider your exit."
+            )
+
+        est = ""
+        if estimate is not None:
+            est = f"\nEstimated unrealized: {'+' if estimate >= 0 else '-'}${abs(estimate):.2f} USDC"
+
+        if alert_type == "take_profit":
+            return (
+                f"💰 TAKE-PROFIT THRESHOLD HIT: {question}\n"
+                f"now {trigger_price * 100:.0f}%{entered}{est}\n"
+                f"This is NOT closed. Polymarket execution is manual-only right now — "
+                f"close it yourself on Polymarket, then tell Charlie so it is logged correctly."
+            )
+
+        return (
+            f"🔴 STOP-LOSS THRESHOLD HIT: {question}\n"
+            f"now {trigger_price * 100:.0f}%{entered}{est}\n"
+            f"This is NOT closed. Polymarket execution is manual-only right now — "
+            f"close it yourself on Polymarket, then tell Charlie so it is logged correctly."
+        )
+
+    # --- close + notify (RESOLUTION ONLY — see EXIT MODEL) ------------------
 
     async def _close(
         self,
@@ -287,7 +467,17 @@ class PositionMonitor:
         exit_reason: str,
         question: str,
     ) -> str:
-        """Write the close, then notify. Returns the sweep outcome tag."""
+        """Write a REAL close, then notify. Returns the sweep outcome tag.
+
+        Since 2026-08-20 this is reached only from the RESOLUTION branch, where
+        the market has settled and Polymarket has actually paid out, so
+        status='closed' with a computed pnl is correct and no human action is
+        pending. TP/SL/weakening go through _flag_for_exit instead and never
+        touch trading_positions.
+
+        Do not re-point TP/SL at this method without a working sell path: that
+        is precisely the defect fixed on 2026-08-20.
+        """
         exit_usdc = (
             round(float(position.shares) * exit_price, 6)
             if position.shares is not None else None

--- a/src/trade_engine/monitor.py
+++ b/src/trade_engine/monitor.py
@@ -591,13 +591,19 @@ class PositionMonitor:
                     "monitor: resolved %d alert(s) on settled position %s",
                     len(cleared), position.id,
                 )
-        except SupabaseError as exc:
+        except Exception as exc:  # noqa: BLE001 - see below, deliberately broad
             # The close stands; only the alert cleanup failed. Surfaced rather
             # than swallowed because a stale alert is exactly the misleading
             # state this PR exists to remove.
+            #
+            # Deliberately broad, NOT just SupabaseError: a transient transport
+            # error (httpx timeout, connection reset) would otherwise unwind
+            # past the _notify below, so a position that really did settle would
+            # close silently and Tyson would never be told it won or lost.
+            # Failing to tidy an alert must never cost the settlement message.
             log.warning(
-                "monitor: position %s closed but alert resolution failed: %s",
-                position.id, exc,
+                "monitor: position %s closed but alert resolution failed (%s): %s",
+                position.id, type(exc).__name__, exc,
             )
         await self._notify(self._close_message(exit_reason, question, exit_price,
                                                exit_usdc, pnl))

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -86,6 +86,8 @@ class MonitorTestCase(unittest.TestCase):
             "update_position": monitor_mod.update_position,
             "insert_alert": monitor_mod.insert_alert,
             "mark_alert_notified": monitor_mod.mark_alert_notified,
+            "get_unresolved_alerts": monitor_mod.get_unresolved_alerts,
+            "resolve_alerts_for_position": monitor_mod.resolve_alerts_for_position,
         }
         monitor_mod._last_monitor.update({"at": None, "resolved_total": 0})
 
@@ -103,6 +105,10 @@ class MonitorTestCase(unittest.TestCase):
         self.live_alerts = set()    # {(position_id, alert_type)}
         self.alert_insert_exc = None
         self.notified_alert_ids = []
+        # Full alert rows, keyed by id, so notified_at and resolved_at can be
+        # asserted the way the real table behaves.
+        self.alert_rows = {}        # alert_id -> row dict
+        self.resolve_calls = []     # (position_id, note)
 
         self.gamma_by_cid = {}      # condition_id -> list payload or Exception
         self.gamma_requests = []
@@ -137,16 +143,45 @@ class MonitorTestCase(unittest.TestCase):
             if key in tests.live_alerts:
                 return None          # partial unique index conflict -> deduped
             tests.live_alerts.add(key)
-            return {"id": f"alert-{len(tests.live_alerts)}", **alert}
+            row = {
+                "id": f"alert-{len(tests.live_alerts)}",
+                "notified_at": None,
+                "resolved_at": None,
+                **alert,
+            }
+            tests.alert_rows[row["id"]] = row
+            return row
 
         async def _mark_notified(alert_id):
             tests.notified_alert_ids.append(alert_id)
+            if alert_id in tests.alert_rows:
+                tests.alert_rows[alert_id]["notified_at"] = "2026-08-20T00:00:00Z"
+
+        async def _get_unresolved(position_id=None):
+            return [
+                r for r in tests.alert_rows.values()
+                if r.get("resolved_at") is None
+                and (position_id is None or r.get("position_id") == position_id)
+            ]
+
+        async def _resolve_for_position(position_id, note):
+            tests.resolve_calls.append((position_id, note))
+            out = []
+            for r in tests.alert_rows.values():
+                if r.get("position_id") == position_id and r.get("resolved_at") is None:
+                    r["resolved_at"] = "2026-08-20T00:00:00Z"
+                    r["resolution_note"] = note
+                    tests.live_alerts.discard((position_id, r["alert_type"]))
+                    out.append(r)
+            return out
 
         monitor_mod.get_open_positions = _get_open
         monitor_mod.get_simulations_by_ids = _get_sims
         monitor_mod.update_position = _update
         monitor_mod.insert_alert = _insert_alert
         monitor_mod.mark_alert_notified = _mark_notified
+        monitor_mod.get_unresolved_alerts = _get_unresolved
+        monitor_mod.resolve_alerts_for_position = _resolve_for_position
 
         def handler(request: httpx.Request) -> httpx.Response:
             if request.url.host == "api.telegram.org":
@@ -498,6 +533,138 @@ class TestTakeProfitStopLoss(MonitorTestCase):
         text = " ".join(r["text"] for r in self.telegram_requests)
         self.assertIn("weakening", text.lower())
         self.assertIn("Nothing has been closed", text)
+
+
+class TestAlertDeliveryTruthfulness(MonitorTestCase):
+    """H1: notified_at must mean Telegram accepted the message.
+
+    Stamping it unconditionally combines with the dedup index to silence a live
+    threshold forever: the row looks delivered, so no sweep ever retries.
+    """
+
+    def _sl_position(self):
+        self.positions = [make_position(entry_price=0.35)]
+        self.sim_rows["sim-1"] = sim_row()
+        self.gamma_by_cid[CID] = gamma_market(yes="0.05", no="0.95")
+
+    def test_notified_at_stamped_on_successful_send(self):
+        self._sl_position()
+        result = self.sweep()
+        self.assertEqual(result.alerts_raised, 1)
+        self.assertEqual(len(self.notified_alert_ids), 1)
+        (row,) = self.alert_rows.values()
+        self.assertIsNotNone(row["notified_at"])
+
+    def test_notified_at_not_stamped_when_telegram_fails(self):
+        self._sl_position()
+        self.telegram_status = 500          # Telegram rejects the send
+        result = self.sweep()
+
+        self.assertEqual(result.alerts_raised, 1, "alert must still be recorded")
+        self.assertEqual(
+            self.notified_alert_ids, [],
+            "notified_at stamped despite a failed send — the row would claim a "
+            "delivery that never happened",
+        )
+        (row,) = self.alert_rows.values()
+        self.assertIsNone(row["notified_at"])
+
+    def test_undelivered_alert_is_retried_on_next_sweep(self):
+        """Delivery failure must not become permanent silence."""
+        self._sl_position()
+        self.telegram_status = 500
+        self.sweep()
+        self.assertEqual(self.notified_alert_ids, [])
+        first_attempts = len(self.telegram_requests)
+        self.assertEqual(first_attempts, 1)
+
+        # Telegram recovers. The dedup index still blocks a second INSERT, so
+        # the retry has to come from the dedup branch.
+        self.telegram_status = 200
+        second = self.sweep()
+        self.assertEqual(second.alerts_deduped, 1)
+        self.assertEqual(
+            len(self.telegram_requests), 2,
+            "undelivered alert was not retried once Telegram recovered",
+        )
+        self.assertEqual(len(self.notified_alert_ids), 1)
+        (row,) = self.alert_rows.values()
+        self.assertIsNotNone(row["notified_at"])
+
+    def test_delivered_alert_is_not_retried(self):
+        """The anti-spam guarantee still holds once delivery succeeded."""
+        self._sl_position()
+        self.sweep()
+        self.assertEqual(len(self.telegram_requests), 1)
+        second = self.sweep()
+        self.assertEqual(second.alerts_deduped, 1)
+        self.assertEqual(
+            len(self.telegram_requests), 1,
+            "a delivered alert was re-sent — dedup broken",
+        )
+
+
+class TestSettlementResolvesAlerts(MonitorTestCase):
+    """H2: settlement must clear alerts raised before the market resolved.
+
+    Otherwise a stale stop-loss alert sits unresolved forever on
+    GET /positions/alerts, the endpoint whose whole job is telling Charlie what
+    still needs attention.
+    """
+
+    def test_resolution_clears_a_pre_existing_alert(self):
+        # Sweep 1: price collapses, stop loss alerts, position stays open.
+        self.positions = [make_position(entry_price=0.35)]
+        self.sim_rows["sim-1"] = sim_row()
+        self.gamma_by_cid[CID] = gamma_market(yes="0.05", no="0.95")
+        first = self.sweep()
+        self.assertEqual(first.alerts_raised, 1)
+        self.assertEqual(self.update_calls, [])
+        (row,) = self.alert_rows.values()
+        self.assertIsNone(row["resolved_at"])
+
+        # Sweep 2: the market settles against us.
+        self.gamma_by_cid[CID] = gamma_market(
+            yes="0", no="1", active=False, closed=True
+        )
+        second = self.sweep()
+        self.assertEqual(second.positions_resolved, 1)
+
+        # The close was written...
+        (pos_id, updates), = self.update_calls
+        self.assertEqual(updates["status"], "closed")
+        self.assertEqual(updates["exit_reason"], "resolved_loss")
+
+        # ...and the stale alert was cleared, after the write.
+        self.assertEqual(len(self.resolve_calls), 1)
+        called_pid, note = self.resolve_calls[0]
+        self.assertEqual(called_pid, pos_id)
+        self.assertIn("resolved_loss", note)
+        self.assertIsNotNone(row["resolved_at"])
+
+    def test_close_write_failure_leaves_alert_unresolved(self):
+        """Resolve only after the close is durable.
+
+        Clearing an alert against a close that failed to write would hide a
+        threshold crossing that is still live.
+        """
+        self.positions = [make_position(entry_price=0.35)]
+        self.sim_rows["sim-1"] = sim_row()
+        self.gamma_by_cid[CID] = gamma_market(yes="0.05", no="0.95")
+        self.sweep()
+        (row,) = self.alert_rows.values()
+
+        self.update_exc_for["pos-1"] = RuntimeError("supabase down")
+        self.gamma_by_cid[CID] = gamma_market(
+            yes="0", no="1", active=False, closed=True
+        )
+        self.sweep()
+
+        self.assertEqual(
+            self.resolve_calls, [],
+            "alerts resolved even though the close write failed",
+        )
+        self.assertIsNone(row["resolved_at"])
 
 
 class TestNotifications(MonitorTestCase):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -642,6 +642,41 @@ class TestSettlementResolvesAlerts(MonitorTestCase):
         self.assertIn("resolved_loss", note)
         self.assertIsNotNone(row["resolved_at"])
 
+    def test_transport_error_in_resolve_does_not_block_settlement_notify(self):
+        """N1: tidying an alert must never cost the settlement message.
+
+        resolve_alerts_for_position previously only caught SupabaseError, so a
+        transport-level failure unwound past the Telegram send: a position that
+        really did settle closed silently and Tyson was never told it won or
+        lost.
+        """
+        self.positions = [make_position(entry_price=0.35)]
+        self.sim_rows["sim-1"] = sim_row()
+        self.gamma_by_cid[CID] = gamma_market(yes="0.05", no="0.95")
+        self.sweep()                      # raises the stop-loss alert
+        self.telegram_requests.clear()
+
+        tests = self
+
+        async def _boom(position_id, note):
+            # NOT a SupabaseError: a transport error, the case N1 is about.
+            raise httpx.ConnectError("connection reset")
+
+        monitor_mod.resolve_alerts_for_position = _boom
+
+        self.gamma_by_cid[CID] = gamma_market(
+            yes="0", no="1", active=False, closed=True
+        )
+        result = self.sweep()
+
+        self.assertEqual(result.positions_resolved, 1, "close must still count")
+        (_, updates), = self.update_calls
+        self.assertEqual(updates["status"], "closed")
+        self.assertTrue(
+            any("Trade lost" in r["text"] for r in self.telegram_requests),
+            "settlement notification was skipped because alert cleanup raised",
+        )
+
     def test_close_write_failure_leaves_alert_unresolved(self):
         """Resolve only after the close is durable.
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -84,6 +84,8 @@ class MonitorTestCase(unittest.TestCase):
             "get_open_positions": monitor_mod.get_open_positions,
             "get_simulations_by_ids": monitor_mod.get_simulations_by_ids,
             "update_position": monitor_mod.update_position,
+            "insert_alert": monitor_mod.insert_alert,
+            "mark_alert_notified": monitor_mod.mark_alert_notified,
         }
         monitor_mod._last_monitor.update({"at": None, "resolved_total": 0})
 
@@ -94,6 +96,13 @@ class MonitorTestCase(unittest.TestCase):
         self.sim_lookups = []
         self.update_calls = []      # (position_id, updates)
         self.update_exc_for = {}    # position_id -> exception
+        # Alert layer. `live_alerts` emulates the partial unique index: a
+        # (position_id, alert_type) already present means insert_alert returns
+        # None, which is the monitor's "already alerted, stay quiet" signal.
+        self.alert_inserts = []     # list of alert dicts the monitor tried to write
+        self.live_alerts = set()    # {(position_id, alert_type)}
+        self.alert_insert_exc = None
+        self.notified_alert_ids = []
 
         self.gamma_by_cid = {}      # condition_id -> list payload or Exception
         self.gamma_requests = []
@@ -120,9 +129,24 @@ class MonitorTestCase(unittest.TestCase):
             tests.update_calls.append((position_id, dict(updates)))
             return {"id": position_id, **updates}
 
+        async def _insert_alert(alert):
+            if tests.alert_insert_exc is not None:
+                raise tests.alert_insert_exc
+            tests.alert_inserts.append(dict(alert))
+            key = (alert["position_id"], alert["alert_type"])
+            if key in tests.live_alerts:
+                return None          # partial unique index conflict -> deduped
+            tests.live_alerts.add(key)
+            return {"id": f"alert-{len(tests.live_alerts)}", **alert}
+
+        async def _mark_notified(alert_id):
+            tests.notified_alert_ids.append(alert_id)
+
         monitor_mod.get_open_positions = _get_open
         monitor_mod.get_simulations_by_ids = _get_sims
         monitor_mod.update_position = _update
+        monitor_mod.insert_alert = _insert_alert
+        monitor_mod.mark_alert_notified = _mark_notified
 
         def handler(request: httpx.Request) -> httpx.Response:
             if request.url.host == "api.telegram.org":
@@ -332,19 +356,42 @@ class TestResolution(MonitorTestCase):
 
 
 class TestTakeProfitStopLoss(MonitorTestCase):
-    def test_take_profit_close(self):
+    """Threshold crossings ALERT; they do not close.
+
+    Rewritten 2026-08-20. These tests previously asserted that a TP/SL crossing
+    wrote status='closed'. That behaviour was the defect: the monitor cannot
+    sell, so the row claimed a close that had not happened. The contract now is
+    "flag it, notify once, leave it open".
+    """
+
+    def _assert_no_position_write(self):
+        # THE core regression guard. If this ever fails, the monitor is once
+        # again claiming closes it did not perform (the 2026-08-19 incident).
+        self.assertEqual(
+            self.update_calls, [],
+            "monitor wrote to trading_positions on a threshold crossing; it "
+            "cannot sell, so it must never mark a position closed",
+        )
+
+    def test_take_profit_alerts_and_leaves_position_open(self):
         self.positions = [make_position()]
         self.sim_rows["sim-1"] = sim_row()
         self.gamma_by_cid[CID] = gamma_market(yes="0.9", no="0.1")
         result = self.sweep()
-        self.assertEqual(result.positions_tp_sl, 1)
+
+        self.assertEqual(result.alerts_raised, 1)
         self.assertEqual(result.positions_resolved, 0)
-        (_, updates), = self.update_calls
-        self.assertEqual(updates["exit_reason"], "take_profit")
-        self.assertEqual(updates["exit_price"], 0.9)
-        self.assertTrue(
-            any("Take profit" in r["text"] for r in self.telegram_requests)
-        )
+        self._assert_no_position_write()
+
+        (alert,) = self.alert_inserts
+        self.assertEqual(alert["alert_type"], "take_profit")
+        self.assertEqual(alert["trigger_price"], 0.9)
+        # Estimate is recorded on the ALERT only, never on the position.
+        self.assertIn("unrealized_pnl_estimate", alert)
+
+        text = " ".join(r["text"] for r in self.telegram_requests)
+        self.assertIn("TAKE-PROFIT THRESHOLD HIT", text)
+        self.assertIn("NOT closed", text)
 
     def test_take_profit_fires_without_entry_price(self):
         # Verbatim n8n behaviour: TP is independent of entry price.
@@ -352,16 +399,81 @@ class TestTakeProfitStopLoss(MonitorTestCase):
         self.sim_rows["sim-1"] = sim_row()
         self.gamma_by_cid[CID] = gamma_market(yes="0.9", no="0.1")
         result = self.sweep()
-        self.assertEqual(result.positions_tp_sl, 1)
+        self.assertEqual(result.alerts_raised, 1)
+        self._assert_no_position_write()
 
-    def test_stop_loss_close(self):
+    def test_stop_loss_alerts_and_leaves_position_open(self):
         self.positions = [make_position(entry_price=0.35)]
         self.sim_rows["sim-1"] = sim_row()
         self.gamma_by_cid[CID] = gamma_market(yes="0.05", no="0.95")
         result = self.sweep()
-        self.assertEqual(result.positions_tp_sl, 1)
-        (_, updates), = self.update_calls
-        self.assertEqual(updates["exit_reason"], "stop_loss")
+
+        self.assertEqual(result.alerts_raised, 1)
+        self._assert_no_position_write()
+
+        (alert,) = self.alert_inserts
+        self.assertEqual(alert["alert_type"], "stop_loss")
+
+        text = " ".join(r["text"] for r in self.telegram_requests)
+        self.assertIn("STOP-LOSS THRESHOLD HIT", text)
+        self.assertIn("NOT closed", text)
+        self.assertIn("manual-only", text)
+
+    def test_repeat_sweep_does_not_re_alert(self):
+        """The anti-spam contract: one alert per threshold crossing.
+
+        A stop-loss condition persists for as long as the price stays low, so
+        without dedup the 15-minute sweep would Telegram every 15 minutes. Dedup
+        lives in a partial unique index; the harness emulates it.
+        """
+        self.positions = [make_position(entry_price=0.35)]
+        self.sim_rows["sim-1"] = sim_row()
+        self.gamma_by_cid[CID] = gamma_market(yes="0.05", no="0.95")
+
+        first = self.sweep()
+        self.assertEqual(first.alerts_raised, 1)
+        self.assertEqual(len(self.telegram_requests), 1)
+
+        second = self.sweep()
+        self.assertEqual(second.alerts_raised, 0)
+        self.assertEqual(second.alerts_deduped, 1)
+        self.assertEqual(
+            len(self.telegram_requests), 1,
+            "second sweep re-notified on an already-live alert",
+        )
+        self._assert_no_position_write()
+
+    def test_manual_hold_suppresses_alerts_but_still_prices(self):
+        """manual_hold silences alerting without blinding the monitor."""
+        self.positions = [make_position(entry_price=0.35, manual_hold=True)]
+        self.sim_rows["sim-1"] = sim_row()
+        self.gamma_by_cid[CID] = gamma_market(yes="0.05", no="0.95")
+
+        result = self.sweep()
+        self.assertEqual(result.positions_held, 1)
+        self.assertEqual(result.alerts_raised, 0)
+        self.assertEqual(self.alert_inserts, [])
+        self.assertEqual(self.telegram_requests, [])
+        self._assert_no_position_write()
+        # Still priced: the market was fetched, so dashboard/Analyst stay live.
+        self.assertTrue(self.gamma_requests)
+
+    def test_alert_write_failure_does_not_notify(self):
+        """No Telegram without a recorded alert.
+
+        A message Tyson can see but the system has no row for would re-notify on
+        the next sweep with no dedup, which is the spam failure mode.
+        """
+        self.positions = [make_position(entry_price=0.35)]
+        self.sim_rows["sim-1"] = sim_row()
+        self.gamma_by_cid[CID] = gamma_market(yes="0.05", no="0.95")
+        self.alert_insert_exc = RuntimeError("supabase down")
+
+        result = self.sweep()
+        self.assertEqual(result.errors, 1)
+        self.assertEqual(result.alerts_raised, 0)
+        self.assertEqual(self.telegram_requests, [])
+        self._assert_no_position_write()
 
     def test_stop_loss_guard_low_entry_stays_open(self):
         # Verbatim n8n behaviour: entry <= 0.20 disables the stop loss. The
@@ -370,7 +482,8 @@ class TestTakeProfitStopLoss(MonitorTestCase):
         self.sim_rows["sim-1"] = sim_row()
         self.gamma_by_cid[CID] = gamma_market(yes="0.05", no="0.95")
         result = self.sweep()
-        self.assertEqual(result.positions_tp_sl, 0)
+        self.assertEqual(result.alerts_raised, 0)
+        self.assertEqual(self.alert_inserts, [])
         self.assertEqual(self.update_calls, [])
 
     def test_weakening_alert_no_db_write(self):
@@ -378,11 +491,13 @@ class TestTakeProfitStopLoss(MonitorTestCase):
         self.sim_rows["sim-1"] = sim_row()
         self.gamma_by_cid[CID] = gamma_market(yes="0.25", no="0.75")
         result = self.sweep()
-        self.assertEqual(result.alerts_sent, 1)
-        self.assertEqual(self.update_calls, [])
-        self.assertTrue(
-            any("Weakening" in r["text"] for r in self.telegram_requests)
-        )
+        self.assertEqual(result.alerts_raised, 1)
+        (alert,) = self.alert_inserts
+        self.assertEqual(alert["alert_type"], "weakening")
+        self._assert_no_position_write()
+        text = " ".join(r["text"] for r in self.telegram_requests)
+        self.assertIn("weakening", text.lower())
+        self.assertIn("Nothing has been closed", text)
 
 
 class TestNotifications(MonitorTestCase):


### PR DESCRIPTION
## The defect

`monitor.py::_close()` wrote `status='closed'` whenever a take-profit or stop-loss threshold fired, but the monitor has never been able to sell. `_close()` only ever wrote to Supabase, and Polymarket execution (BUY and SELL alike) is blocked by an unresolved signer/maker-address issue.

**Real incident, 2026-08-19:** a BTC position's stop loss fired at 15:39. The database recorded a closed position with a phantom `-9.27` pnl. The actual Polymarket position stayed open for another 17 hours until Tyson closed it by hand. Nothing detected the divergence, and the phantom loss was consuming the executor's daily-loss budget the whole time.

## What this does

A threshold crossing now **flags**; it does not close.

- **`trading_position_alerts`** table. Dedup is a **partial unique index** on `(position_id, alert_type) WHERE resolved_at IS NULL` — enforced in Postgres, not in monitor logic, so it survives restarts and concurrent sweeps. A condition persisting across 15-minute sweeps notifies once.
- **`trading_positions` is never written on a crossing.** The mark-to-market figure lives on the alert as `unrealized_pnl_estimate` and never reaches `trading_positions.pnl`, which feeds Gate 3.
- **Two-tier Telegram** wording that states explicitly that nothing was closed and a manual exit is required.
- **`manual_hold`** column suppresses alerts on a position already being handled by hand, while price tracking continues.
- **New endpoints:** `GET /positions/alerts`, `GET /positions/{id}/alerts`, `POST /positions/{id}/hold`, `POST /positions/manual-close`. Manual-close is the only writer of `exit_price/exit_usdc/pnl/status`; it resolves live alerts and returns them so a close can be cross-referenced.
- **`trading-api.md`** documents all of it, closing the gap that caused the fabrication incident: alerts previously existed only as Telegram messages on a bot Charlie cannot see.
- **Dashboard** Live Positions gains an Alert column.

## Unchanged on purpose

**Resolution.** A settled market (`active=false && closed=true`, or a finalised 1.0/0.0 price) really has closed and really does pay out, so `resolved_win`/`resolved_loss` still write a real close via `_close()`. Routing those through the alert path would be wrong: they are completed facts, not requests for a human to act.

**The entry-side executor.** Untouched.

## Not in this PR

SELL scaffolding (threading `side` through `execute_trade.py` and the relay, the shares-vs-USDC unit fix, `calculate_sell_market_price`) is deliberately a **separate PR**. It is the only part touching the money path, it is externally blocked anyway, and bundling it would force a reviewer to review dead-but-live-adjacent code alongside the urgent fix.

**No execution is added here. Nothing in this PR can place an order.**

## Verification

- `tests/test_monitor.py` 32 tests green. Full Python suite green (analyst, approval, executor, manual_position, monitor). `probes.test.js` green.
- Tests rewritten to the new contract, with `_assert_no_position_write()` as an explicit regression guard against the monitor ever again claiming a close.
- **Dedup verified against the real index**, not just the mock: first insert 201, duplicate 409 `23505`, different type alongside 201, re-insert after resolve 201. All test rows deleted; table empty.
- Endpoints exercised in-process via ASGI transport against the real DB. Fail-closed paths confirmed: closing an already-closed position 404s, `exit_price > 1` 400s, unknown field 400s (`extra="forbid"`). `hold` written and reverted.
- No residue: zero alert rows, `manual_hold=false` on both positions.

## Review focus

1. `_flag_for_exit` ordering — alert row is written **before** Telegram, so a notification failure loses a message, not the alert. The inverse would produce silent unrecorded crossings.
2. The `alerts_sent` / `alerts_raised` / `alerts_deduped` split — deduped crossings must not count as notifications sent.
3. `positions_tp_sl` now counts alerts raised rather than closes written. Historical series changes meaning; flagged in the model docstring.
4. Whether `_close()` is now genuinely unreachable from TP/SL.

Draft until adversarial review, per the financial-path rule.
