### PR TITLE
fix(paths): redirect append-only logs away from the live store under test

### DIFF
--- a/src/agents/skill-loader.js
+++ b/src/agents/skill-loader.js
@@ -21,8 +21,8 @@
 import { readdirSync, readFileSync, existsSync, appendFileSync, chmodSync, statSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { join, dirname } from 'path';
-import { homedir } from 'os';
 import { log } from '../core/logger.js';
+import { resolveLogPath } from '../core/paths.js';
 import { routeKeywords } from './skill-router.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -31,7 +31,7 @@ const SKILLS_DIR = join(REPO_ROOT, 'src', 'agents', 'skills');
 
 // Tests override via QCLAW_SKILL_LOG_PATH so they don't pollute the real log.
 function _logPath() {
-  return process.env.QCLAW_SKILL_LOG_PATH || join(homedir(), '.quantumclaw', 'skill-load.log');
+  return resolveLogPath('QCLAW_SKILL_LOG_PATH', 'skill-load.log');
 }
 
 const HARD_CAP_ON_DEMAND = 4;

--- a/src/core/paths.js
+++ b/src/core/paths.js
@@ -12,23 +12,21 @@
  * memory.db, and the append-only logs. A test writing there corrupts the
  * evidence trail the gates depend on, and would look exactly like real traffic.
  *
- * This PR covers the STORES: qclaw.db and the bootstrap workspace. No current
- * test reaches either without a dir, so the hole here is latent rather than
- * active, and closing it is cheap insurance on the two files whose contents the
- * gates treat as evidence.
+ * The STORES half landed first (resolveStoreDir). This adds the LOGS, which is
+ * the half that was actually leaking: a full `npm test` on a machine with a real
+ * ~/.quantumclaw writes to the production skill-load.log and tool-call.log on
+ * every run. That is the same gap that put synthetic userIds (9999 / 8888 /
+ * 7777 / integration-test) into the production skill-load.log on 2026-08-27,
+ * interleaved with real Telegram traffic, because the per-log override is opt-in
+ * and only 1 of ~40 test files sets it.
  *
- * The append-only LOGS have the same defect and it is NOT latent: a full test
- * run writes to the production skill-load.log and tool-call.log today. That half
- * needs a different remedy (redirect, not throw, because those writers swallow
- * their own errors) and lands separately so isTestContext can be reviewed on its
- * own before anything depends on it more widely.
- *
- * The fix here is to make omission fail loudly under test instead of quietly
- * resolving to production. In production, behaviour is unchanged.
+ * Stores throw, logs redirect. The remedies differ because the failure modes do:
+ * see resolveLogPath.
  */
 
 import { join } from 'path';
-import { homedir } from 'os';
+import { homedir, tmpdir } from 'os';
+import { mkdtempSync } from 'fs';
 
 /** The production store directory, honouring an explicit QCLAW_HOME override. */
 export function qclawHome() {
@@ -80,4 +78,39 @@ export function resolveStoreDir(explicitDir, label = 'store') {
     );
   }
   return qclawHome();
+}
+
+// Lazily-created scratch dir, one per test process, shared by every log writer
+// that falls through to it. Created on first use so a production run never makes
+// a temp directory it will not use.
+let _scratch = null;
+export function testScratchDir() {
+  if (!_scratch) _scratch = mkdtempSync(join(tmpdir(), 'qclaw-test-logs-'));
+  return _scratch;
+}
+
+/**
+ * Resolve an append-only log path.
+ *
+ * Logs get a REDIRECT rather than the throw resolveStoreDir uses, because every
+ * one of these writers is best-effort and swallows its own errors. A throw there
+ * would be caught by the writer's own try/catch, the test would pass, and the
+ * only visible effect would be a log line that silently went missing. Redirecting
+ * to a per-process temp dir cannot break a caller and cannot reach production.
+ *
+ * This is the half that was actually leaking. `skill-load.log` and
+ * `tool-call.log` are written on ordinary agent code paths that ~40 test files
+ * exercise, while only ONE (skill-loader.test.js) sets the opt-in override. The
+ * 2026-08-27 run that put synthetic userIds into the production skill-load.log
+ * went through exactly this gap, and a full `npm test` on a dev machine with a
+ * real ~/.quantumclaw still reproduces it.
+ *
+ * @param {string} envVar    the existing per-log override (kept, still wins)
+ * @param {string} filename  e.g. 'gate.log'
+ */
+export function resolveLogPath(envVar, filename) {
+  const explicit = envVar ? process.env[envVar] : null;
+  if (explicit && String(explicit).trim()) return String(explicit);
+  if (isTestContext() && !process.env.QCLAW_HOME) return join(testScratchDir(), filename);
+  return join(qclawHome(), filename);
 }

--- a/src/observability/cache-usage-log.js
+++ b/src/observability/cache-usage-log.js
@@ -18,11 +18,10 @@
 
 import { existsSync, appendFileSync, chmodSync, statSync, renameSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 import { createHash } from 'crypto';
 import { log } from '../core/logger.js';
+import { resolveLogPath } from '../core/paths.js';
 
-const DEFAULT_PATH = join(homedir(), '.quantumclaw', 'cache-usage.log');
 const ROTATION_BYTES = 50 * 1024 * 1024; // 50 MB
 const MODE = 0o600;
 
@@ -54,7 +53,7 @@ export function __resetCacheUsageLogForTests() {
 }
 
 function _path() {
-  return process.env.QCLAW_CACHE_USAGE_LOG_PATH || DEFAULT_PATH;
+  return resolveLogPath('QCLAW_CACHE_USAGE_LOG_PATH', 'cache-usage.log');
 }
 
 function _rotateIfNeeded(path) {

--- a/src/observability/channel-events.js
+++ b/src/observability/channel-events.js
@@ -12,13 +12,12 @@
 
 import { appendFileSync, chmodSync, existsSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
-import { homedir } from 'os';
 import { log } from '../core/logger.js';
+import { resolveLogPath } from '../core/paths.js';
 import { scrubSecrets } from './anthropic-spend-poller.js';
 
 function _path() {
-  return process.env.QCLAW_CHANNEL_EVENTS_LOG_PATH
-    || join(homedir(), '.quantumclaw', 'channel-events.log');
+  return resolveLogPath('QCLAW_CHANNEL_EVENTS_LOG_PATH', 'channel-events.log');
 }
 
 /** Append one JSONL channel event ({ts, event, ...}); string fields scrubbed. Best-effort. */

--- a/src/observability/gate-log.js
+++ b/src/observability/gate-log.js
@@ -14,17 +14,15 @@
  */
 
 import { existsSync, appendFileSync, chmodSync, statSync, renameSync } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
 import { log } from '../core/logger.js';
+import { resolveLogPath } from '../core/paths.js';
 import { scrubSecrets } from './anthropic-spend-poller.js';
 
-const DEFAULT_PATH = join(homedir(), '.quantumclaw', 'gate.log');
 const ROTATION_BYTES = 50 * 1024 * 1024;
 const MODE = 0o600;
 
 function _path() {
-  return process.env.QCLAW_GATE_LOG_PATH || DEFAULT_PATH;
+  return resolveLogPath('QCLAW_GATE_LOG_PATH', 'gate.log');
 }
 
 function _rotateIfNeeded(path) {

--- a/src/observability/spend-alerter.js
+++ b/src/observability/spend-alerter.js
@@ -33,15 +33,15 @@
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync, chmodSync, statSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 import { readEnvFile } from '../core/env.js';
+import { resolveLogPath } from '../core/paths.js';
 
 const OWNER_TELEGRAM_CHAT_ID = 1375806243; // mirrors src/tools/executor.js
 const DEFAULTS = { soft_24h_usd: 5, hard_1h_usd: 3, cooldown_minutes: 60 };
 const MODE = 0o600;
 
-function thresholdsPath() { return process.env.QCLAW_SPEND_THRESHOLDS_PATH || join(homedir(), '.quantumclaw', 'spend-thresholds.json'); }
-function statePath() { return process.env.QCLAW_SPEND_ALERT_STATE_PATH || join(homedir(), '.quantumclaw', 'spend-alert-state.log'); }
+function thresholdsPath() { return resolveLogPath('QCLAW_SPEND_THRESHOLDS_PATH', 'spend-thresholds.json'); }
+function statePath() { return resolveLogPath('QCLAW_SPEND_ALERT_STATE_PATH', 'spend-alert-state.log'); }
 function healthPath() { return statePath() + '.health'; }
 
 /** Load thresholds, falling back to baked defaults on missing/malformed file. */

--- a/src/tools/registry.js
+++ b/src/tools/registry.js
@@ -16,9 +16,9 @@
 
 import { MCPClient } from './mcp-client.js';
 import { log } from '../core/logger.js';
+import { resolveLogPath } from '../core/paths.js';
 import { appendFileSync, chmodSync, existsSync, mkdirSync, statSync } from 'fs';
 import { dirname, join } from 'path';
-import { homedir } from 'os';
 
 /**
  * Per-preset scope map. Domain tools (stripe, ghl) scope to the build/
@@ -37,8 +37,7 @@ const PRESET_SCOPE_MAP = {
  * alongside audit.db in ~/.quantumclaw/.
  */
 function _toolCallLogPath() {
-  return process.env.QCLAW_TOOL_CALL_LOG_PATH
-    || join(homedir(), '.quantumclaw', 'tool-call.log');
+  return resolveLogPath('QCLAW_TOOL_CALL_LOG_PATH', 'tool-call.log');
 }
 
 /**

--- a/tests/store-isolation.test.js
+++ b/tests/store-isolation.test.js
@@ -3,20 +3,26 @@
  *
  * Run: node tests/store-isolation.test.js
  *
- * Covers src/core/paths.js and the two store call sites that previously defaulted
- * straight into the live ~/.quantumclaw store when a caller omitted the path:
- * getDb() (src/core/database.js) and bootstrap's identity + log directory
- * resolution (src/agents/bootstrap.js).
+ * Covers src/core/paths.js and every call site that previously defaulted straight
+ * into the live ~/.quantumclaw evidence store when a caller omitted the path:
+ * getDb() (src/core/database.js), bootstrap's identity + log resolution
+ * (src/agents/bootstrap.js), and the six append-only log writers.
  *
- * The contract is asymmetric on purpose: production (explicit path, or no test
- * context) behaves exactly as before, and only a test that omits the path sees
- * new behaviour. A store is opened once and read back, so failing loudly is
- * right and a test fixes it by passing a dir.
+ * The contract is asymmetric on purpose, in two directions.
+ *
+ * By context: production (explicit path, or no test context) behaves exactly as
+ * before. Only a test that omits the path sees new behaviour.
+ *
+ * By kind: STORES throw, LOGS redirect. A store is opened once and read back, so
+ * failing loudly is right and a test can fix it by passing a dir. A log writer
+ * swallows its own errors by design, so a throw there would be caught inside the
+ * writer, the test would still pass, and the only symptom would be a silently
+ * missing line. Redirecting cannot break a caller and cannot reach production.
  */
 
-import { qclawHome, isTestContext, resolveStoreDir } from '../src/core/paths.js';
+import { qclawHome, isTestContext, resolveStoreDir, resolveLogPath, testScratchDir } from '../src/core/paths.js';
 import { getDb } from '../src/core/database.js';
-import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { mkdtempSync, rmSync, existsSync, statSync } from 'fs';
 import { tmpdir, homedir } from 'os';
 import { join } from 'path';
 
@@ -54,6 +60,7 @@ delete process.env.QCLAW_HOME;
 
 console.log('resolveStoreDir:');
 const tmp = mkdtempSync(join(tmpdir(), 'qclaw-store-'));
+const tmp2 = mkdtempSync(join(tmpdir(), 'qclaw-store2-'));
 check('an explicit dir always wins', resolveStoreDir(tmp, 'x') === tmp);
 const e = threw(() => resolveStoreDir(null, 'audit.db'));
 check('omitting the dir under test THROWS instead of using the live store', e !== null);
@@ -89,7 +96,47 @@ check('bootstrap.log resolution refuses an omitted dir under test', bootErr !== 
 // The guard must not have broken the isolated path the existing tests use.
 check('an explicit tmpdir still resolves for bootstrap.log', resolveStoreDir(tmp, 'bootstrap.log') === tmp);
 
+console.log('log writers (redirect, not throw):');
+// Logs redirect rather than throw. Every one of these writers swallows its own
+// errors, so a throw would be caught inside the writer, the test would pass, and
+// the only symptom would be a silently missing log line.
+delete process.env.QCLAW_HOME;
+delete process.env.QCLAW_SKILL_LOG_PATH;
+const skillPath = resolveLogPath('QCLAW_SKILL_LOG_PATH', 'skill-load.log');
+check('skill-load.log redirects to a temp dir under test, never the live store',
+  skillPath !== join(LIVE, 'skill-load.log') && skillPath.endsWith('skill-load.log'));
+check('the redirect target is inside the per-process scratch dir',
+  skillPath.startsWith(testScratchDir()));
+check('every log writer shares one scratch dir per process',
+  resolveLogPath('QCLAW_TOOL_CALL_LOG_PATH', 'tool-call.log').startsWith(testScratchDir())
+  && resolveLogPath('QCLAW_GATE_LOG_PATH', 'gate.log').startsWith(testScratchDir()));
+process.env.QCLAW_SKILL_LOG_PATH = join(tmp2, 'explicit.log');
+check('an explicit per-log override still wins (existing opt-in unchanged)',
+  resolveLogPath('QCLAW_SKILL_LOG_PATH', 'skill-load.log') === join(tmp2, 'explicit.log'));
+delete process.env.QCLAW_SKILL_LOG_PATH;
+process.env.QCLAW_TEST = '0';
+check('outside test context logs resolve to the live store, unchanged',
+  resolveLogPath('QCLAW_GATE_LOG_PATH', 'gate.log') === join(LIVE, 'gate.log'));
+delete process.env.QCLAW_TEST;
+process.env.QCLAW_HOME = tmp2;
+check('QCLAW_HOME redirects logs wholesale',
+  resolveLogPath('QCLAW_GATE_LOG_PATH', 'gate.log') === join(tmp2, 'gate.log'));
+delete process.env.QCLAW_HOME;
+
+// End-to-end: the writer that actually leaked on 2026-08-27.
+const { appendGateLog } = await import('../src/observability/gate-log.js');
+const liveGate = join(LIVE, 'gate.log');
+const liveBefore = existsSync(liveGate) ? statSync(liveGate).mtimeMs : null;
+appendGateLog({ gate: 'completion', claim: 'isolation probe', result: 'pass', attempt: 1 });
+const liveAfter = existsSync(liveGate) ? statSync(liveGate).mtimeMs : null;
+check('appendGateLog with no override does NOT touch the live gate.log',
+  liveBefore === liveAfter);
+check('appendGateLog wrote to the scratch dir instead',
+  existsSync(join(testScratchDir(), 'gate.log')));
+
 rmSync(tmp, { recursive: true, force: true });
+rmSync(tmp2, { recursive: true, force: true });
+rmSync(testScratchDir(), { recursive: true, force: true });
 restore();
 console.log(`\n${passed}/${passed + failed} checks passed`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
**Unit 2, second half. Stacked on #97** (base is `fix/test-store-isolation`, review that first).

#97 closed the **latent** hole in the stores. This closes the **active** one.

## It is leaking right now

A full `npm test` on a machine with a real `~/.quantumclaw` writes to the production logs on every run. A/B, same suite against both trees, listing files modified in `~/.quantumclaw` during the run:

```
origin/main               -> ~/.quantumclaw/skill-load.log
                             ~/.quantumclaw/tool-call.log
fix/test-log-isolation    -> (nothing)
```

That is the same gap that put synthetic userIds (`9999` / `8888` / `7777` / `integration-test`) into the production `skill-load.log` on 2026-08-27, interleaved with real Telegram traffic. The per-log env override already existed; only **1 of ~40** test files sets it.

## Why logs redirect instead of throwing

The stores throw. Logs cannot, and the reason is specific rather than stylistic: **every one of these writers swallows its own errors by design** (`appendGateLog` wraps its whole body in `try/catch` and calls `log.debug` on failure, and the others follow the same pattern). A throw would be caught *inside the writer*, the test would still pass, and the only symptom would be a silently missing log line, which is strictly worse than what we have now.

`resolveLogPath` redirects to a lazily-created per-process temp dir instead. It cannot break a caller and cannot reach production.

## Coverage

`skill-load.log`, `tool-call.log`, `gate.log`, `channel-events.log`, `cache-usage.log`, and the two spend-alerter paths.

Every existing per-log override still wins and takes precedence over the redirect, so `skill-loader.test.js` needs no change. Outside test context, resolution is identical to before. Now-unused `homedir` / `join` imports and the two `DEFAULT_PATH` constants are dropped.

## Verification

Full suite green; every existing test file byte-identical in result to `origin/main`. `store-isolation.test.js` 18 -> 26 checks, including an end-to-end assertion that `appendGateLog` with no override leaves the live `gate.log` mtime untouched and writes to the scratch dir instead.

---

Draft until #97 lands, since it carries `isTestContext()`.
