### PR TITLE
feat(gates): record which evidence path backed a claim (instrumentation only)

### DIFF
--- a/src/agents/gates.js
+++ b/src/agents/gates.js
@@ -164,10 +164,43 @@ export function correlatePairs(events) {
 }
 
 /**
+ * Which evidence path backed a claim. Instrumentation only: nothing branches on
+ * these, they are recorded so gate.log can show HOW a claim was backed, not just
+ * whether it was.
+ *
+ * Replaces the `weak: true` boolean that was set at the bootstrap-recitation and
+ * no-entity-fallback returns and read nowhere in src/ (introduced with the
+ * fallback itself in Slice 4, PR #43, never given a consumer). The boolean
+ * conflated two structurally different returns: bootstrap recitation matches an
+ * entity in the briefing snapshot, the fallback has no entity to match at all.
+ * Anything keyed on "weak" would therefore have moved both. Naming the path keeps
+ * them distinguishable.
+ *
+ * `sourced: 'bootstrap'` is UNCHANGED and stays on the bootstrap return: it is
+ * live, load-bearing state read by gateState (a recited characterisation is not a
+ * contradicted one). `path` is additive next to it, never a replacement.
+ */
+export const EVIDENCE_PATH = {
+  /** The claim's entity token was found in a this-turn tool row. */
+  ENTITY_MATCH: 'entity_match',
+  /** The claim's entity token was found only in the session bootstrap snapshot. */
+  BOOTSTRAP_RECITATION: 'bootstrap_recitation',
+  /** The claim had NO extractable entity; any relevant this-turn success backed it. */
+  NO_ENTITY_FALLBACK: 'no_entity_fallback',
+};
+
+/**
  * §2.5 entity-aware match. `requireStatus`: 'success' (completion/character) or
  * 'nonnull' (probe "ran"). Entity token must appear in the CALL row's args
  * (`detail`); falls back to a this-turn relevant-tool pair when the claim has
- * no extractable entity. Returns { backed, evidence? }.
+ * no extractable entity.
+ *
+ * Returns { backed, path, entityFree, evidence?, sourced? }. `path` is one of
+ * EVIDENCE_PATH when backed, null when not. `entityFree` records whether
+ * extractEntities() came back empty, which `path` alone cannot express on the
+ * unbacked returns: those come from two structurally different places (an entity
+ * was present but matched nothing, versus there was no entity and no relevant
+ * success) and were previously indistinguishable to every caller.
  */
 export function matchEvidence(sentence, events, { requireStatus = 'success', turnStartMs = 0, relevant = null, bootstrapText = null, strictRelevant = false, noEntityFallback = true, matchResultDetail = false } = {}) {
   const pairs = correlatePairs(events);
@@ -201,7 +234,9 @@ export function matchEvidence(sentence, events, { requireStatus = 'success', tur
       const hay = resultUsable
         ? String(p.call.detail || '') + '\n' + String(p.result.detail || '')
         : String(p.call.detail || '');
-      if (entities.some(e => hay.includes(e))) return { backed: true, evidence: p };
+      if (entities.some(e => hay.includes(e))) {
+        return { backed: true, path: EVIDENCE_PATH.ENTITY_MATCH, entityFree: false, evidence: p };
+      }
     }
     // Slice 4.1: the this-session bootstrap snapshot is a legitimate source for
     // a RECITED claim about a known entity (Charlie cites his briefing). DEFAULT
@@ -218,20 +253,39 @@ export function matchEvidence(sentence, events, { requireStatus = 'success', tur
     // those require a real this-turn result event, not the briefing snapshot.
     if (!strictRelevant && bootstrapText && bootstrapMayBack(sentence)
         && entities.some(e => corpusHasEntity(bootstrapText, e))) {
-      return { backed: true, sourced: 'bootstrap', weak: true };
+      return { backed: true, path: EVIDENCE_PATH.BOOTSTRAP_RECITATION, entityFree: false, sourced: 'bootstrap' };
     }
-    return { backed: false };
+    return { backed: false, path: null, entityFree: false };
   }
   // no-entity fallback: a this-turn pair for a verb-relevant tool. Disabled when
   // noEntityFallback=false so an entity-free outcome claim FAILS CLOSED.
-  if (!noEntityFallback) return { backed: false };
+  if (!noEntityFallback) return { backed: false, path: null, entityFree: true };
   for (const p of candidates) {
     const ts = parseAuditTs(p.result.timestamp);
     if (ts >= turnStartMs && (!relevant || relevant(p.result.action))) {
-      return { backed: true, evidence: p, weak: true };
+      return { backed: true, path: EVIDENCE_PATH.NO_ENTITY_FALLBACK, entityFree: true, evidence: p };
     }
   }
-  return { backed: false };
+  return { backed: false, path: null, entityFree: true };
+}
+
+/**
+ * One instrumentation row per matchEvidence CALL, not per claim: gateState calls
+ * it twice for a characterisation ('ran' then 'ok') and those two answers can
+ * differ, which is exactly the kind of thing the log needs to show. `check` names
+ * the call site. Never read by any gate; carried on the gate result as
+ * `observations` (deliberately NOT `claims`, which drives hedgeResponse and the
+ * escalation text and must keep containing only fired claims).
+ */
+function observe(check, sentence, m) {
+  return {
+    check,
+    claim: sentence,
+    backed: m.backed === true,
+    path: m.path ?? null,
+    sourced: m.sourced ?? null,
+    entity_free: m.entityFree ?? null,
+  };
 }
 
 // ── Gate 4 — tool reference (structural) ──────────────────────────────────
@@ -448,9 +502,10 @@ export function gateCompletion(response, ctx) {
   const claims = splitSentences(response)
     .filter(s => !isSuppressed(s))
     .filter(s => COMPLETION_RE.test(s) || isExtendedActionClaim(s));
-  if (!claims.length) return { gate: 'completion', fired: false };
+  if (!claims.length) return { gate: 'completion', fired: false, observations: [] };
   const events = windowEvents(ctx, ctx.windowMinComplete);
   const unbacked = [];
+  const observations = [];
   for (const c of claims) {
     // matchResultDetail: a created record's id is SERVER-generated and exists
     // only in the result payload (e.g. create_positions_manual returns
@@ -459,20 +514,22 @@ export function gateCompletion(response, ctx) {
     // replaying the genuine 2026-08-11 19:21 position. Confined to
     // isCompletionTool actions by the `relevant` guard in matchEvidence.
     const m = matchEvidence(c, events, { requireStatus: 'success', turnStartMs: ctx.turnStartMs ?? 0, relevant: isCompletionTool, bootstrapText: ctx.bootstrapText, matchResultDetail: true });
+    observations.push(observe('completion', c, m));
     if (!m.backed) unbacked.push({ text: c, verification_attempted: true, verified: false });
   }
-  if (!unbacked.length) return { gate: 'completion', fired: false };
-  return { gate: 'completion', fired: true, severity: 'hard', claims: unbacked, action: 'reprompt', reason: 'completion claim without a backing success tool result' };
+  if (!unbacked.length) return { gate: 'completion', fired: false, observations };
+  return { gate: 'completion', fired: true, severity: 'hard', claims: unbacked, action: 'reprompt', reason: 'completion claim without a backing success tool result', observations };
 }
 
 /** Gate 3 — state: probe must have RUN (nonnull); characterization needs success. */
 export function gateState(response, ctx) {
   const claims = detectClaims(response, STATE_RE);
-  if (!claims.length) return { gate: 'state', fired: false };
+  if (!claims.length) return { gate: 'state', fired: false, observations: [] };
   const events = windowEvents(ctx, ctx.windowMinState);
-  let anyHard = false; const fired = [];
+  let anyHard = false; const fired = []; const observations = [];
   for (const c of claims) {
     const ran = matchEvidence(c, events, { requireStatus: 'nonnull', turnStartMs: ctx.turnStartMs ?? 0, relevant: isStateTool, bootstrapText: ctx.bootstrapText });
+    observations.push(observe('ran', c, ran));
     if (!ran.backed) { fired.push({ text: c, verification_attempted: true, verified: false, severity: 'soft' }); continue; }
     if (CHARACTERIZATION_RE.test(c)) {
       // Success check is TOOL-ONLY (no bootstrapText): a this-turn probe that
@@ -481,11 +538,12 @@ export function gateState(response, ctx) {
       // at all), there is no this-turn probe to contradict, so a recited
       // characterization ("agex-hub stable at 38h") is not a hard contradiction.
       const ok = matchEvidence(c, events, { requireStatus: 'success', turnStartMs: ctx.turnStartMs ?? 0, relevant: isStateTool });
+      observations.push(observe('ok', c, ok));
       if (!ok.backed && ran.sourced !== 'bootstrap') { anyHard = true; fired.push({ text: c, verification_attempted: true, verified: false, severity: 'hard' }); } // this-turn probe ran but not success → contradicted
     }
   }
-  if (!fired.length) return { gate: 'state', fired: false };
-  return { gate: 'state', fired: true, severity: anyHard ? 'hard' : 'soft', claims: fired, action: anyHard ? 'reprompt' : 'rewrite', reason: anyHard ? 'characterization contradicted by tool result' : 'state claim without a probe in window' };
+  if (!fired.length) return { gate: 'state', fired: false, observations };
+  return { gate: 'state', fired: true, severity: anyHard ? 'hard' : 'soft', claims: fired, action: anyHard ? 'reprompt' : 'rewrite', reason: anyHard ? 'characterization contradicted by tool result' : 'state claim without a probe in window', observations };
 }
 
 /**
@@ -512,9 +570,10 @@ export function gateState(response, ctx) {
 export function gateDelegation(response, ctx) {
   const sentences = splitSentences(response).filter(s => !isSuppressed(s));
   const cc = sentences.filter(s => DELEGATION_RE.test(s) || ((CC_MENTION_RE.test(s) || SPECIALIST_MENTION_RE.test(s)) && CC_OUTCOME_RE.test(s)));
-  if (!cc.length) return { gate: 'delegation', fired: false };
+  if (!cc.length) return { gate: 'delegation', fired: false, observations: [] };
   const events = windowEvents(ctx, ctx.windowMinComplete);
   const fired = [];
+  const observations = [];
   for (const s of cc) {
     const ccMention = CC_MENTION_RE.test(s);
     const specMention = SPECIALIST_MENTION_RE.test(s);
@@ -532,11 +591,12 @@ export function gateDelegation(response, ctx) {
       // lives in the result row, not the call args — so match the result detail too
       // (safe: strictRelevant already confines candidates to success dispatch events).
       : matchEvidence(s, events, { requireStatus: 'success', turnStartMs: ctx.turnStartMs ?? 0, relevant: isAnyDispatch, strictRelevant: true, matchResultDetail: true });
+    observations.push(observe(isOutcome ? 'outcome' : 'dispatch', s, m));
     if (!m.backed) fired.push({ text: s, verification_attempted: true, verified: false });
   }
-  if (!fired.length) return { gate: 'delegation', fired: false };
+  if (!fired.length) return { gate: 'delegation', fired: false, observations };
   return {
-    gate: 'delegation', fired: true, severity: 'hard', claims: fired, action: 'reprompt',
+    gate: 'delegation', fired: true, severity: 'hard', claims: fired, action: 'reprompt', observations,
     reason: 'delegation claim unbacked: a dispatch claim needs a this-turn claude_code_dispatch or delegate_to event; an outcome claim needs a completed claude_code_result (Claude Code) or delegate_to_result (specialist) for the cited task',
   };
 }
@@ -1118,18 +1178,29 @@ export function buildEscalation(gateOut) {
  * The raw failing response is NEVER returned — only a hedged/corrected/escalated
  * one. Branches on gateOut.result (NOT action literals). Caller keeps tools
  * registered for the whole call (cleanupTools fires once after this returns).
+ *
+ * `onGateLog` is now invoked after EVERY runGates call, including the ones that
+ * pass. Previously it was called only from the top of the failure loop, so two
+ * classes of outcome were never recorded anywhere: a turn that passed first time,
+ * and the post-hedge re-check. Both are the interesting cases for the evidence
+ * path: a claim backed by the no-entity fallback PASSES, so the gate does not
+ * fire, so nothing was written. That absence is why the fallback's real usage
+ * could not be counted retrospectively. Control flow is untouched: the callback is
+ * best-effort and its return value is ignored, exactly as before.
  */
 export async function regenerateWithGates({ generate, auditLog, toolRegistry, turnStart, agentScope = null, bootstrap = null, provenance = null, entityCorpus = null, baseMessages, maxAttempts = 3, onGateLog = null, onEscalate = null, now = null }) {
   const opts = () => ({ now: now || Date.now(), turnStart, agentScope, bootstrap, provenance, entityCorpus });
+  const emit = (g, a) => { if (onGateLog) { try { onGateLog(g, a); } catch { /* logging best-effort */ } } };
   let messages = baseMessages;
   let result = await generate(messages);
   let attempt = 1;
   let gateOut = runGates(result.content, auditLog, toolRegistry, opts());
+  emit(gateOut, attempt);
   while (gateOut.result !== 'pass') {
-    if (onGateLog) { try { onGateLog(gateOut, attempt); } catch { /* logging best-effort */ } }
     if (gateOut.result === 'soft_fail') {
       result = { ...result, content: hedgeResponse(result.content, gateOut) };
       gateOut = runGates(result.content, auditLog, toolRegistry, opts());
+      emit(gateOut, attempt);
       if (gateOut.result === 'pass') break;
     }
     if (attempt >= maxAttempts) {
@@ -1141,6 +1212,7 @@ export async function regenerateWithGates({ generate, auditLog, toolRegistry, tu
     result = await generate(messages);
     attempt++;
     gateOut = runGates(result.content, auditLog, toolRegistry, opts());
+    emit(gateOut, attempt);
   }
   return { ...result, gateAttempts: attempt, gateOutcome: gateOut.result };
 }

--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -13,7 +13,7 @@ import { loadSkills } from './skill-loader.js';
 import { scanSpecialistResults } from '../tools/delegate-to.js';
 import { regenerateWithGates, isGatedTurn, buildProvenanceText } from './gates.js';
 import { gatherCcResults, depositCcEvidence } from './cc-results.js';
-import { appendGateLog } from '../observability/gate-log.js';
+import { appendGateLog, gateLogRows } from '../observability/gate-log.js';
 import { appendChannelEvent } from '../observability/channel-events.js';
 
 // Slice 3f: prompt-cache kill-switch read per-request. process.env is a
@@ -567,35 +567,11 @@ export class Agent {
         provenance: buildProvenanceText(textMessage, truncatedHistory),
         baseMessages: messages,
         // Called after EVERY runGates now, passes included (see regenerateWithGates).
-        // Two row kinds go out: the firings that were always logged, and the new
-        // per-matchEvidence observations. The observations are the point of the
-        // change: a claim backed by the no-entity fallback does not fire a gate,
-        // so before this the only evidence path anyone could count was the one on
-        // claims that FAILED. Observations carry claim text, so they go through the
-        // same scrubber (appendGateLog scrubs `claim` unconditionally).
+        // gateLogRows owns the mapping and the content policy (firing rows keep
+        // their claim text, observation rows carry none), so both are unit-tested
+        // rather than living in this callback.
         onGateLog: (gateOut, attempt) => {
-          for (const g of gateOut.gates) {
-            if (g.fired) {
-              for (const c of (g.claims || [])) {
-                appendGateLog({
-                  gate: g.gate, claim: c.text || String(c),
-                  verification_attempted: c.verification_attempted !== false,
-                  verified: false, result: gateOut.result, action: g.action, attempt,
-                  fired: true,
-                });
-              }
-            }
-            // Gates 4 and 5 do not call matchEvidence, so they report none.
-            for (const o of (g.observations || [])) {
-              appendGateLog({
-                gate: g.gate, claim: o.claim,
-                verification_attempted: true, verified: false,
-                result: gateOut.result, action: g.action, attempt,
-                fired: false, check: o.check, backed: o.backed,
-                path: o.path, sourced: o.sourced, entity_free: o.entity_free,
-              });
-            }
-          }
+          for (const row of gateLogRows(gateOut, attempt)) appendGateLog(row);
         },
         onEscalate: (gateOut, attempt) => {
           const gates = gateOut.gates.filter(g => g.fired).map(g => g.gate);

--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -566,14 +566,33 @@ export class Agent {
         // become self-justifying on the following turn.
         provenance: buildProvenanceText(textMessage, truncatedHistory),
         baseMessages: messages,
+        // Called after EVERY runGates now, passes included (see regenerateWithGates).
+        // Two row kinds go out: the firings that were always logged, and the new
+        // per-matchEvidence observations. The observations are the point of the
+        // change: a claim backed by the no-entity fallback does not fire a gate,
+        // so before this the only evidence path anyone could count was the one on
+        // claims that FAILED. Observations carry claim text, so they go through the
+        // same scrubber (appendGateLog scrubs `claim` unconditionally).
         onGateLog: (gateOut, attempt) => {
           for (const g of gateOut.gates) {
-            if (!g.fired) continue;
-            for (const c of (g.claims || [])) {
+            if (g.fired) {
+              for (const c of (g.claims || [])) {
+                appendGateLog({
+                  gate: g.gate, claim: c.text || String(c),
+                  verification_attempted: c.verification_attempted !== false,
+                  verified: false, result: gateOut.result, action: g.action, attempt,
+                  fired: true,
+                });
+              }
+            }
+            // Gates 4 and 5 do not call matchEvidence, so they report none.
+            for (const o of (g.observations || [])) {
               appendGateLog({
-                gate: g.gate, claim: c.text || String(c),
-                verification_attempted: c.verification_attempted !== false,
-                verified: false, result: gateOut.result, action: g.action, attempt,
+                gate: g.gate, claim: o.claim,
+                verification_attempted: true, verified: false,
+                result: gateOut.result, action: g.action, attempt,
+                fired: false, check: o.check, backed: o.backed,
+                path: o.path, sourced: o.sourced, entity_free: o.entity_free,
               });
             }
           }

--- a/src/observability/gate-log.js
+++ b/src/observability/gate-log.js
@@ -37,12 +37,31 @@ function _rotateIfNeeded(path) {
   }
 }
 
+/** Boolean or null. Never coerce an absent field to false. */
+const _bool = (v) => (typeof v === 'boolean' ? v : null);
+
 /**
- * Append one gate-firing record. Never throws (logging must not break the
- * regeneration loop). Scrubs `claim` + `rewritten_claim` before write.
+ * Append one gate record. Never throws (logging must not break the regeneration
+ * loop). Scrubs `claim` + `rewritten_claim` before write.
  *
  * record: { gate, claim, verification_attempted, verified, result, action,
- *           attempt, rewritten_claim? }
+ *           attempt, rewritten_claim?, fired?, check?, backed?, path?, sourced?,
+ *           entity_free? }
+ *
+ * Two row kinds share this schema, told apart by `fired`:
+ *
+ *  - `fired: true`  = a gate firing, the only kind that existed before. Every
+ *    pre-existing field keeps its exact meaning, so existing greps still work.
+ *  - `fired: false` = an OBSERVATION: one matchEvidence call that did not (on its
+ *    own) fire the gate. These are new. They exist because a claim backed by the
+ *    no-entity fallback passes silently, so the evidence path that backed it was
+ *    unrecorded and uncountable.
+ *
+ * The evidence fields are null on rows that have no such notion (Gate 4's phantom
+ * tool names, Gate 5's identifier provenance, a gate that threw): those gates do
+ * not call matchEvidence, so there is no path to report. Null means "not
+ * applicable", not "no evidence", hence _bool rather than a `!!` coercion, which
+ * would have silently reported every such row as backed:false.
  */
 export function appendGateLog(record = {}) {
   const path = _path();
@@ -57,6 +76,13 @@ export function appendGateLog(record = {}) {
       result: record.result || null,            // 'pass'|'soft_fail'|'hard_fail'
       action: record.action || null,            // 'rewrite'|'reprompt'|'escalate'|'fail_closed_slice5_pending'|...
       attempt: record.attempt ?? 0,
+      // ── instrumentation (Unit 1) ──
+      fired: _bool(record.fired),               // true = gate firing, false = observation
+      check: record.check || null,              // 'completion'|'ran'|'ok'|'dispatch'|'outcome'
+      backed: _bool(record.backed),
+      path: record.path || null,                // EVIDENCE_PATH value, or null
+      sourced: record.sourced || null,          // 'bootstrap' when the snapshot backed it
+      entity_free: _bool(record.entity_free),
     };
     if (record.rewritten_claim != null) {
       entry.rewritten_claim = scrubSecrets(String(record.rewritten_claim)).slice(0, 500);

--- a/src/observability/gate-log.js
+++ b/src/observability/gate-log.js
@@ -63,6 +63,52 @@ const _bool = (v) => (typeof v === 'boolean' ? v : null);
  * applicable", not "no evidence", hence _bool rather than a `!!` coercion, which
  * would have silently reported every such row as backed:false.
  */
+/**
+ * Map one runGates outcome to the rows that describe it. Pure, so the content
+ * policy below is a tested invariant rather than a comment inside a callback.
+ *
+ * FIRING rows carry claim text, exactly as they always have.
+ * OBSERVATION rows carry NONE.
+ *
+ * That asymmetry is the point. Before observations existed, gate.log held claim
+ * text only for claims that FAILED. Observations fire on every gated turn
+ * including passes, so logging their text would have widened the file to most of
+ * Charlie's real output, including replies quoting customer names, amounts and
+ * emails. scrubSecrets covers API keys and Telegram tokens, not PII. Nulling the
+ * claim keeps the content envelope exactly where it was while still recording
+ * which evidence path backed what.
+ *
+ * Nothing analytic is lost: gate + check + backed + path + entity_free is the
+ * payload, and sentence-shape analysis belongs in the replay harness, which reads
+ * memory.db directly instead of persisting a second copy here.
+ */
+export function gateLogRows(gateOut = {}, attempt = 0) {
+  const rows = [];
+  for (const g of (gateOut.gates || [])) {
+    if (g.fired) {
+      for (const c of (g.claims || [])) {
+        rows.push({
+          gate: g.gate, claim: c.text || String(c),
+          verification_attempted: c.verification_attempted !== false,
+          verified: false, result: gateOut.result, action: g.action, attempt,
+          fired: true,
+        });
+      }
+    }
+    // Gates 4 and 5 do not call matchEvidence, so they report no observations.
+    for (const o of (g.observations || [])) {
+      rows.push({
+        gate: g.gate, claim: null,          // never the sentence: see above
+        verification_attempted: true, verified: false,
+        result: gateOut.result, action: g.action, attempt,
+        fired: false, check: o.check, backed: o.backed,
+        path: o.path, sourced: o.sourced, entity_free: o.entity_free,
+      });
+    }
+  }
+  return rows;
+}
+
 export function appendGateLog(record = {}) {
   const path = _path();
   try {

--- a/tests/verification-gates.test.js
+++ b/tests/verification-gates.test.js
@@ -15,7 +15,7 @@
 import { AuditLog, parseAuditTs } from '../src/security/audit.js';
 import {
   splitSentences, stripCodeSpans, isSuppressed, extractEntities, correlatePairs,
-  matchEvidence, gateToolReference, runGates,
+  matchEvidence, gateToolReference, runGates, EVIDENCE_PATH,
 } from '../src/agents/gates.js';
 import { appendGateLog } from '../src/observability/gate-log.js';
 import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from 'fs';
@@ -74,9 +74,46 @@ check('matchEvidence: error-only row → not backed for success', matchEvidence(
   { action: 'deploy', detail: '{"id":"toolu_2","result":"boom"}', result_status: 'error', timestamp: evNow },
   { action: 'deploy', detail: '{"id":"toolu_2","args":{"id":"Qf39NEOEgz2W0uls"}}', result_status: null, timestamp: evNow },
 ], { requireStatus: 'success' }).backed === false);
-check('matchEvidence: no-entity this-turn fallback → backed weak', (() => {
+// Unit 1: the `weak` boolean is replaced by an explicit evidence path. This was
+// its ONLY read in the repo; nothing in src/ ever read it.
+check('matchEvidence: no-entity this-turn fallback → backed via no_entity_fallback', (() => {
   const r = matchEvidence('it is done', events, { requireStatus: 'success', turnStartMs: Date.now() - 120000 });
-  return r.backed === true && r.weak === true;
+  return r.backed === true
+    && r.path === EVIDENCE_PATH.NO_ENTITY_FALLBACK
+    && r.entityFree === true
+    && r.weak === undefined;          // the old boolean is gone, not shadowed
+})());
+check('matchEvidence: entity hit → path entity_match, not entity-free', (() => {
+  const r = matchEvidence('deployed Qf39NEOEgz2W0uls', events, { requireStatus: 'success' });
+  return r.backed === true && r.path === EVIDENCE_PATH.ENTITY_MATCH && r.entityFree === false;
+})());
+// The two former `weak: true` sites must stay distinguishable: bootstrap
+// recitation matched an ENTITY in the briefing, the fallback had no entity at
+// all. A single boolean could not tell them apart, so anything keyed on it would
+// have moved both.
+check('matchEvidence: bootstrap recitation → path bootstrap_recitation, sourced preserved', (() => {
+  const boot = bootstrapCorpus({ probes: [{ detail: 'workflow Qf39NEOEgz2W0uls is live' }] });
+  const r = matchEvidence('The build log shows Qf39NEOEgz2W0uls is now RESOLVED.', [],
+    { requireStatus: 'success', turnStartMs: Date.now() - 120000, bootstrapText: boot });
+  return r.backed === true
+    && r.path === EVIDENCE_PATH.BOOTSTRAP_RECITATION
+    && r.sourced === 'bootstrap'      // still read by gateState, must not regress
+    && r.entityFree === false;
+})());
+check('matchEvidence: the three paths are distinct values', new Set(Object.values(EVIDENCE_PATH)).size === 3);
+// entityFree is the discriminator `path` cannot carry: BOTH unbacked returns have
+// path null, but they come from structurally different places.
+check('matchEvidence: unbacked WITH an entity → entity_free false', (() => {
+  const r = matchEvidence('deployed WkXX0000zz9988yy', events, { requireStatus: 'success' });
+  return r.backed === false && r.path === null && r.entityFree === false;
+})());
+check('matchEvidence: unbacked with NO entity → entity_free true', (() => {
+  const r = matchEvidence('it is done', events, { requireStatus: 'success', turnStartMs: Date.now() + 60000 });
+  return r.backed === false && r.path === null && r.entityFree === true;
+})());
+check('matchEvidence: noEntityFallback=false → fails closed, still entity_free', (() => {
+  const r = matchEvidence('it is done', events, { requireStatus: 'success', turnStartMs: Date.now() - 120000, noEntityFallback: false });
+  return r.backed === false && r.path === null && r.entityFree === true;
 })());
 check('matchEvidence: no-entity, evidence pre-dates turn → not backed', matchEvidence('it is done', events, { requireStatus: 'success', turnStartMs: Date.now() + 60000 }).backed === false);
 // P1-2: interleaved cross-agent rows — id correlation must pair correctly (errored claim not success-backed)
@@ -877,7 +914,111 @@ const glRow = JSON.parse(gl);
 check('gate.log JSONL shape', glRow.gate === 'completion' && glRow.result === 'hard_fail' && glRow.attempt === 1);
 check('gate.log scrubs mid-string sk-ant key', !gl.includes('SECRET123') && gl.includes('<scrubbed>'));
 check('gate.log mode 0600', (statSync(join(dir, 'gate.log')).mode & 0o777) === 0o600);
+
+// ── Unit 1: evidence-path instrumentation ────────────────────────────────────
+// A row with no evidence notion (Gate 4/5, or a gate that threw) must report
+// null, NOT false. `!!undefined` would have logged every such row as
+// backed:false / not-entity-free, which is a claim the row cannot support.
+check('gate.log: absent evidence fields are null, never coerced to false',
+  glRow.fired === null && glRow.backed === null && glRow.path === null
+  && glRow.sourced === null && glRow.entity_free === null && glRow.check === null);
+
+const obsPath = join(dir, 'gate-obs.log');
+process.env.QCLAW_GATE_LOG_PATH = obsPath;
+appendGateLog({
+  gate: 'completion', claim: 'it is done; token sk-ant-admin01-OBSSECRET here',
+  result: 'pass', action: null, attempt: 1,
+  fired: false, check: 'completion', backed: true,
+  path: EVIDENCE_PATH.NO_ENTITY_FALLBACK, sourced: null, entity_free: true,
+});
+const obsRaw = readFileSync(obsPath, 'utf-8').trim();
+const obsRow = JSON.parse(obsRaw);
+check('gate.log: observation row carries path + backed + entity_free',
+  obsRow.fired === false && obsRow.backed === true && obsRow.check === 'completion'
+  && obsRow.path === 'no_entity_fallback' && obsRow.entity_free === true);
+check('gate.log: a PASS is now recordable (was unrepresentable before)', obsRow.result === 'pass');
+check('gate.log: observation claim text goes through the same scrubber',
+  !obsRaw.includes('OBSSECRET') && obsRaw.includes('<scrubbed>'));
+check('gate.log: pre-existing fields keep their meaning on observation rows',
+  obsRow.gate === 'completion' && obsRow.verified === false && obsRow.attempt === 1);
 delete process.env.QCLAW_GATE_LOG_PATH;
+
+// Observations must never leak into `claims`: that array drives hedgeResponse
+// (which DELETES the sentence from the reply) and the escalation text. A backed
+// claim appearing there would silently strip a truthful sentence.
+const obsEv = (action, id) => {
+  const t = new Date().toISOString();
+  return [
+    { action, detail: JSON.stringify({ id: 'o1', result: 'ok' }), result_status: 'success', timestamp: t },
+    { action, detail: JSON.stringify({ id: 'o1', args: { id } }), result_status: null, timestamp: t },
+  ];
+};
+const obsCtx = (evs) => ({
+  auditLog: { toolEventsSince: () => evs }, toolRegistry: { has: () => true },
+  now: Date.now(), turnStartMs: Date.now() - 120000, windowMinComplete: 10, windowMinState: 5,
+});
+const gPass = gateCompletion('Deployed workflow Qf39NEOEgz2W0uls.', obsCtx(obsEv('n8n_workflow_update', 'Qf39NEOEgz2W0uls')));
+check('observations: a PASSING gate still reports its evidence path',
+  gPass.fired === false && gPass.observations.length === 1
+  && gPass.observations[0].backed === true
+  && gPass.observations[0].path === EVIDENCE_PATH.ENTITY_MATCH);
+check('observations: a passing gate exposes no claims array',
+  gPass.claims === undefined);
+const gFail = gateCompletion('Deployed workflow Zz000000zz11.', obsCtx([]));
+check('observations: a FIRING gate reports both claims and observations',
+  gFail.fired === true && gFail.claims.length === 1 && gFail.observations.length === 1
+  && gFail.observations[0].backed === false && gFail.observations[0].path === null);
+check('observations: shell_exec backing an entity-free claim is now visible in the log',
+  (() => {
+    const g = gateCompletion('**Confirmed:** the fix is deployed and merged to main.', obsCtx(obsEv('shell_exec', 'x')));
+    return g.fired === false && g.observations.some(o =>
+      o.backed === true && o.path === EVIDENCE_PATH.NO_ENTITY_FALLBACK && o.entity_free === true);
+  })());
+check('observations: gateState records both the ran and ok checks',
+  (() => {
+    const g = gateState('The workflow Qf39NEOEgz2W0uls is healthy.',
+      obsCtx(obsEv('shared__n8n-api__n8n-api__get_workflows_id', 'Qf39NEOEgz2W0uls')));
+    const checks = g.observations.map(o => o.check);
+    return checks.includes('ran') && checks.includes('ok');
+  })());
+check('observations: gates that do not call matchEvidence report none',
+  gateToolReference('all good', { toolRegistry: { has: () => true } }).observations === undefined);
+
+// The blind spot this unit closes: a turn that passes first time called onGateLog
+// zero times before, so a fallback-backed claim was never recorded anywhere.
+const CLEAN = 'The workflow Qf39NEOEgz2W0uls is running.';
+const passLog = [];
+const rPass = await regenerateWithGates({
+  generate: async () => ({ content: CLEAN, model: 'm' }),
+  auditLog: mkAudit(readPair('shared__n8n-api__n8n-api__get_workflows_id', 'Qf39NEOEgz2W0uls')),
+  toolRegistry: { has: () => true }, turnStart: past, baseMessages: BM,
+  onGateLog: (g, a) => passLog.push({ result: g.result, attempt: a }),
+});
+check('U1: onGateLog now fires on a first-attempt PASS (was silent)',
+  rPass.gateOutcome === 'pass' && passLog.length === 1
+  && passLog[0].result === 'pass' && passLog[0].attempt === 1);
+check('U1: a passing turn still returns its content untouched',
+  rPass.content === CLEAN && rPass.gateAttempts === 1);
+check('U1: the passing turn reported an evidence path for its claim',
+  runGates(CLEAN, mkAudit(readPair('shared__n8n-api__n8n-api__get_workflows_id', 'Qf39NEOEgz2W0uls')),
+    { has: () => true }, { now: Date.now(), turnStart: past })
+    .gates.flatMap(g => g.observations || []).some(o => o.backed === true && o.path !== null));
+
+// The post-hedge re-check was the other unlogged outcome: the old loop logged
+// from its top, so a soft_fail that hedged clean emitted one row for the
+// soft_fail and nothing for the pass that followed.
+const hedgeLog = [];
+const rHedge = await regenerateWithGates({
+  generate: async () => ({ content: 'Deployed workflow Qf39NEOEgz2W0uls.', model: 'm' }),
+  auditLog: mkAudit(successPair('n8n_workflow_update', 'Qf39NEOEgz2W0uls')),
+  toolRegistry: { has: () => true }, turnStart: past, baseMessages: BM,
+  onGateLog: (g, a) => hedgeLog.push({ result: g.result, attempt: a }),
+});
+check('U1: soft_fail then hedge-to-pass now logs BOTH outcomes',
+  rHedge.gateOutcome === 'pass' && hedgeLog.length === 2
+  && hedgeLog[0].result === 'soft_fail' && hedgeLog[1].result === 'pass');
+check('U1: hedging behaviour itself is unchanged (content still replaced)',
+  rHedge.content === NO_VERIFIED_ANSWER && rHedge.gateAttempts === 1);
 
 rmSync(dir, { recursive: true, force: true });
 console.log(`\n${passed}/${passed + failed} checks passed`);

--- a/tests/verification-gates.test.js
+++ b/tests/verification-gates.test.js
@@ -17,7 +17,7 @@ import {
   splitSentences, stripCodeSpans, isSuppressed, extractEntities, correlatePairs,
   matchEvidence, gateToolReference, runGates, EVIDENCE_PATH,
 } from '../src/agents/gates.js';
-import { appendGateLog } from '../src/observability/gate-log.js';
+import { appendGateLog, gateLogRows } from '../src/observability/gate-log.js';
 import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -926,7 +926,7 @@ check('gate.log: absent evidence fields are null, never coerced to false',
 const obsPath = join(dir, 'gate-obs.log');
 process.env.QCLAW_GATE_LOG_PATH = obsPath;
 appendGateLog({
-  gate: 'completion', claim: 'it is done; token sk-ant-admin01-OBSSECRET here',
+  gate: 'completion', claim: null,
   result: 'pass', action: null, attempt: 1,
   fired: false, check: 'completion', backed: true,
   path: EVIDENCE_PATH.NO_ENTITY_FALLBACK, sourced: null, entity_free: true,
@@ -937,11 +937,54 @@ check('gate.log: observation row carries path + backed + entity_free',
   obsRow.fired === false && obsRow.backed === true && obsRow.check === 'completion'
   && obsRow.path === 'no_entity_fallback' && obsRow.entity_free === true);
 check('gate.log: a PASS is now recordable (was unrepresentable before)', obsRow.result === 'pass');
-check('gate.log: observation claim text goes through the same scrubber',
-  !obsRaw.includes('OBSSECRET') && obsRaw.includes('<scrubbed>'));
 check('gate.log: pre-existing fields keep their meaning on observation rows',
   obsRow.gate === 'completion' && obsRow.verified === false && obsRow.attempt === 1);
+check('gate.log: the writer still scrubs whatever claim it IS given',
+  (() => {
+    const p = join(dir, 'gate-scrub.log');
+    process.env.QCLAW_GATE_LOG_PATH = p;
+    appendGateLog({ gate: 'completion', claim: 'done; key sk-ant-admin01-OBSSECRET here', result: 'hard_fail', attempt: 1, fired: true });
+    const raw = readFileSync(p, 'utf-8');
+    return !raw.includes('OBSSECRET') && raw.includes('<scrubbed>');
+  })());
 delete process.env.QCLAW_GATE_LOG_PATH;
+
+// Content policy, as an invariant rather than a comment: gate.log held claim text
+// only for FAILING claims before observations existed. Observations fire on every
+// gated turn including passes, so carrying their text would have widened the file
+// to most of Charlie's real output, and scrubSecrets covers keys, not PII.
+const polGateOut = {
+  result: 'hard_fail',
+  gates: [{
+    gate: 'completion', fired: true, severity: 'hard', action: 'reprompt',
+    claims: [{ text: 'Deployed the thing for Bianca Stuurman, $1,075.00', verification_attempted: true }],
+    observations: [
+      { check: 'completion', claim: 'Deployed the thing for Bianca Stuurman, $1,075.00', backed: false, path: null, sourced: null, entity_free: true },
+      { check: 'completion', claim: 'Invoice 1000148 is sent, due 4 Sep, bianca@example.com', backed: true, path: EVIDENCE_PATH.NO_ENTITY_FALLBACK, sourced: null, entity_free: true },
+    ],
+  }],
+};
+const polRows = gateLogRows(polGateOut, 2);
+check('gateLogRows: one firing row plus one row per observation', polRows.length === 3);
+check('gateLogRows: the FIRING row still carries its claim text (unchanged)',
+  polRows.filter(r => r.fired === true).length === 1
+  && polRows.find(r => r.fired === true).claim.includes('Bianca Stuurman'));
+check('gateLogRows: NO observation row carries claim text',
+  polRows.filter(r => r.fired === false).every(r => r.claim === null));
+check('gateLogRows: no customer data reaches gate.log via an observation',
+  !JSON.stringify(polRows.filter(r => r.fired === false)).includes('bianca@example.com'));
+check('gateLogRows: observations still carry the analytic payload',
+  polRows.filter(r => r.fired === false).every(r => r.check === 'completion' && typeof r.backed === 'boolean')
+  && polRows.some(r => r.fired === false && r.path === EVIDENCE_PATH.NO_ENTITY_FALLBACK));
+check('gateLogRows: a PASSING gate emits observations and no firing rows',
+  (() => {
+    const rows = gateLogRows({ result: 'pass', gates: [{ gate: 'completion', fired: false, observations: [{ check: 'completion', claim: 'x', backed: true, path: EVIDENCE_PATH.ENTITY_MATCH, sourced: null, entity_free: false }] }] }, 1);
+    return rows.length === 1 && rows[0].fired === false && rows[0].claim === null && rows[0].result === 'pass';
+  })());
+check('gateLogRows: a gate with neither claims nor observations emits nothing',
+  gateLogRows({ result: 'pass', gates: [{ gate: 'tool_reference', fired: false }] }, 1).length === 0);
+check('gateLogRows: kill-switch output (no gates) emits nothing',
+  gateLogRows({ result: 'pass', gates: [], disabled: true }, 1).length === 0);
 
 // Observations must never leak into `claims`: that array drives hedgeResponse
 // (which DELETES the sentence from the reply) and the escalation text. A backed


### PR DESCRIPTION
**Unit 1 of the P1 weak-flag work. Instrumentation only. No gate decision changes.**

This makes the evidence path visible so the deferred decisions (no-entity downgrade, the P2 `sent` collision, pseudo-success filtering) can be made on data instead of on argument. It deliberately changes nothing about what fires.

## Why the `weak` boolean could not just be consumed

`weak: true` was set at two returns in `matchEvidence` and read nowhere in `src/`. It was introduced with the no-entity fallback itself (Slice 4, PR #43, 2026-06-05) and never given a consumer. `git log -S ".weak" -- src/` returns zero commits: it has been write-only since the day it was created. Its single read in the whole repo was one test assertion, which this PR updates.

It also conflated two structurally different returns:

| site | situation | old | new |
|---|---|---|---|
| `gates.js:221` | entity found, but only in the bootstrap snapshot | `weak: true` | `path: 'bootstrap_recitation'` |
| `gates.js:231` | no entity at all; any relevant this-turn success backed it | `weak: true` | `path: 'no_entity_fallback'` |
| `gates.js:204` | entity found in a real tool row | *(unmarked)* | `path: 'entity_match'` |

Anything keyed on the boolean would have moved **both** sites. That matters because the bootstrap site also carries `sourced: 'bootstrap'`, which **is** live, load-bearing state read by `gateState` (a recited characterisation is not a contradicted one). `sourced` is untouched here; `path` sits next to it.

## What changed

**`matchEvidence` returns `{ backed, path, entityFree, evidence?, sourced? }`.**

`entityFree` carries what `path` structurally cannot. Both unbacked returns have `path: null`, but they come from different places: one had an entity that matched nothing (line 223), the other had no entity and no relevant success (line 234). Callers could not tell them apart. That is exactly the discriminator the deferred no-entity work needs, so it is captured now rather than requiring a second pass. It is one field and one line to drop if you would rather not have it.

**Gates 1, 2 and 3 attach `observations`** — one entry per `matchEvidence` **call**, not per claim, because `gateState` calls it twice for a characterisation (`ran` then `ok`) and those two answers can differ. Gates 4 and 5 do not call `matchEvidence` and report none.

Observations are deliberately **not** in `claims`. That array drives `hedgeResponse`, which *deletes* the sentence from the reply, and `buildEscalation`. A backed claim landing there would silently strip a truthful sentence. There is a test pinning this.

**`onGateLog` now fires after every `runGates`, passes included.** Before, it ran only from the top of the failure loop, so two outcomes were never recorded anywhere:

1. a turn that passed first time, and
2. the post-hedge re-check.

That absence is precisely why fallback usage could not be counted retrospectively: a fallback-backed claim **passes**, so no gate fires, so nothing was written. The blind spot was structural, not a sampling gap. Control flow is unchanged; the callback stays best-effort with its return value ignored.

**`gate.log` gains `fired` / `check` / `backed` / `path` / `sourced` / `entity_free`.** Every pre-existing field keeps its exact meaning, so existing greps still work. New fields are `null`, not `false`, on rows with no such notion — a `!!` coercion would have reported every Gate 4 and Gate 5 row as `backed: false`, which is a claim those rows cannot support.

## Acceptance: zero behaviour change, demonstrated

**3475 replay cases, byte-identical before and after** (`sha256 b6d31cea…` both trees).

The corpus is **1655 real historical Charlie replies** pulled from the live `memory.db` (2026-02-23 to 2026-08-27), each paired with the **real `audit.db` tool rows from its own 10-minute window**, plus a 1820-case stress matrix over the most recent 260 replies forcing every path and branch: bootstrap corpus supplied, no events at all, a lone successful `shell_exec`, an `out_of_scope` pseudo-success, a dispatch + result pair, a strict registry (Gate 4 fires on everything), and supplied provenance + entityCorpus (Gate 5's alternate corpora).

Compared per case: `runGates` result and every gate's `fired` / `severity` / `action` / `reason` / `claims`, **plus** the user-visible `hedgeResponse`, `buildRepromptNote` and `buildEscalation` output. 1706 of 3475 cases are non-pass, so the failing paths are genuinely exercised. 0 throws.

Full suite green. `verification-gates.test.js` 231 → 261 checks. Every other test file byte-identical between the two trees. `tests/probes.test.js` `pm2_processes` fails identically on both trees (no `pm2` on the dev Mac) — pre-existing and environmental.

## The instrumentation is not vacuous

Replaying the same 1655 real turns through the new code:

- **673 turns** produce at least one observation
- **9 turns** passed on backed evidence and logged **nothing** before
- `no_entity_fallback` backed **37** real claims (18 `ran`, 18 `ok`, 1 `dispatch`); `entity_match` backed **2**
- unbacked completion checks split **488 entity-free / 139 entity-bearing** — the P2 discriminator, now recorded

Those counts come from reconstructed turn windows (`turnStart` approximated at T-120s), so treat them as indicative of shape, not as production truth. The point is that production will now record the real ones.

## gate.log content: decided, not left open

Raised as a reviewer question on the first commit, now settled in `8e66a1a`.

`gate.log` previously held claim text only for claims that FAILED. Observations fire on every gated turn including passes, so carrying their text would have widened the file to most of Charlie's real output, including replies quoting customer names, amounts and emails. `scrubSecrets` covers API keys and Telegram tokens, not PII.

**Observation rows now carry `claim: null`.** Firing rows are unchanged and still carry their text, so the content envelope is exactly where it was before this branch. Nothing analytic is lost: `gate` + `check` + `backed` + `path` + `entity_free` is the payload, and sentence-shape analysis belongs in the replay harness, which reads `memory.db` directly rather than persisting a second copy here.

The policy lives in `gateLogRows()` rather than in a comment inside the callback, so it is a unit-tested invariant. `registry.js` now just maps and appends.

## Adversarial review

Run against the branch, comparing to `origin/main` where behaviour is the claim. All clean:

| # | attack | result |
|---|---|---|
| A1 | observations reaching `hedgeResponse` would DELETE a truthful sentence | `hedgeResponse` output identical; soft claims drawn only from `claims` |
| A2 | `observe()` throwing on malformed rows would synthesise a hard_fail | malformed rows do not throw out of `runGates` |
| A3 | a gate that throws must still fail closed | verdict unchanged; thrown gate emits its firing row and no observations |
| A4 | `gateState` recording an `ok` observation where that check never ran | `ok` recorded only past the `ran.backed` short-circuit |
| A5 | claim text leaking through some other field of the row | no field of any observation row contains the sentence; `claim` is explicitly `null` |
| A6 | `sourced` regressing (read at `gates.js:484`) | backing, `sourced`, and the `gateState` verdict all unchanged |
| A7 | `emit()` double-firing or skipping a `runGates` | exactly one emission per call in all three loop shapes; no object emitted twice |
| A8 | a throwing `onGateLog` changing the turn outcome | outcome and content identical |

Reproduce: `node /tmp/adv_review_96.mjs`.

## Not in this PR

The behaviour change itself. No downgrade, no severity seam, no pseudo-success filter in `matchEvidence`. Those are deferred pending the path data this PR produces.

---

Ready for review. Suite green, `verification-gates` 231 -> 261 checks.
