### PR TITLE
fix(monitor): find resolved markets so settled positions actually close

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -24702,3 +24702,193 @@ The ~21:10Z threshold in falsification condition 1 was therefore not comfortably
 in the past, it was exactly the current minute. Reasoning "it is the next day,
 so the deadline is long gone" would have converted a boundary reading into a
 confident wrong conclusion. Anchor to host time, not to the local date.
+
+---
+
+## 2026-09-02: trading disabled by owner decision; the phantom-open close path found and fixed on a branch
+
+Read-only investigation of position `e09b82fe` (the PR #94 acceptance test)
+turned up seven defects. One gate was closed immediately; the rest are scoped
+and sequenced. This entry records the halt, its reason, and build item 3.
+
+### Trading is DISABLED
+
+`trading_config.trading_enabled` set to `false` at 2026-09-02, verified by an
+independent re-read. `max_position_usdc` (10), `min_edge_threshold` (7) and
+`daily_loss_limit` (20) were deliberately left untouched.
+
+**Reason, per owner decision:** the entry logic is systematically wrong on short
+horizons, and the daily loss limit cannot see a loss that resolves to zero.
+Those two combine badly: the scanner was proposing 5 to 14 maximum-size
+candidates per scan, and the one loss it produced never closed, so it never
+entered the daily-loss sum that Gate 3 reads.
+
+**Trading stays disabled until build items 3, 1 and 2 are all merged and
+verified.** That is an owner decision, not an engineering recommendation, and it
+does not lapse when item 3 lands.
+
+Enforcement is Gate 1 at `QClaw src/trade_engine/executor.py:227`, which
+re-reads `trading_config` live on every execution attempt. No cache, no restart
+needed. Gate 1 runs AFTER the approval step (`scanner.py` calls
+`apply_approval` then `apply_execution`, confirmed from the 2026-08-31 log where
+`Trade APPROVED` at 15:24:38 precedes the `trading_config` read at 15:24:39), so
+Telegram proposals continue to arrive and are refused after approval. Moving
+that read earlier is build item 5.
+
+### What PR #94 settled
+
+Verified, thread closed. Position `e09b82fe` tx
+`0xf6bee8991d7219ff761442393613b3a3095ec11ad165c5edc326d0851e2a942b` resolves to
+a successful Polygon receipt at block 92989904. Decoded: two ERC1155 transfers
+to the funder totalling 659.388887 shares, collateral out 9.999999, fee
+0.689380 to `0x115f48dc2a731aa16251c6d6e1befc42f92accc9`, total debit
+10.689379. The row holds `shares 659.39` and `usdc_amount 10.69`. The executor
+logged it at the time:
+
+```
+2026-08-31 15:24:42,661 INFO  trade_engine.executor: recording real cash out 10.689379 USDC (notional 9.999999)
+```
+
+`usdc_amount` is fee-inclusive and reconciles to the receipt to the cent.
+
+### The phantom-open: why a resolved position stayed open for four days
+
+The market resolved at `closedTime 2026-08-31 16:54:31+00`. On-chain payout
+vector read at `latest` on 2026-09-02: `payoutDenominator = 1`,
+`payoutNumerators = [0, 1]`, so YES pays nothing. The funder wallet still holds
+659.388887 of the losing token, so no redemption transaction exists and none
+will: redeeming a losing outcome pays zero, and Polymarket's UI "Loss" row is a
+resolution display, not a transaction.
+
+The monitor was not waiting for a fill. It has a resolution branch that would
+have closed this correctly. It never reached it, because the fetch that feeds
+that branch returned `None`. Probed live against Gamma on 2026-09-02:
+
+```
+market    query                                          rows
+live      condition_ids=0xa467b14d51…                       1
+live      condition_ids=0xa467b14d51…&closed=true           0
+resolved  condition_ids=0x535f3249cc…                       0
+resolved  condition_ids=0x535f3249cc…&closed=true           1
+```
+
+`closed` is a strict two-valued filter with no "either" value, and omitting it
+behaves exactly like `closed=false`. `_fetch_market` used the bare listing, so a
+market became invisible the moment it settled.
+
+189 occurrences in `/root/.pm2/logs/trade-engine-error.log` on the qclaw host,
+first `2026-08-31 17:12:51`, last `2026-09-02 16:12:51`:
+
+```
+2026-09-02 16:12:51,205 WARNING  trade_engine.monitor: monitor: market not found on Gamma for 0x535f3249cc… (position e09b82fe-6674-4ba4-9717-5ea22e9d99aa) — skipped
+```
+
+**It reported healthy throughout.** `unpriceable` is not an error, so the sweep
+logged `checked=1 resolved=0 tp_sl=0 alerts=0 unpriceable=1 errors=0` and emitted
+a success heartbeat whose metadata is `{"positions_checked": 1}` and nothing
+else (`main.py:219`). Heartbeat rows for `trade-engine-monitor` since
+2026-08-28: 461 rows, all `success`, first 2026-08-28T21:06:28Z, last
+2026-09-02T16:12:51Z, no gaps. Supabase, the dashboard and the Dormancy Alerter
+were all green through four days of a dead close path. Surfacing those counters
+is build item 4.
+
+### A second defect was queued behind the first
+
+`resolved_flags` required `active is False and closed is True`. Gamma reports
+this settled market as `active: True, closed: True`. The conjunction was
+therefore False on a market that had genuinely resolved, and only the
+`current_price in (0.0, 1.0)` fallback would have closed it. A market resolving
+to a non-final price fell through both and stayed open indefinitely.
+
+### Build item 3, on branch `trade-engine-phantom-open-close-path`
+
+Unmerged as of this entry. `_fetch_market` now takes a `MarketRef` and tries
+three routes, best first:
+
+1. `GET /markets/<numeric id>`. The only state-agnostic route, verified
+   2026-09-02 against both the resolved market (3846614) and a live one
+   (559651). `raw_output.polymarket_market_id` carries the id and is present on
+   all 500 most recent `trading_simulations` rows.
+2. `GET /markets?condition_ids=…` for live markets.
+3. the same with `&closed=true` for resolved ones.
+
+Routes 2 and 3 cover simulation rows predating `polymarket_market_id` and mean a
+Gamma hiccup on route 1 degrades to the old behaviour rather than making every
+position unpriceable. `manual.py:102` already walked both listing states for its
+slug lookup; the pattern existed in this repo and had simply never been applied
+to the monitor. `resolved_flags` now keys on `closed` alone. A new `not_found`
+outcome tag separates "no route found it" from "found but could not price it",
+and both still total into `positions_unpriceable` so the existing counter keeps
+its meaning.
+
+Test suite `tests/test_monitor.py` 39 tests to 51, all passing at the branch
+head. The mock Gamma transport was rewritten to enforce the real routing and
+filter semantics rather than a more permissive fiction, since the bug was
+precisely a mismatch between assumed and real semantics.
+
+**Coverage proved by mutation, run 2026-09-02, not asserted:**
+
+- Reverting `_fetch_market` to the listing-only route fails 24 tests
+  (21 failures, 3 errors), including the whole pre-existing `TestResolution`
+  class, which the stricter mock converted into regression coverage.
+- Restoring the `active is False` conjunction fails exactly ONE test,
+  `test_active_true_closed_true_with_non_final_price_does_not_close`. Every
+  other resolution test survives it, because a market settling to 0.0/1.0 is
+  closed by the price fallback regardless. That asymmetry is recorded in the
+  test class docstring: it is the single test standing between the repo and a
+  future "simplification" back to the broken conjunction.
+
+`python3 -m unittest discover -s tests` reports 14 tests and 6 errors on this
+branch AND on `QClaw main at 5795c03`; `test_analyst`, `test_manual_position`
+and `test_relay_settlement` fail locally on `ModuleNotFoundError: No module
+named 'anthropic'`. Both are pre-existing and unrelated. CI runs pytest per file
+for exactly this reason (`.github/workflows/ci.yml:108`).
+
+### Position e09b82fe is deliberately NOT corrected
+
+It is the live acceptance test for this branch: on the first sweep after deploy
+it must close itself with `exit_price 0.0`, `exit_reason resolved_loss`,
+`exit_usdc 0.0`, `pnl -10.69`. Correcting the row by hand first would do
+manually what the fix exists to do automatically and would destroy the only
+end-to-end evidence available. `tests/test_monitor.py::TestPhantomOpenAcceptance`
+pins the same assertion in unit form.
+
+### Settlement provenance: a narrowed rule
+
+`tx_hash` present is not proof of settlement. Position `b3cecdef` carries
+`0xc0def89b…`, which returns null for both `eth_getTransactionByHash` and
+`eth_getTransactionReceipt` on three independent Polygon RPCs while the other
+hashes resolve on those same nodes. Its real transactions, recovered from the
+Polymarket data API and confirmed against receipts, are
+`0xa64e3b7fed0be710fd44e01b0153fa391c1e992bf9a65df216935cf45af67d84` (entry) and
+`0xfae10c8a6f26760d0c27614fecb89de15625239c7ec960dbf992b1334a23ef47` (exit). The
+row's money is correct to the cent, so the 2026-08-28 correction it records was
+substantively right; only the field that made it auditable was wrong.
+
+> `tx_hash` NULL is not a paper trade. `tx_hash` present is not proof of
+> settlement. A position is settlement-verified only when its hash resolves to a
+> successful Polygon receipt whose ERC1155 transfer to the funder matches
+> `shares` and whose collateral movement matches `usdc_amount`. Anything else is
+> unverified regardless of what the field contains.
+
+Four of five position rows have a hash that is wrong or missing. Nothing was
+written to `trading_positions`; the corrected values and the full hash map are
+scoped, not applied. A standing reconciler is queued.
+
+### Polymarket's fee, solved
+
+Eight receipts, buys and sells, prices from 1.5c to 90c, maximum residual 4e-6:
+
+```
+fee = 0.07 * p * (1 - p) * shares        equivalently   fee / notional = 0.07 * (1 - p)
+```
+
+A first pass at this under-counted the fee on matched trades, because on those
+the exchange contract pays the fee sink rather than the funder and the decoder
+keyed on the funder as sender. There is one fee mechanism, not two. Treat 0.07
+as a monitored hypothesis with a residual check, not a constant: it is an
+empirical fit to one wallet in one market family, not documentation.
+
+The consequence is that `usdc_amount` is predictable before an order is sent, so
+position sizing can bound the realised debit instead of the notional. That is
+build item 7, merged with the Kelly sizing decision as item 2.

--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -24839,10 +24839,32 @@ precisely a mismatch between assumed and real semantics.
   future "simplification" back to the broken conjunction.
 
 `python3 -m unittest discover -s tests` reports 14 tests and 6 errors on this
-branch AND on `QClaw main at 5795c03`; `test_analyst`, `test_manual_position`
-and `test_relay_settlement` fail locally on `ModuleNotFoundError: No module
-named 'anthropic'`. Both are pre-existing and unrelated. CI runs pytest per file
-for exactly this reason (`.github/workflows/ci.yml:108`).
+branch AND on `QClaw main at 5795c03`. Pre-existing and unrelated to this change.
+CI runs pytest per file for exactly this reason (`.github/workflows/ci.yml:108`).
+
+**CORRECTION, 2026-09-03, from the cold review of PR #103.** The paragraph above
+originally attributed those 6 errors to `ModuleNotFoundError: No module named
+'anthropic'` across three modules. The count was right and the conclusion
+(pre-existing, unrelated) was right, but the named modules and the cause were
+both wrong. Re-run verbatim:
+
+```
+ImportError: cannot import name 'ConfigDict' from 'pydantic' (unknown location)   x3
+ImportError: cannot import name 'ValidationError' from 'pydantic' (unknown location)
+ImportError: cannot import name 'Header' from 'fastapi' (unknown location)
+ImportError: cannot import name 'Request' from 'fastapi' (unknown location)
+```
+
+Six modules error, not three, and they include `test_monitor` itself, the very
+file this PR adds tests to. The cause is the already-tracked `tests/clipper`
+`sys.modules` stub-poisoning defect, not a missing `anthropic`.
+
+How the wrong cause got written down: `anthropic` is what you see running the
+modules INDIVIDUALLY, where the clipper stubs never load. That observation was
+carried across to the `discover` run without re-reading its output. It is the
+anchored-claims failure this log's own convention exists to prevent, in the
+entry that documents a verification-discipline fix, which is worth recording
+rather than quietly correcting.
 
 ### Position e09b82fe is deliberately NOT corrected
 

--- a/src/trade_engine/monitor.py
+++ b/src/trade_engine/monitor.py
@@ -8,9 +8,9 @@ APScheduler (Session 6) and on demand via /monitor/run.
 
 Rule order per position — first match wins:
 
-1. RESOLUTION (new, not in n8n). A market reporting active=false AND
-   closed=true, or whose direction-side price has finalised at exactly 1.0 or
-   0.0, is settled: close at the final price with exit_reason 'resolved_win' /
+1. RESOLUTION (new, not in n8n). A market reporting closed=true, or whose
+   direction-side price has finalised at exactly 1.0 or 0.0, is settled: close
+   at the final price with exit_reason 'resolved_win' /
    'resolved_loss'. The n8n TP/SL rules caught most settlements implicitly (a
    resolved-YES market trips take_profit at 1.0) but mislabelled the exit and
    missed one case entirely: a position entered at <= 0.20 that resolves
@@ -38,11 +38,21 @@ So a threshold crossing now FLAGS, it does not close:
   * trading_positions is NOT touched. status stays 'open', and pnl stays NULL
     until a real close is logged via POST /positions/manual-close.
 
-RESOLUTION IS DIFFERENT AND IS UNCHANGED. A settled market (active=false and
-closed=true, or a finalised 1.0/0.0 price) really has closed and really does pay
-out, so _close() still writes status='closed' for resolved_win / resolved_loss.
+RESOLUTION IS DIFFERENT AND IS UNCHANGED. A settled market (closed=true, or a
+finalised 1.0/0.0 price) really has closed and really does pay out, so
+_close() still writes status='closed' for resolved_win / resolved_loss.
 Do not route those through the alert path: they are real closes, not requests
 for a human to act.
+
+FINDING A RESOLVED MARKET (2026-09-02: read _fetch_market before changing it)
+------------------------------------------------------------------------------
+Gamma drops closed markets from the default /markets listing, so the
+conditionId query this monitor used could not see a market once it settled.
+Position e09b82fe stayed 'open' for four days after resolving worthless while
+the sweep scored it 'unpriceable' 189 times and reported a healthy run. The
+close path above was never reached, because the fetch that feeds it returned
+None. _fetch_market now prefers the numeric-id path form, which is the only
+state-agnostic route, and falls back to the listing in both of its states.
 
 Prices are DIRECTION-SIDE throughout, matching the n8n `priceFor(conditionId,
 direction)` helper: for a NO position, currentPrice is outcomePrices[1] and a
@@ -70,7 +80,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 import httpx
 
@@ -104,6 +114,33 @@ WEAKENING_MIN_ENTRY = 0.50
 # Populated after each sweep so /health can report monitor freshness.
 # resolved_total is a process-lifetime running count of settlement closes.
 _last_monitor: dict[str, Any] = {"at": None, "resolved_total": 0}
+
+
+class MarketRef(NamedTuple):
+    """The identifiers needed to price one position's market.
+
+    Both ids are carried, not just the conditionId. The numeric Gamma id is
+    the only one that resolves a market whose state we do not already know
+    (see _fetch_market), and trading_positions itself carries neither: its
+    market_id column is a uuid FK to the empty trading_markets table and
+    stays NULL, so the simulation row is the only route back to a market.
+    """
+
+    condition_id: Optional[str]
+    market_id: Optional[str]
+    question: Optional[str]
+
+    @property
+    def usable(self) -> bool:
+        """True when at least one identifier can address a Gamma market."""
+        return bool(self.condition_id or self.market_id)
+
+    @property
+    def label(self) -> str:
+        """Short, log-safe identifier. Prefers whichever id will be tried."""
+        if self.market_id:
+            return f"market_id={self.market_id}"
+        return f"{(self.condition_id or '?')[:12]}…"
 
 
 def last_monitor_state() -> dict[str, Any]:
@@ -173,7 +210,7 @@ class PositionMonitor:
 
         counts = {
             "resolved": 0, "tp_sl": 0, "alert": 0, "unpriceable": 0, "error": 0,
-            "alert_dup": 0, "held": 0,
+            "alert_dup": 0, "held": 0, "not_found": 0,
         }
         for position in positions:
             try:
@@ -189,7 +226,10 @@ class PositionMonitor:
             positions_checked=len(positions),
             positions_resolved=counts["resolved"],
             positions_tp_sl=counts["alert"],
-            positions_unpriceable=counts["unpriceable"],
+            # not_found totals in here so this counter keeps its old meaning:
+            # every position the sweep could not act on. The tags stay separate
+            # because only not_found can conceal a settled position.
+            positions_unpriceable=counts["unpriceable"] + counts["not_found"],
             # alerts_sent counts NEW alerts only: a deduped crossing sends no
             # Telegram message, so counting it here would misreport notification
             # volume and hide whether the anti-spam path is working.
@@ -211,7 +251,14 @@ class PositionMonitor:
 
     async def _check_one(self, position: TradePosition) -> str:
         """Evaluate one position. Returns an outcome tag for the sweep counts:
-        'resolved' | 'tp_sl' | 'alert' | 'unpriceable' | 'error' | 'open'."""
+        'resolved' | 'tp_sl' | 'alert' | 'unpriceable' | 'not_found' | 'error'
+        | 'held' | 'open'.
+
+        'not_found' is a distinct tag, not a flavour of 'unpriceable': a market
+        no route can find is a different failure from one we found and could
+        not price, and only the first can hide a settled position. Both still
+        total into positions_unpriceable so the existing counter is unchanged.
+        """
         if not position.simulation_id:
             # M3 gap: pre-Session-6 positions opened without a persisted
             # simulation row. There is no route back to a market — skip.
@@ -221,44 +268,53 @@ class PositionMonitor:
             )
             return "unpriceable"
 
-        condition_id, question = await self._resolve_condition_id(position.simulation_id)
-        if not condition_id:
+        ref = await self._resolve_market_ref(position.simulation_id)
+        if not ref.usable:
             log.warning(
-                "monitor: position %s: simulation %s carries no condition_id — skipped",
-                position.id, position.simulation_id,
+                "monitor: position %s: simulation %s carries no market "
+                "identifier, skipped", position.id, position.simulation_id,
             )
             return "unpriceable"
 
-        market = await self._fetch_market(condition_id)
+        market = await self._fetch_market(ref)
         if market is None:
             log.warning(
-                "monitor: market not found on Gamma for %s… (position %s) — skipped",
-                condition_id[:12], position.id,
+                "monitor: market not found on Gamma for %s (position %s), skipped",
+                ref.label, position.id,
             )
-            return "unpriceable"
+            return "not_found"
 
         yes_price, no_price = self._outcome_prices(market)
         if yes_price is None or no_price is None:
             log.warning(
-                "monitor: no price available for %s… (position %s) — skipped",
-                condition_id[:12], position.id,
+                "monitor: no price available for %s (position %s), skipped",
+                ref.label, position.id,
             )
             return "unpriceable"
 
         direction = (position.direction or "").upper()
         current_price = yes_price if direction == "YES" else no_price
-        question = question or f"{condition_id[:10]}…"
+        question = ref.question or ref.label
 
         # 1. RESOLUTION — settled markets close at the final price.
-        resolved_flags = market.get("active") is False and market.get("closed") is True
+        #
+        # Keyed on `closed` ALONE. This test also required `active is False`
+        # until 2026-09-02, and Gamma reports a settled market like this:
+        #     active: True, closed: True, outcomePrices: ["0", "1"]
+        # (condition 0x535f3249cc…, read 2026-09-02, closedTime 16:54:31Z).
+        # The conjunction was therefore False on a market that had genuinely
+        # resolved, and only the 0.0/1.0 price fallback below closed it. A
+        # market resolving to a non-final price fell through both and stayed
+        # open. `closed` is the field that actually means settled.
+        resolved_flags = market.get("closed") is True
         if resolved_flags or current_price in (0.0, 1.0):
             if current_price not in (0.0, 1.0):
-                # active=false/closed=true but outcomePrices not finalised
+                # closed=true but outcomePrices not finalised
                 # (e.g. voided or still settling): there is no defensible
                 # win/loss to write, so wait for the next sweep.
                 log.warning(
-                    "monitor: %s… reports closed but price %.4f is not final "
-                    "(position %s) — skipped", condition_id[:12], current_price,
+                    "monitor: %s reports closed but price %.4f is not final "
+                    "(position %s), skipped", ref.label, current_price,
                     position.id,
                 )
                 return "unpriceable"
@@ -637,49 +693,117 @@ class PositionMonitor:
 
     # --- lookups ----------------------------------------------------------
 
-    async def _resolve_condition_id(
-        self, simulation_id: str
-    ) -> tuple[Optional[str], Optional[str]]:
-        """simulation_id -> (conditionId, question) via trading_simulations.
+    async def _resolve_market_ref(self, simulation_id: str) -> MarketRef:
+        """simulation_id -> MarketRef via trading_simulations.
 
-        trading_positions stores no Polymarket identifier of its own
-        (market_id is a uuid FK to trading_markets and stays NULL), so the
-        simulation row is the only route back to a priceable market. Key
-        fallback order matches the n8n node: polymarket_condition_id first,
-        then condition_id.
+        Key fallback order for the conditionId matches the n8n node:
+        polymarket_condition_id first, then condition_id. The numeric Gamma id
+        at polymarket_market_id is new here and is what _fetch_market prefers;
+        it is present on all 500 most recent trading_simulations rows (checked
+        2026-09-02), and the conditionId routes remain for anything older.
         """
         rows = await get_simulations_by_ids([simulation_id])
         raw = (rows[0].get("raw_output") if rows else None) or {}
         condition_id = raw.get("polymarket_condition_id") or raw.get("condition_id")
+        market_id = raw.get("polymarket_market_id")
         question = raw.get("question")
-        return (
-            str(condition_id) if condition_id else None,
-            str(question) if question else None,
+        return MarketRef(
+            condition_id=str(condition_id) if condition_id else None,
+            market_id=str(market_id) if market_id else None,
+            question=str(question) if question else None,
         )
 
-    async def _fetch_market(self, condition_id: str) -> Optional[dict[str, Any]]:
-        """GET /markets?condition_ids=<id> — query param, NOT the path form:
-        the path form resolves Gamma's numeric ids and 404s for a conditionId."""
-        try:
-            response = await self._get_client().get(
-                GAMMA_MARKETS_URL, params={"condition_ids": condition_id}
+    async def _fetch_market(self, ref: MarketRef) -> Optional[dict[str, Any]]:
+        """Fetch the market for `ref`, live or already resolved.
+
+        Three routes, best first:
+
+          1. GET /markets/<numeric id>. The ONLY state-agnostic route.
+             Verified 2026-09-02 against both a resolved market (3846614) and
+             a live one (559651).
+          2. GET /markets?condition_ids=<id>. Live markets only.
+          3. GET /markets?condition_ids=<id>&closed=true. Resolved only.
+
+        Routes 2 and 3 are the fallback for simulation rows that predate
+        polymarket_market_id, and they also mean a Gamma hiccup on route 1
+        degrades to the old behaviour instead of making every position
+        unpriceable.
+
+        DO NOT collapse this to a single listing call, and in particular do
+        NOT "fix" the resolved case by appending closed=true to route 2.
+        Gamma's `closed` is a strict two-valued filter with no "either" value,
+        and OMITTING it behaves exactly like closed=false. Probed live
+        2026-09-02:
+
+            market    query                            rows
+            live      condition_ids=...                   1
+            live      condition_ids=...&closed=true       0   <- breaks TP/SL
+            resolved  condition_ids=...                   0   <- the bug
+            resolved  condition_ids=...&closed=true       1
+
+        Route 2 alone is what left position e09b82fe 'open' for four days
+        after it resolved worthless. manual.py:102 already walks both states
+        for its slug lookup; this restores the same discipline here.
+        """
+        if ref.market_id:
+            market = await self._gamma_get(
+                f"{GAMMA_MARKETS_URL}/{ref.market_id}", None, ref
             )
+            if market is not None:
+                return market
+            log.info(
+                "monitor: gamma id lookup missed for %s, falling back to the "
+                "conditionId listing", ref.label,
+            )
+
+        if not ref.condition_id:
+            return None
+
+        market = await self._gamma_get(
+            GAMMA_MARKETS_URL, {"condition_ids": ref.condition_id}, ref
+        )
+        if market is not None:
+            return market
+        return await self._gamma_get(
+            GAMMA_MARKETS_URL,
+            {"condition_ids": ref.condition_id, "closed": "true"},
+            ref,
+        )
+
+    async def _gamma_get(
+        self,
+        url: str,
+        params: Optional[dict[str, str]],
+        ref: MarketRef,
+    ) -> Optional[dict[str, Any]]:
+        """One Gamma request. Returns the market dict, or None for any miss.
+
+        Normalises both response shapes: the path form returns an object, the
+        listing form an array. An empty array is a miss, not an error, and a
+        404 from the path form is an ordinary miss too. Both fall through to
+        the next route rather than logging noise on every sweep.
+        """
+        try:
+            response = await self._get_client().get(url, params=params)
         except httpx.HTTPError as exc:
-            log.warning("monitor: gamma fetch failed for %s…: %s", condition_id[:12], exc)
+            log.warning("monitor: gamma fetch failed for %s: %s", ref.label, exc)
+            return None
+        if response.status_code == 404:
             return None
         if response.status_code >= 300:
             log.warning(
-                "monitor: gamma HTTP %s for %s…: %s",
-                response.status_code, condition_id[:12], response.text[:200],
+                "monitor: gamma HTTP %s for %s: %s",
+                response.status_code, ref.label, response.text[:200],
             )
             return None
         try:
             payload = response.json()
         except ValueError:
-            log.warning("monitor: gamma returned non-JSON for %s…", condition_id[:12])
+            log.warning("monitor: gamma returned non-JSON for %s", ref.label)
             return None
-        market = payload[0] if isinstance(payload, list) and payload else payload
-        return market if isinstance(market, dict) else None
+        if isinstance(payload, list):
+            payload = payload[0] if payload else None
+        return payload if isinstance(payload, dict) else None
 
     @staticmethod
     def _outcome_prices(

--- a/src/trade_engine/monitor.py
+++ b/src/trade_engine/monitor.py
@@ -309,9 +309,24 @@ class PositionMonitor:
         resolved_flags = market.get("closed") is True
         if resolved_flags or current_price in (0.0, 1.0):
             if current_price not in (0.0, 1.0):
-                # closed=true but outcomePrices not finalised
-                # (e.g. voided or still settling): there is no defensible
-                # win/loss to write, so wait for the next sweep.
+                # closed=true but the direction-side price is not 0.0 or 1.0.
+                #
+                # KNOWN GAP, do not read this as handled (cold review of PR
+                # #103, F1). Polymarket VOIDS a market by resolving it 50/50,
+                # and a void is a real settlement: it refunds 0.5 per share.
+                # Sampling 800 recently-closed markets on 2026-09-03 found 8
+                # sitting at closed=true, umaResolutionStatus=resolved,
+                # outcomePrices ["0.5","0.5"] (e.g. id 4049628, a cancelled
+                # cricket fixture). A position in one of those returns
+                # 'unpriceable' here on every sweep, forever, with errors=0.
+                # That is the same silent-success shape this PR exists to kill.
+                #
+                # It is left unfixed deliberately: closing at 0.5 is a real
+                # money-write and a behaviour change, so it belongs in its own
+                # reviewed change, not smuggled into the fetch fix. Until then
+                # this branch is correct only for markets that are still
+                # settling, where waiting IS right.
+
                 log.warning(
                     "monitor: %s reports closed but price %.4f is not final "
                     "(position %s), skipped", ref.label, current_price,

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -61,10 +61,16 @@ def make_position(**overrides) -> TradePosition:
     return TradePosition(**base)
 
 
-def sim_row(sim_id="sim-1", condition_id=CID, question=QUESTION) -> dict:
+MARKET_ID = "3846614"
+
+
+def sim_row(sim_id="sim-1", condition_id=CID, question=QUESTION,
+            market_id=None) -> dict:
     raw = {"question": question}
     if condition_id is not None:
         raw["polymarket_condition_id"] = condition_id
+    if market_id is not None:
+        raw["polymarket_market_id"] = market_id
     return {"id": sim_id, "asset": "eth", "raw_output": raw}
 
 
@@ -111,6 +117,7 @@ class MonitorTestCase(unittest.TestCase):
         self.resolve_calls = []     # (position_id, note)
 
         self.gamma_by_cid = {}      # condition_id -> list payload or Exception
+        self.gamma_by_id = {}       # numeric market id -> dict payload or Exception
         self.gamma_requests = []
         self.telegram_requests = []
         self.telegram_status = 200
@@ -189,19 +196,46 @@ class MonitorTestCase(unittest.TestCase):
                 return httpx.Response(tests.telegram_status, json={"ok": True})
             if request.url.host == "gamma-api.polymarket.com":
                 tests.gamma_requests.append(str(request.url))
-                cid = request.url.params.get("condition_ids")
-                payload = tests.gamma_by_cid.get(cid)
-                if isinstance(payload, Exception):
-                    raise payload
-                if payload is None:
-                    return httpx.Response(200, json=[])
-                return httpx.Response(200, json=payload)
+                return tests.gamma_response(request)
             raise AssertionError(f"unexpected host: {request.url.host}")
 
         self.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         self.monitor = PositionMonitor(
             client=self.client, token="test-token", chat_id="12345"
         )
+
+    def gamma_response(self, request: httpx.Request) -> httpx.Response:
+        """Emulate Gamma's real routing and filter semantics, not a friendlier
+        version of them. Probed live 2026-09-02:
+
+          * /markets/<numeric id> returns the market as an OBJECT regardless
+            of whether it is live or closed, and 404s for an unknown id.
+          * /markets?condition_ids=... returns an ARRAY and applies `closed`
+            as a strict two-valued filter. Omitting `closed` behaves exactly
+            like closed=false, so a resolved market is invisible without
+            closed=true.
+
+        The monitor's phantom-open bug was a mismatch between assumed and real
+        semantics, so a permissive mock here would let it back in unnoticed.
+        """
+        path = request.url.path
+        if path.startswith("/markets/"):
+            payload = self.gamma_by_id.get(path.rsplit("/", 1)[-1])
+            if isinstance(payload, Exception):
+                raise payload
+            if payload is None:
+                return httpx.Response(404, json={"error": "not found"})
+            return httpx.Response(200, json=payload)
+
+        payload = self.gamma_by_cid.get(request.url.params.get("condition_ids"))
+        if isinstance(payload, Exception):
+            raise payload
+        if not payload:
+            return httpx.Response(200, json=[])
+        wants_closed = request.url.params.get("closed") == "true"
+        if bool(payload[0].get("closed")) is not wants_closed:
+            return httpx.Response(200, json=[])
+        return httpx.Response(200, json=payload)
 
     def tearDown(self) -> None:
         for name, fn in self._orig.items():
@@ -277,6 +311,196 @@ class TestLookups(MonitorTestCase):
         result = self.sweep()
         self.assertEqual(result.positions_unpriceable, 1)
         self.assertEqual(self.update_calls, [])
+
+
+class TestMarketLookupRouting(MonitorTestCase):
+    """The phantom-open regression surface.
+
+    Position e09b82fe resolved worthless on 2026-08-31 and stayed 'open' for
+    four days because the conditionId listing cannot see a closed market and
+    _fetch_market had no other route. These tests pin every route and, just as
+    importantly, pin that the fix did not invert the bug onto live markets.
+    """
+
+    def test_path_form_preferred_and_is_the_only_call(self):
+        self.positions = [make_position()]
+        self.sim_rows["sim-1"] = sim_row(market_id=MARKET_ID)
+        self.gamma_by_id[MARKET_ID] = gamma_market(yes="0.55", no="0.45")[0]
+        self.gamma_by_cid[CID] = gamma_market(yes="0.55", no="0.45")
+        self.sweep()
+        self.assertEqual(len(self.gamma_requests), 1)
+        self.assertTrue(self.gamma_requests[0].endswith(f"/markets/{MARKET_ID}"))
+
+    def test_path_form_finds_a_resolved_market(self):
+        """The regression test. Path form is state-agnostic, so one call."""
+        self.positions = [make_position()]
+        self.sim_rows["sim-1"] = sim_row(market_id=MARKET_ID)
+        self.gamma_by_id[MARKET_ID] = gamma_market(
+            yes="0", no="1", active=True, closed=True
+        )[0]
+        result = self.sweep()
+        self.assertEqual(len(self.gamma_requests), 1)
+        self.assertEqual(result.positions_resolved, 1)
+        self.assertEqual(result.positions_unpriceable, 0)
+        self.assertEqual(self.update_calls[0][1]["exit_reason"], "resolved_loss")
+
+    def test_listing_fallback_finds_a_resolved_market(self):
+        """No market_id (older simulation rows): plain listing misses, the
+        closed=true retry finds it. Two calls, still closes."""
+        self.positions = [make_position()]
+        self.sim_rows["sim-1"] = sim_row()
+        self.gamma_by_cid[CID] = gamma_market(
+            yes="0", no="1", active=True, closed=True
+        )
+        result = self.sweep()
+        self.assertEqual(len(self.gamma_requests), 2)
+        self.assertNotIn("closed=true", self.gamma_requests[0])
+        self.assertIn("closed=true", self.gamma_requests[1])
+        self.assertEqual(result.positions_resolved, 1)
+
+    def test_live_market_still_found_by_the_plain_listing(self):
+        """Guards against inverting the bug. A live market must resolve on the
+        FIRST listing call, with no closed=true request at all: appending that
+        filter globally would make every open position unpriceable."""
+        self.positions = [make_position()]
+        self.sim_rows["sim-1"] = sim_row()
+        self.gamma_by_cid[CID] = gamma_market(yes="0.55", no="0.45")
+        result = self.sweep()
+        self.assertEqual(len(self.gamma_requests), 1)
+        self.assertNotIn("closed=true", self.gamma_requests[0])
+        self.assertEqual(result.positions_unpriceable, 0)
+        self.assertEqual(self.update_calls, [])
+
+    def test_path_form_404_falls_back_to_the_listing(self):
+        self.positions = [make_position()]
+        self.sim_rows["sim-1"] = sim_row(market_id=MARKET_ID)
+        # gamma_by_id left empty -> 404
+        self.gamma_by_cid[CID] = gamma_market(yes="0.55", no="0.45")
+        result = self.sweep()
+        self.assertEqual(len(self.gamma_requests), 2)
+        self.assertTrue(self.gamma_requests[0].endswith(f"/markets/{MARKET_ID}"))
+        self.assertIn(f"condition_ids={CID}", self.gamma_requests[1])
+        self.assertEqual(result.positions_unpriceable, 0)
+
+    def test_path_form_transport_error_falls_back_to_the_listing(self):
+        """A Gamma hiccup on the preferred route must degrade to the old
+        behaviour, not make every position unpriceable."""
+        self.positions = [make_position()]
+        self.sim_rows["sim-1"] = sim_row(market_id=MARKET_ID)
+        self.gamma_by_id[MARKET_ID] = httpx.ConnectError("boom")
+        self.gamma_by_cid[CID] = gamma_market(
+            yes="0", no="1", active=True, closed=True
+        )
+        result = self.sweep()
+        self.assertEqual(result.positions_resolved, 1)
+
+    def test_missing_from_every_route_counts_unpriceable(self):
+        self.positions = [make_position()]
+        self.sim_rows["sim-1"] = sim_row(market_id=MARKET_ID)
+        with self.assertLogs("trade_engine.monitor", level="WARNING") as logs:
+            result = self.sweep()
+        self.assertEqual(len(self.gamma_requests), 3)
+        self.assertEqual(result.positions_unpriceable, 1)
+        self.assertEqual(self.update_calls, [])
+        self.assertTrue(any("market not found" in line for line in logs.output))
+
+    def test_no_identifier_at_all_makes_no_request(self):
+        self.positions = [make_position()]
+        self.sim_rows["sim-1"] = sim_row(condition_id=None)
+        result = self.sweep()
+        self.assertEqual(self.gamma_requests, [])
+        self.assertEqual(result.positions_unpriceable, 1)
+
+
+class TestResolutionFlagSemantics(MonitorTestCase):
+    """`closed` alone means settled.
+
+    Gamma reports a resolved market as active=True, closed=True (condition
+    0x535f3249cc…, read 2026-09-02). The old `active is False and closed is
+    True` conjunction was therefore False on a genuinely settled market, and
+    only the 0.0/1.0 price fallback closed it.
+
+    COVERAGE NOTE, verified by mutation on 2026-09-02: restoring the old
+    conjunction fails exactly ONE test in this file,
+    test_active_true_closed_true_with_non_final_price_does_not_close. Every
+    other resolution test survives it, because a market settling to 0.0/1.0
+    is closed by the price fallback whether or not resolved_flags fired. So
+    that non-final-price test is the only thing standing between us and a
+    future "simplification" back to the broken conjunction. Do not delete it,
+    and do not trust a green suite here without it.
+    """
+
+    def test_active_true_closed_true_resolves(self):
+        """Pins the intended path. NOT a discriminator on its own: the price
+        fallback closes this case under the old conjunction too."""
+        self.positions = [make_position()]
+        self.sim_rows["sim-1"] = sim_row(market_id=MARKET_ID)
+        self.gamma_by_id[MARKET_ID] = gamma_market(
+            yes="0", no="1", active=True, closed=True
+        )[0]
+        result = self.sweep()
+        self.assertEqual(result.positions_resolved, 1)
+        self.assertEqual(self.update_calls[0][1]["exit_reason"], "resolved_loss")
+
+    def test_active_true_closed_true_with_non_final_price_does_not_close(self):
+        """Keying on `closed` alone must not license a close at a price that
+        has not settled. Voided or still-settling markets wait."""
+        self.positions = [make_position()]
+        self.sim_rows["sim-1"] = sim_row(market_id=MARKET_ID)
+        self.gamma_by_id[MARKET_ID] = gamma_market(
+            yes="0.4", no="0.6", active=True, closed=True
+        )[0]
+        with self.assertLogs("trade_engine.monitor", level="WARNING") as logs:
+            result = self.sweep()
+        self.assertEqual(result.positions_resolved, 0)
+        self.assertEqual(result.positions_unpriceable, 1)
+        self.assertEqual(self.update_calls, [])
+        self.assertTrue(any("not final" in line for line in logs.output))
+
+    def test_open_market_is_not_treated_as_resolved(self):
+        self.positions = [make_position()]
+        self.sim_rows["sim-1"] = sim_row(market_id=MARKET_ID)
+        self.gamma_by_id[MARKET_ID] = gamma_market(
+            yes="0.55", no="0.45", active=True, closed=False
+        )[0]
+        result = self.sweep()
+        self.assertEqual(result.positions_resolved, 0)
+        self.assertEqual(self.update_calls, [])
+
+
+class TestPhantomOpenAcceptance(MonitorTestCase):
+    """End-to-end reproduction of the live position this fix exists for."""
+
+    def test_e09b82fe_closes_with_the_expected_row(self):
+        self.positions = [make_position(
+            id="e09b82fe-6674-4ba4-9717-5ea22e9d99aa",
+            direction="YES",
+            entry_price=0.0152,
+            shares=659.39,
+            usdc_amount=10.69,
+        )]
+        self.sim_rows["sim-1"] = sim_row(
+            market_id=MARKET_ID,
+            question="Will the price of Ethereum be above $2,500 on August 31?",
+        )
+        # Exactly what Gamma serves for condition 0x535f3249cc… since
+        # closedTime 2026-08-31T16:54:31Z.
+        self.gamma_by_id[MARKET_ID] = gamma_market(
+            yes="0", no="1", active=True, closed=True
+        )[0]
+
+        result = self.sweep()
+
+        self.assertEqual(result.positions_resolved, 1)
+        self.assertEqual(result.positions_unpriceable, 0)
+        self.assertEqual(len(self.update_calls), 1)
+        position_id, updates = self.update_calls[0]
+        self.assertEqual(position_id, "e09b82fe-6674-4ba4-9717-5ea22e9d99aa")
+        self.assertEqual(updates["status"], "closed")
+        self.assertEqual(updates["exit_price"], 0.0)
+        self.assertEqual(updates["exit_reason"], "resolved_loss")
+        self.assertEqual(updates["exit_usdc"], 0.0)
+        self.assertEqual(updates["pnl"], -10.69)
 
 
 class TestUnresolved(MonitorTestCase):


### PR DESCRIPTION
Build item 3 of the trade-engine remediation. Scope: https://claude.ai/code/artifact/792ca69e-31d9-433f-a967-a33d5e0a9371

**Draft pending cold adversarial review** in a fresh session against this branch, per the agreed sequence. Do not un-draft before that.

## The defect

Position `e09b82fe` resolved worthless at `closedTime 2026-08-31 16:54:31+00` and was still `status = open` four days later. The monitor was not waiting for a fill: it has a resolution branch that would have closed it correctly. It never reached that branch, because the fetch feeding it returned `None`.

Gamma drops closed markets from the default `/markets` listing. 189 skips in `/root/.pm2/logs/trade-engine-error.log` on qclaw, first `2026-08-31 17:12:51`, last `2026-09-02 16:12:51`:

```
2026-09-02 16:12:51,205 WARNING  trade_engine.monitor: monitor: market not found on Gamma for 0x535f3249cc… (position e09b82fe-6674-4ba4-9717-5ea22e9d99aa) — skipped
```

Every one of those sweeps reported `unpriceable=1 errors=0` and emitted a success heartbeat.

## Why the obvious fix is wrong

`closed` is a strict two-valued filter with no "either" value, and omitting it behaves exactly like `closed=false`. Probed live 2026-09-02:

| market | query | rows |
|---|---|---|
| live | `condition_ids=…` | 1 |
| live | `condition_ids=…&closed=true` | **0** |
| resolved | `condition_ids=…` | **0** |
| resolved | `condition_ids=…&closed=true` | 1 |

Appending `closed=true` would make every live position unpriceable and kill TP/SL. That is worse than the current state, and it is the change a reader of the bug report would most naturally make.

## The change

`_fetch_market` takes a `MarketRef` and tries three routes:

1. `GET /markets/<numeric id>` — the only state-agnostic route. Verified against resolved market 3846614 and live market 559651. `raw_output.polymarket_market_id` is present on all 500 most recent `trading_simulations` rows.
2. `GET /markets?condition_ids=…` for live markets.
3. the same with `&closed=true` for resolved ones.

Routes 2 and 3 cover older simulation rows and mean a Gamma hiccup on route 1 degrades to the old behaviour rather than blinding the monitor. `manual.py:102` already walked both listing states for its slug lookup; this restores the same discipline here.

**Second defect, fixed with it.** `resolved_flags` required `active is False and closed is True`, and Gamma reports a settled market as `active: True, closed: True`. The conjunction was False on a genuinely resolved market, so only the `current_price in (0.0, 1.0)` fallback closed it.

> **Scope correction at `d05d90c`.** This paragraph originally ended "and anything resolving to a non-final price stayed open indefinitely", which reads as though that half is fixed. **It is not.** Voided markets settle at `["0.5","0.5"]` and still return `unpriceable` on every sweep, forever. Closing at 0.5 is a real money-write and belongs in its own reviewed change, so it is filed as #107 rather than added here. The cold review (F1/F2) found it and the code comment now states it.

New `not_found` outcome tag separates "no route found it" from "found but could not price it". Both still total into `positions_unpriceable`, so that counter is unchanged; surfacing the split is build item 4.

## Tests

39 to 51, all passing. The mock Gamma transport was rewritten to enforce the real routing and filter semantics rather than a more permissive fiction, since the bug was exactly a mismatch between assumed and real semantics. That change alone converts the pre-existing `TestResolution` class into regression coverage.

**Coverage proved by mutation on 2026-09-02, not asserted:**

- Reverting `_fetch_market` to listing-only fails **24 tests** (21 failures, 3 errors).
- Restoring the `active is False` conjunction fails **exactly one**: `test_active_true_closed_true_with_non_final_price_does_not_close`. Every other resolution test survives it, because a market settling to 0.0/1.0 is closed by the price fallback regardless. That single test is all that stands between the repo and a future "simplification" back to the broken conjunction, and the asymmetry is recorded in the test class docstring.

Pre-existing and unrelated: `python3 -m unittest discover -s tests` reports 14 tests / 6 errors on this branch **and** on `QClaw main at 5795c03`. CI runs pytest per file for that reason (`.github/workflows/ci.yml:108`).

> **Corrected at `d05d90c`.** This paragraph originally named three modules failing on `ModuleNotFoundError: No module named 'anthropic'`. The count and the conclusion were right; the modules and the cause were wrong. Six modules error, including `test_monitor` itself, and the cause is the tracked `tests/clipper` stub-poisoning defect (`cannot import name 'ConfigDict' from 'pydantic'` and friends). `anthropic` is what you see running modules individually. Caught by the cold review (F6).

## Acceptance test, and why the row must not be touched

Position `e09b82fe` is deliberately left uncorrected. On the first sweep after this deploys it must close itself:

```
exit_price   0.0
exit_reason  resolved_loss
exit_usdc    0.0
pnl          -10.69
```

Correcting it by hand first would do manually what this fix exists to do automatically, and would destroy the only end-to-end evidence available. `tests/test_monitor.py::TestPhantomOpenAcceptance` pins the same assertion in unit form.

## Not in this PR

Trading is disabled (`trading_config.trading_enabled = false`, set 2026-09-02) and **stays disabled until build items 3, 1 and 2 are all merged and verified**, per owner decision. Merging this does not lift that.

Build items 4 (heartbeat counters), 5 (approval-timeout visibility), 1 (fractional horizon) and 7+2 (fee-aware Kelly sizing) are scoped in the linked document and are separate PRs.



---

## Cold adversarial review: complete, no blocker

Fresh session, `5e07a28`, read-only, `e09b82fe` untouched. **Recommendation: safe to un-draft and merge.**

Claims 1, 2, 3, 5, 6, 7, 8 CONFIRMED by execution against the live API. Claim 4 (`polymarket_market_id` coverage) was unverifiable in the sandbox with no Supabase creds; it was verified in the originating session (0 missing across the 500 most recent rows).

Three things the review established that this PR did not claim:

- **Claim 5 is understated.** Across **800 sampled closed markets**, `active` was `True` on **800/800** and `umaResolutionStatus` was `resolved` on 800/800. The old conjunction was essentially never satisfiable, so the resolution branch on `main` was dead code reachable only through the price fallback. That is a stronger argument for this change than the PR made.
- **The primary pricing route swap is safe.** The review diffed path-form against listing-form payloads for the same market: `outcomePrices`, `outcomes`, `active`, `closed`, `archived`, `lastTradePrice`, `bestAsk` are identical on both a resolved and a live market. Had `outcomePrices` differed in shape, this PR would have made every live position unpriceable.
- **No live-path regression, measured.** A differential harness ran `main`'s and the branch's real `_check_one` logic over **1,245 unique real Gamma payloads x 8 position scenarios = 9,960 evaluations**. **Zero divergence across all 488 open markets.** All 64 divergences were closed-market voids, which is #107.

Mutation claims reproduced exactly: listing-only → `FAILED (failures=21, errors=3)` = 24; restoring the conjunction → `FAILED (failures=1)` and it is the named test.

**Follow-ups filed, not merge gates:** #107 (voided markets stay phantom-open; also covers the alert-suppression widening), #108 (Gamma outage reports a healthy sweep; also `market_id` path validation and 422 log noise).