### PR TITLE
fix(trade-engine): price markets against the real horizon, not a rounded-up day

### DIFF
--- a/docs/trade-engine-horizon-rebaseline.md
+++ b/docs/trade-engine-horizon-rebaseline.md
@@ -11,7 +11,7 @@ Two things are separated here on purpose:
    days instead of `math.ceil`, and the simulator derives `dt = horizon/steps`
    instead of hardwiring `dt = 1.0`.
 2. **The step density** (NOT shipped). `STEPS_PER_DAY` stays at 1. Raising it
-   is an exposure decision and is tracked separately.
+   is an exposure decision and is tracked separately as issue #119.
 
 ## Method, and what it cannot tell you
 

--- a/docs/trade-engine-horizon-rebaseline.md
+++ b/docs/trade-engine-horizon-rebaseline.md
@@ -1,0 +1,139 @@
+# Fractional horizon re-baseline
+
+Companion to the fractional-horizon fix. Produced 2026-09-07, before that PR
+was marked ready, because changing how a market is discretised re-prices
+markets we have already traded and that is a sizing question, not a code
+review question.
+
+Two things are separated here on purpose:
+
+1. **The arithmetic fix** (shipped). `_horizon_days` returns exact fractional
+   days instead of `math.ceil`, and the simulator derives `dt = horizon/steps`
+   instead of hardwiring `dt = 1.0`.
+2. **The step density** (NOT shipped). `STEPS_PER_DAY` stays at 1. Raising it
+   is an exposure decision and is tracked separately.
+
+## Method, and what it cannot tell you
+
+Each historical simulation was rebuilt offline from the values persisted in
+`trading_simulations.raw_output`: `current_price`, `target`, `daily_mu`,
+`daily_sigma` and `market_type`. Nothing was re-fetched from yfinance, so these
+numbers are reproducible and do not drift with market data.
+
+400,000 paths per cell, seed 20260907. Production runs 10,000 paths, so live
+figures carry about +/-0.005 of Monte Carlo noise at p = 0.5.
+
+**Reproduction check.** The offline model matches what production actually
+returned, which is what makes the rest of this document evidence rather than
+opinion:
+
+| position | stored P | reproduced | delta |
+|---|---|---|---|
+| e09b82fe | 0.4834 | 0.4838 | +0.0004 |
+| cee4eacd | 0.9890 | 0.9870 | -0.0020 |
+| 71f8a608 | 0.5646 | 0.5593 | -0.0053 |
+| f4be9ee8 | 0.6283 | 0.6318 | +0.0035 |
+| b3cecdef | 0.7385 | 0.7328 | -0.0057 |
+
+All inside production's own 10,000-path noise.
+
+**Model validity.** The four touch_* figures below are NOT sound probability
+estimates and must not be read as edges we believe in. They are like-for-like
+re-prices under the model the code already uses, which is the only question a
+re-baseline asks. The model assumes GBM with constant volatility estimated from
+21 daily closes: no term structure, no volatility clustering, no fat tails, and
+a drift estimated from the same 21 points and therefore dominated by sampling
+noise. The barrier is checked on a simulated grid, while Polymarket resolves
+against a specific reference feed on a schedule that is neither that grid nor
+continuous. The continuous-limit column assumes exact continuous monitoring,
+which no real market has.
+
+The one exception is e09b82fe. It is a `close_above` market, so the terminal
+lognormal closed form is exact for it and the recomputed 6.5% is sound as far
+as the vol estimate goes.
+
+## The numbers
+
+Scan-time implied odds, 7-point edge floor.
+
+- **CURRENT**: `steps = ceil(T)`, `dt = 1.0`, so total simulated time is `ceil(T)` days
+- **P0**: fractional horizon, step density unchanged at 1/day (what shipped)
+- **P1**: fractional horizon, hourly grid (NOT shipped)
+- **limit**: continuous first-passage closed form, the steps to infinity ceiling
+
+| position | market | true horizon | ceil | CURRENT P / edge | P0 P / edge | P1 P / edge | limit |
+|---|---|---|---|---|---|---|---|
+| cee4eacd | XRP `touch_below` | 20.583 d | 21 | 0.9870 / +6.20 | 0.9863 / +6.13 | 0.9930 / +6.80 | 0.9942 / +6.92 |
+| 71f8a608 | BTC `touch_below` | 20.333 d | 21 | 0.5593 / +14.43 | 0.5459 / +13.09 | 0.5899 / +17.49 | 0.6023 / +18.73 |
+| f4be9ee8 | ETH `touch_above` | 11.416 d | 12 | 0.6318 / +35.28 | 0.6149 / +33.59 | 0.6725 / +39.35 | 0.6901 / +41.11 |
+| b3cecdef | SOL `touch_above` | 4.666 d | 5 | 0.7328 / +33.68 | 0.7062 / +31.02 | 0.7704 / +37.44 | 0.7913 / +39.53 |
+| e09b82fe | ETH `close_above` | 0.0412 d | 1 | 0.4838 / +45.83 | 0.0648 / +3.93 | 0.0648 / +3.93 | n/a |
+
+Edges are percentage points.
+
+`close_*` markets are step-invariant: summing n increments of
+`N(nu*dt, sigma^2*dt)` gives `N(nu*T, sigma^2*T)` for any n. Measured at
+e09b82fe's parameters, P moves 0.0648 -> 0.0651 across steps 1 to 128, which is
+noise. The same parameters priced as `touch_above` move 0.0648 -> 0.1148 over
+the same range. That is the whole issue in one comparison.
+
+## Two effects, opposite signs
+
+**Correcting the horizon (P0) lowers touch probabilities by 0.7 to 2.7 points.**
+Safe direction, pure arithmetic, no judgement involved.
+
+**Refining the grid (P1) raises them by 0.7 to 6.4 points over P0**, netting
++0.6 to +4.1 points above today. A discrete path only observes the barrier at
+step boundaries, so it undercounts crossings and undercounts more at coarser
+grids.
+
+## Which historical trades change
+
+**Under P0, exactly one.**
+
+- **e09b82fe would not have fired.** +45.83 points today, +3.93 recomputed,
+  against a 7-point floor. This is the $10.69 loss.
+- The other four keep their verdicts. One resize: 71f8a608 $9.50 -> $8.33.
+- Nothing that did not fire begins to.
+
+**Under P1, no historical verdict flips either, and that understates the risk.**
+
+`_amount_usdc` saturates at $10 above 15 points, so P1 barely resizes trades we
+already took. Its real effect is recruitment at the margin:
+
+- cee4eacd moves 6.13 -> 6.80 points, stopping **0.2 points short** of the floor.
+- The measured lift is up to +6.4 points against a 7-point floor, so any touch
+  market currently sitting anywhere in the 1 to 7 point band could start
+  proposing.
+- On this sample that roughly doubles the population of qualifying markets while
+  changing sizing on almost none of them.
+
+That is an exposure change, not an accuracy improvement, which is why
+`STEPS_PER_DAY` ships at 1 and is guarded by a test that names the approval
+requirement.
+
+## What was NOT measured
+
+- Whether any of these markets would have resolved differently. Re-pricing a
+  historical simulation says what the scanner would have proposed, not what
+  would have happened.
+- The 1 to 7 point band population, directly. The "roughly doubles" claim is
+  inferred from the size of the lift against the floor on a sample of four, not
+  counted from the 5,649 stored simulation rows. Counting it is the first thing
+  the P1 work should do, and the newly persisted `steps` / `horizon_days_model`
+  fields are what make that possible for rows written from now on.
+- Anything about touch model validity. See the method note above.
+
+## Reproducing this
+
+Parameters are in the table plus `trading_simulations.raw_output` for each id.
+The kernel is `src/trading/simulation.py`; `simulate_paths` takes
+`steps_per_day` directly, so P0 and P1 are one argument apart. The continuous
+limit uses the reflection principle:
+
+```
+nu = mu - sigma^2/2 ,  b = ln(K/S0) ,  s = sigma*sqrt(T)
+
+touch_above (b > 0):  Phi((-b + nu T)/s) + exp(2 nu b / sigma^2) * Phi((-b - nu T)/s)
+touch_below (b < 0):  Phi(( b - nu T)/s) + exp(2 nu b / sigma^2) * Phi(( b + nu T)/s)
+```

--- a/src/agents/skills/trading.md
+++ b/src/agents/skills/trading.md
@@ -91,7 +91,12 @@ Verified in code 2026-08-14:
   7 percentage points).
 - High-edge floor: **0.07** (`scanner.AMOUNT_EDGE_FLOOR`).
 - Pre-simulation volume floor: **20,000 USDC** (`scanner.MIN_PRESIM_VOLUME`).
-- Horizon cap: **35 days** (`scanner.HORIZON_MAX_DAYS`).
+- Horizon window: **1.0 to 35 days**. Upper bound `scanner.HORIZON_MAX_DAYS`;
+  lower bound `config.min_horizon_tradeable_days`, enforced twice, in
+  `scanner.analyse_edge` at scan time and again in executor GATE 7 against the
+  clock at execution. Horizons are FRACTIONAL days as of 2026-09-08; they used
+  to be rounded up to whole days, which is what priced position e09b82fe into a
+  maximum-size loss.
 - No-edge band and the alert volume floor come from
   `config.no_edge_threshold` and `config.min_alert_volume`, both read from the
   environment. Historically −0.20 and 5,000 USDC, but these are NOT hardcoded:
@@ -110,8 +115,8 @@ Monte Carlo worker — http://localhost:4001 (PM2: trading-worker):
 
 Trade execution path (rewritten 2026-08-14): execution belongs entirely to the
 standalone trade engine, src/trade_engine/executor.py, which invokes
-src/trading/execute_trade.py as a subprocess behind SIX pre-flight gates.
-Verified against the code 2026-08-14. Every one of these can refuse a trade
+src/trading/execute_trade.py as a subprocess behind SEVEN pre-flight gates.
+Verified against the code 2026-09-08. Every one of these can refuse a trade
 the Analyst and Tyson have already approved, so check them before telling
 Tyson a trade "will" go through:
 
@@ -123,10 +128,20 @@ Tyson a trade "will" go through:
 | 4 | edge_below_threshold | `candidate.edge < min_edge_threshold / 100` | 7% |
 | 5 | invalid_amount | size ≤ 0, above config, or above a hard ceiling | `max_position_usdc` (10) AND **ABSOLUTE_MAX_POSITION_USDC = 25.0** (hardcoded ceiling that config cannot raise) |
 | 6 | invalid_market_identifier | no well-formed Polymarket conditionId | — |
+| 7 | horizon_below_minimum | the market resolves too soon, RECOMPUTED from `end_date` at execution, or `end_date` is missing/unparseable | **MIN_HORIZON_TRADEABLE_DAYS = 1.0** (`config`; env may raise it, never lower it) |
 
 Gates 2 and 5's hard limits are code constants, not database config: raising
 `max_position_usdc` above 25 does NOT raise the real ceiling, and there is no
 config key for the 2-position cap.
+
+**Gate 7 uses the clock, not the candidate.** It recomputes days-to-resolution
+from `end_date` at the moment of execution rather than reading the horizon the
+scanner recorded. Those differ by up to 2100 seconds (the approval timeout plus
+the maximum approval age), which is enough to carry a market from exactly the
+1.00d floor to 0.976d. So a trade the scanner proposed can be refused here with
+nothing having changed except time passing, and that is correct rather than a
+bug. If asked why a trade was blocked as `horizon_below_minimum` when the
+proposal looked fine, this is the answer.
 
 **Gate 3 depends on manual logging (changed 2026-08-20).** The Position Monitor
 no longer writes a close when a stop-loss or take-profit threshold fires: it
@@ -250,7 +265,7 @@ Credentials: POLYMARKET_PRIVATE_KEY + POLYMARKET_FUNDER_ADDRESS
    markets below this edge.
 7. There is no HTTP execution route and no TRADING_WEBHOOK_SECRET path any
    more (both retired 2026-08-14). Execution runs only through the trade
-   engine's executor, behind its six gates plus the Telegram approval gate.
+   engine's executor, behind its seven gates plus the Telegram approval gate.
    Never propose reinstating an HTTP execution route.
 8. The Monte Carlo worker must be running (PM2: trading-worker) before any
    simulation or execution calls.

--- a/src/trade_engine/analyst.py
+++ b/src/trade_engine/analyst.py
@@ -209,7 +209,7 @@ class TradeAnalyst:
             f"Edge: {candidate.edge:.1%} (Sim: {candidate.sim_probability:.1%} vs "
             f"Market: {candidate.market_probability:.1%})",
             f"Volume: ${candidate.volume:,.0f}",
-            f"Horizon: {candidate.horizon_days} days",
+            f"Horizon: {candidate.horizon_days:.2f} days",
             f"Proposed position: ${candidate.amount_usdc:.2f}",
             "",
             f"TRADE HISTORY ({history['total_trades']} resolved trades):",

--- a/src/trade_engine/approval.py
+++ b/src/trade_engine/approval.py
@@ -247,7 +247,10 @@ class ApprovalGate:
             f"Market: {candidate.market_probability:.1%})\n"
             f"{market_now}"
             f"Volume: ${candidate.volume:,.0f} | "
-            f"Horizon: {candidate.horizon_days}d\n"
+            # .2f, not bare: horizon_days is fractional now, and an
+            # unformatted 20.582881944444444d in the message a human reads
+            # while deciding whether to spend money is worse than useless.
+            f"Horizon: {candidate.horizon_days:.2f}d\n"
             f"Position: ${candidate.amount_usdc:.2f}\n"
             "\n"
             f"📊 Analyst: {verdict} ({recommendation.confidence:.0%} confidence)\n"

--- a/src/trade_engine/config.py
+++ b/src/trade_engine/config.py
@@ -56,6 +56,25 @@ DEFAULT_HIGH_EDGE_THRESHOLD = 0.07
 DEFAULT_NO_EDGE_THRESHOLD = -0.20
 DEFAULT_MIN_ALERT_VOLUME = 5000.0
 
+# Hard refusal floor on how short a market may be to be proposed OR placed.
+# THIS is the control that protects the money path from short-dated markets, 
+# not monte_carlo.MIN_HORIZON_MODEL_DAYS, which is numerical safety only.
+#
+# The scanner's Monte Carlo estimates daily_sigma from 21 daily closes. Making
+# the horizon arithmetic exact (2026-09-07) lets it price a 59-minute window
+# correctly by its own lights, but a 21-day daily-close vol estimate is not
+# calibrated for an intraday window at all, there is no intraday data behind
+# it. Correct arithmetic on an uncalibrated model is still not a tradeable
+# number, so anything under a day is refused outright rather than sized.
+#
+# Enforced in TWO independent places on purpose: PolymarketScanner.analyse_edge
+# drops the market before it is ever simulated, and TradeExecutor GATE 7
+# re-checks it against live state immediately before the order goes out. A
+# control that exists in one layer only is not a control, the scanner
+# proposes, the executor executes, and an approval can be up to 30 minutes
+# stale by the time it is acted on.
+DEFAULT_MIN_HORIZON_TRADEABLE_DAYS = 1.0
+
 VERSION = "0.1.0"
 
 
@@ -111,6 +130,15 @@ class Config:
         )
         self.min_alert_volume: float = self._float_env(
             "MIN_ALERT_VOLUME", DEFAULT_MIN_ALERT_VOLUME
+        )
+        # Clamped at the floor, never below: an env typo (0, negative, or an
+        # over-eager 0.5) must not be able to re-open the sub-day path that
+        # cost position e09b82fe. Raising it is allowed, lowering it is not.
+        self.min_horizon_tradeable_days: float = max(
+            DEFAULT_MIN_HORIZON_TRADEABLE_DAYS,
+            self._float_env(
+                "MIN_HORIZON_TRADEABLE_DAYS", DEFAULT_MIN_HORIZON_TRADEABLE_DAYS
+            ),
         )
 
         self.approval_timeout_seconds: int = self._int_env(

--- a/src/trade_engine/executor.py
+++ b/src/trade_engine/executor.py
@@ -300,6 +300,18 @@ class TradeExecutor:
         # at scan time; this evaluates it at execution time. They can disagree,
         # and when they do this one wins.
         #
+        # PRECISELY WHICH HALF IS LIVE, because the obvious reading is wrong.
+        # Only the horizon is. `floor` below is config.min_horizon_tradeable_days,
+        # which is read from the environment ONCE in Config.__init__ at import
+        # and is NOT a trading_config column, so nothing reloads it and its
+        # import-time and execution-time values are always the same number. This
+        # gate is therefore NOT the parallel to GATE 1 that it looks like: GATE 1
+        # re-reads trading_config from Supabase on every call and can genuinely
+        # change under it. Changing the floor here needs a process restart.
+        #
+        # Stated because an earlier version of this comment implied both halves
+        # were live, and a review found the floor half of that claim vacuous.
+        #
         # Fails CLOSED on absent or unparseable end_date, matching gates 1-6.
         # An unknown resolution time is refused, never waved through, and in
         # particular is never backfilled from the stale snapshot.

--- a/src/trade_engine/executor.py
+++ b/src/trade_engine/executor.py
@@ -30,7 +30,6 @@ well-formed conditionId is refused rather than sent with the wrong identifier.
 import asyncio
 import json
 import logging
-import math
 import re
 import subprocess
 from datetime import datetime, timezone
@@ -41,6 +40,7 @@ import httpx
 
 from src.trade_engine.approval import _scrub
 from src.trade_engine.config import config, install_bot_token_redaction
+from src.trade_engine.horizon import horizon_days
 from src.trade_engine.database import (
     SupabaseError,
     count_open_positions,
@@ -283,34 +283,46 @@ class TradeExecutor:
             raise ExecutionGateError("invalid_market_identifier")
         log.debug("gate 6 ok: conditionId well-formed")
 
-        # GATE 7, the market must still be long enough to price.
-        # PolymarketScanner.analyse_edge already refuses anything under this
-        # floor, so in a healthy pipeline this gate never fires. That is the
-        # point: the scanner PROPOSES and the executor EXECUTES, and a control
-        # that lives in one layer only is not a control. GATE 1 re-reads the
-        # global brake here for the same reason, the candidate in hand may
-        # have been selected up to 30 minutes ago, by a scanner running older
-        # code, or reconstructed from a persisted approval.
+        # GATE 7, the market must STILL be long enough to price, measured now.
         #
-        # Fails CLOSED on a missing or non-finite value, matching gates 1-6:
-        # an unknown horizon is refused, never waved through.
-        horizon = candidate.horizon_days
+        # This RECOMPUTES the horizon from end_date against the current clock.
+        # It deliberately does not read candidate.horizon_days, which is a
+        # snapshot taken during the scan and is stale by the time this runs:
+        # APPROVAL_TIMEOUT_SECONDS (1800) plus APPROVAL_MAX_AGE_SECONDS (300)
+        # is 2100s, so a market at exactly the 1.00d floor when it was proposed
+        # is 0.976d when the order goes out. Reading the frozen field passes it,
+        # and 0.976d is intraday by exactly the argument the floor exists for:
+        # daily_sigma comes from 21 daily closes and is not calibrated for a
+        # sub-day window.
+        #
+        # This is also what makes the gate an independent control rather than a
+        # second copy of the scanner's check. The scanner evaluates the horizon
+        # at scan time; this evaluates it at execution time. They can disagree,
+        # and when they do this one wins.
+        #
+        # Fails CLOSED on absent or unparseable end_date, matching gates 1-6.
+        # An unknown resolution time is refused, never waved through, and in
+        # particular is never backfilled from the stale snapshot.
         floor = config.min_horizon_tradeable_days
-        if horizon is None or not isinstance(horizon, (int, float)) \
-                or isinstance(horizon, bool) or not math.isfinite(float(horizon)):
+        remaining = horizon_days(candidate.end_date, datetime.now(timezone.utc))
+        if remaining is None:
             log.error(
-                "gate 7: candidate has no usable horizon (market_id=%s, value=%r)",
-                candidate.market_id, horizon,
+                "gate 7: candidate has no usable end_date (market_id=%s, value=%r), "
+                "refusing rather than trusting the scan-time horizon %r",
+                candidate.market_id, candidate.end_date, candidate.horizon_days,
             )
             raise ExecutionGateError("horizon_below_minimum")
-        if float(horizon) < floor:
+        if remaining < floor:
             log.error(
-                "gate 7: horizon %.4fd is below the %.2fd tradeable floor "
-                "(market_id=%s), refusing",
-                float(horizon), floor, candidate.market_id,
+                "gate 7: horizon is %.4fd now (was %.4fd at scan), below the "
+                "%.2fd tradeable floor (market_id=%s), refusing",
+                remaining, candidate.horizon_days, floor, candidate.market_id,
             )
             raise ExecutionGateError("horizon_below_minimum")
-        log.debug("gate 7 ok: horizon=%.4fd >= %.2fd", float(horizon), floor)
+        log.debug(
+            "gate 7 ok: horizon=%.4fd now (%.4fd at scan) >= %.2fd",
+            remaining, candidate.horizon_days, floor,
+        )
 
     # --- execution --------------------------------------------------------
 

--- a/src/trade_engine/executor.py
+++ b/src/trade_engine/executor.py
@@ -2,7 +2,7 @@
 """Trade executor — the only component in this repo that spends real money.
 
 Sits behind the approval gate: nothing here runs until a human has tapped
-Execute on a Telegram message. Even then, six independent gates are re-checked
+Execute on a Telegram message. Even then, seven independent gates are re-checked
 against LIVE state before the order goes out, because the approval may be up to
 30 minutes stale by the time it is acted on and the world moves in between.
 
@@ -30,6 +30,7 @@ well-formed conditionId is refused rather than sent with the wrong identifier.
 import asyncio
 import json
 import logging
+import math
 import re
 import subprocess
 from datetime import datetime, timezone
@@ -212,7 +213,7 @@ class TradeExecutor:
     # --- gates ------------------------------------------------------------
 
     async def _run_gates(self, candidate: ScannerCandidate) -> None:
-        """Six checks against live state. Raises ExecutionGateError on refusal.
+        """Seven checks against live state. Raises ExecutionGateError on refusal.
 
         Ordered cheapest-and-most-decisive first: the global brake before the
         per-trade arithmetic, so a disabled system does not spend three
@@ -281,6 +282,35 @@ class TradeExecutor:
             )
             raise ExecutionGateError("invalid_market_identifier")
         log.debug("gate 6 ok: conditionId well-formed")
+
+        # GATE 7, the market must still be long enough to price.
+        # PolymarketScanner.analyse_edge already refuses anything under this
+        # floor, so in a healthy pipeline this gate never fires. That is the
+        # point: the scanner PROPOSES and the executor EXECUTES, and a control
+        # that lives in one layer only is not a control. GATE 1 re-reads the
+        # global brake here for the same reason, the candidate in hand may
+        # have been selected up to 30 minutes ago, by a scanner running older
+        # code, or reconstructed from a persisted approval.
+        #
+        # Fails CLOSED on a missing or non-finite value, matching gates 1-6:
+        # an unknown horizon is refused, never waved through.
+        horizon = candidate.horizon_days
+        floor = config.min_horizon_tradeable_days
+        if horizon is None or not isinstance(horizon, (int, float)) \
+                or isinstance(horizon, bool) or not math.isfinite(float(horizon)):
+            log.error(
+                "gate 7: candidate has no usable horizon (market_id=%s, value=%r)",
+                candidate.market_id, horizon,
+            )
+            raise ExecutionGateError("horizon_below_minimum")
+        if float(horizon) < floor:
+            log.error(
+                "gate 7: horizon %.4fd is below the %.2fd tradeable floor "
+                "(market_id=%s), refusing",
+                float(horizon), floor, candidate.market_id,
+            )
+            raise ExecutionGateError("horizon_below_minimum")
+        log.debug("gate 7 ok: horizon=%.4fd >= %.2fd", float(horizon), floor)
 
     # --- execution --------------------------------------------------------
 

--- a/src/trade_engine/horizon.py
+++ b/src/trade_engine/horizon.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Horizon arithmetic shared by the scanner and the executor.
+
+Its own module because `scanner.py` imports `executor.py`, so the executor
+cannot import the scanner back without a cycle, and the alternative to sharing
+is two copies of a date parser on the money path.
+
+The split in behaviour is deliberate and is the point of the module:
+
+  `horizon_days()` returns None when the end date is absent or unparseable.
+  It NEVER substitutes a default, because the two callers need opposite things
+  from that case. The scanner treats an unknown end date as a 30-day market and
+  carries on; executor GATE 7 refuses. A shared function that picked either one
+  would be wrong for the other caller, so it returns None and each decides.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+def parse_end_date(end_date: Any) -> Optional[datetime]:
+    """Parse a Gamma endDate into an aware UTC datetime, or None.
+
+    Accepts the trailing-Z form Gamma actually sends. A naive timestamp is
+    treated as UTC, matching how the scanner has always read these and how both
+    hosts are configured.
+    """
+    if not end_date:
+        return None
+    if isinstance(end_date, datetime):
+        parsed = end_date
+    else:
+        try:
+            parsed = datetime.fromisoformat(str(end_date).replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def horizon_days(end_date: Any, now: datetime) -> Optional[float]:
+    """Exact fractional days from `now` until `end_date`. None if unusable.
+
+    None means "cannot be determined", not "zero" and not "far away". Callers
+    must decide what that means for them; see the module docstring.
+
+    May be negative for a market that has already resolved. That is a real
+    answer rather than an error, and both callers reject it on the same
+    comparison they use for a short horizon.
+    """
+    parsed = parse_end_date(end_date)
+    if parsed is None:
+        return None
+    value = (parsed - now).total_seconds() / 86400.0
+    return value if math.isfinite(value) else None

--- a/src/trade_engine/main.py
+++ b/src/trade_engine/main.py
@@ -787,8 +787,12 @@ async def execute(result: ApprovalResult) -> JSONResponse:
     THIS SPENDS REAL MONEY. It bypasses the scanner, the Analyst and the
     approval gate, so the ApprovalResult in the body is the only evidence of
     consent — which is why the executor re-checks `status == approved` itself
-    rather than trusting the caller, and re-runs all six financial gates
+    rather than trusting the caller, and re-runs all seven financial gates
     against live Supabase state before anything is sent to Polymarket.
+
+    GATE 7 recomputes the horizon from end_date against the clock, so replaying
+    an old ApprovalResult here can be refused as horizon_below_minimum even
+    though it was valid when it was approved. That is the gate working.
 
     No auth, in the same sense as /scan and /config: the process binds
     127.0.0.1 only. That is the whole access control story — do not expose this

--- a/src/trade_engine/models.py
+++ b/src/trade_engine/models.py
@@ -236,6 +236,12 @@ class ScannerCandidate(BaseModel):
     # into a ValidationError that takes down the whole scan rather than one
     # market. Verified against pydantic 2.12.4.
     horizon_days: float
+    # Market resolution time as Gamma reports it, carried from the scanner row.
+    # horizon_days above is a SNAPSHOT taken at scan time; this is the input
+    # executor GATE 7 uses to recompute the horizon against the clock at
+    # execution. Optional so an ApprovalResult persisted before 2026-09-08 still
+    # validates; GATE 7 refuses when it is absent rather than assuming.
+    end_date: Optional[str] = None
     market_url: str
     amount_usdc: float
 

--- a/src/trade_engine/models.py
+++ b/src/trade_engine/models.py
@@ -182,7 +182,11 @@ class MonteCarloResponse(BaseModel):
     current_price: float
     target: float
     asset: str
-    horizon_days: int
+    # Fractional. See ScannerCandidate.horizon_days for why this must not be
+    # int. NOTE this model is currently unused, nothing constructs it, but it
+    # is kept in step with the wire format rather than left as a stale shape
+    # that would reject a real worker response if it were ever wired up.
+    horizon_days: float
     market_type: str
     question: Optional[str] = None
     simulations: Optional[int] = None
@@ -225,7 +229,13 @@ class ScannerCandidate(BaseModel):
     sim_probability: float
     market_probability: float
     volume: float
-    horizon_days: int
+    # Fractional days to resolution, NOT a whole-day count. This annotation is
+    # load-bearing: pydantic v2 rejects a float with a fractional part for an
+    # int field (`int_from_float`), and _to_candidate below runs for every
+    # high-edge AND no-edge row, so leaving this as int turns the horizon fix
+    # into a ValidationError that takes down the whole scan rather than one
+    # market. Verified against pydantic 2.12.4.
+    horizon_days: float
     market_url: str
     amount_usdc: float
 

--- a/src/trade_engine/requirements.txt
+++ b/src/trade_engine/requirements.txt
@@ -16,6 +16,15 @@ python-dotenv>=1.0.0
 # file, so the suite passed on the box and could not even import that module on
 # a bare CI runner.
 requests>=2.31.0
+# numpy is imported by src/trading/monte_carlo.py, which the test suite now
+# covers directly (tests/test_monte_carlo_horizon.py exercises the pricing
+# kernel with fixed parameters and no network). It was present system-wide on
+# qclaw, 2.4.4, alongside flask 3.1.3, yfinance 1.2.0 and scipy 1.17.1, and
+# absent from this file, which is why that module had no tests at all: CI
+# installs only this file, so any test importing it failed at import.
+# CI-only in effect: the deploy job never runs pip install, and this adds no
+# new runtime dependency to the host.
+numpy>=1.26.0
 
 # NOTE: every constraint above is a LOWER BOUND only. CI resolves the newest
 # matching release on each run, so this job can turn red with no repo change,

--- a/src/trade_engine/scanner.py
+++ b/src/trade_engine/scanner.py
@@ -111,6 +111,11 @@ WEEKEND_ASSETS = {"btc", "eth", "sol", "xrp"}
 
 MIN_PRESIM_VOLUME = 20000
 HORIZON_MAX_DAYS = 35
+
+# Fallback horizon when endDate is absent or unparseable. 30.0, not 30: every
+# horizon downstream of _horizon_days is a float now, and a bare int here would
+# be the one path that still fed an integer into the simulator.
+DEFAULT_HORIZON_DAYS = 30.0
 YES_PRICE_MIN = 0.01
 YES_PRICE_MAX = 0.99
 RUNGS_PER_EVENT = 3
@@ -341,6 +346,7 @@ class PolymarketScanner:
 
         results: list[dict[str, Any]] = []
         seen: set[str] = set()
+        short_horizon = 0
 
         for market in markets:
             question = (market.get("question") or "").lower()
@@ -382,6 +388,21 @@ class PolymarketScanner:
             if horizon_days <= 0 or horizon_days > HORIZON_MAX_DAYS:
                 continue
 
+            # Hard refusal, not a scoring penalty. Dropped here, before the
+            # /simulate call, so a sub-day market is never priced, never
+            # bucketed and never proposed. Making the horizon arithmetic exact
+            # does not make daily_sigma (21 daily closes) valid intraday; see
+            # DEFAULT_MIN_HORIZON_TRADEABLE_DAYS in config.py. Executor GATE 7
+            # re-checks the same floor against live state before the order.
+            if horizon_days < config.min_horizon_tradeable_days:
+                short_horizon += 1
+                log.info(
+                    "refusing %s: horizon %.4fd below tradeable floor %.2fd (%s)",
+                    market_id, horizon_days, config.min_horizon_tradeable_days,
+                    market.get("question"),
+                )
+                continue
+
             yes_price = _outcome_yes_price(market)
             if yes_price is None or yes_price < YES_PRICE_MIN or yes_price > YES_PRICE_MAX:
                 continue
@@ -409,23 +430,42 @@ class PolymarketScanner:
 
         selected = self._select_rungs(results)
         log.info(
-            "analyse_edge: %d markets in, %d passed filters, %d after rung/cap selection",
+            "analyse_edge: %d markets in, %d passed filters, %d after rung/cap "
+            "selection (%d refused below the %.2fd tradeable horizon floor)",
             len(markets), len(results), len(selected),
+            short_horizon, config.min_horizon_tradeable_days,
         )
         return selected
 
     @staticmethod
-    def _horizon_days(end_date: Optional[str], now: datetime) -> int:
-        """Math.ceil((endDate - now) / 86400000); absent endDate defaults to 30."""
+    def _horizon_days(end_date: Optional[str], now: datetime) -> float:
+        """Exact time to resolution in days, fractional. Absent endDate -> 30.0.
+
+        This used to be Math.ceil((endDate - now) / 86400000), ported verbatim
+        from n8n. The rounding was not conservative, it was systematically
+        wrong in ONE direction. A shorter real horizon rounded UP means the
+        simulator diffuses the price for longer than the market actually has,
+        which overstates the probability of reaching the target, which inflates
+        the edge, which maximises position size. On 2026-08-31 a 3,558-second
+        market (0.0412d) was priced as a full day: P 0.0648 -> 0.4834, edge
+        +3.9pts -> +45.8pts, and position e09b82fe fired at the $10 cap for a
+        total loss.
+
+        NOTE the two downstream guards are unaffected, which is why they are
+        left exactly as they are: ceil(T) <= 0 iff T <= 0, and ceil(T) <= 35 iff
+        T <= 35, so the `horizon_days <= 0` rejection, HORIZON_MAX_DAYS and
+        monte_carlo's 21-vs-90-day lookback selector all keep their old
+        behaviour. The only thing this changes is the VALUE handed downstream.
+        """
         if not end_date:
-            return 30
+            return DEFAULT_HORIZON_DAYS
         try:
             parsed = datetime.fromisoformat(str(end_date).replace("Z", "+00:00"))
         except ValueError:
-            return 30
+            return DEFAULT_HORIZON_DAYS
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=timezone.utc)
-        return math.ceil((parsed - now).total_seconds() / 86400.0)
+        return (parsed - now).total_seconds() / 86400.0
 
     @staticmethod
     def _select_rungs(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -875,7 +915,16 @@ def simulation_rows(summary_source: list[dict[str, Any]]) -> list[dict[str, Any]
                 "polymarket_condition_id": row.get("condition_id"),
                 "question": row["question"],
                 "target": row["target"],
+                # Fractional since 2026-09-07. Rows written before then carry a
+                # ceil()-rounded integer, so a calibration query spanning that
+                # date is comparing two different quantities. The three fields
+                # below are what the simulator actually discretised, recorded
+                # because the absence of exactly this made the ceil() bug
+                # invisible in 5,649 stored rows.
                 "horizon_days": row["horizon_days"],
+                "horizon_days_model": sim.get("horizon_days_model"),
+                "steps": sim.get("steps"),
+                "steps_per_day": sim.get("steps_per_day"),
                 "end_date": row["end_date"],
                 "volume": row["volume"],
                 "source": row["source"],

--- a/src/trade_engine/scanner.py
+++ b/src/trade_engine/scanner.py
@@ -35,6 +35,7 @@ import httpx
 from src.trade_engine.config import config
 from src.trade_engine.approval import ApprovalGate, ApprovalGateBusy
 from src.trade_engine.database import SupabaseError, write_simulation
+from src.trade_engine.horizon import horizon_days
 from src.trade_engine.executor import TradeExecutor
 from src.trade_engine.models import (
     ApprovalStatus,
@@ -457,15 +458,13 @@ class PolymarketScanner:
         monte_carlo's 21-vs-90-day lookback selector all keep their old
         behaviour. The only thing this changes is the VALUE handed downstream.
         """
-        if not end_date:
-            return DEFAULT_HORIZON_DAYS
-        try:
-            parsed = datetime.fromisoformat(str(end_date).replace("Z", "+00:00"))
-        except ValueError:
-            return DEFAULT_HORIZON_DAYS
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
-        return (parsed - now).total_seconds() / 86400.0
+        value = horizon_days(end_date, now)
+        # None means the end date is absent or unparseable. The SCANNER treats
+        # that as a 30-day market, which is the behaviour this has always had.
+        # Executor GATE 7 makes the opposite choice on the same None and
+        # refuses; see src/trade_engine/horizon.py for why that asymmetry is
+        # deliberate rather than an inconsistency.
+        return DEFAULT_HORIZON_DAYS if value is None else value
 
     @staticmethod
     def _select_rungs(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -633,6 +632,12 @@ class PolymarketScanner:
             market_probability=row["yes_price"],
             volume=row["volume"],
             horizon_days=row["horizon_days"],
+            # Carried so the executor can RECOMPUTE the horizon at execution
+            # time. horizon_days above is frozen at scan time and decays by up
+            # to 2100s (approval timeout + max approval age) before the order
+            # goes out, which is enough to carry a market from exactly the
+            # floor to below it.
+            end_date=row.get("end_date"),
             market_url=POLYMARKET_MARKET_URL.format(slug=slug) if slug else "",
             amount_usdc=_amount_usdc(edge),
         )

--- a/src/trading/monte_carlo.py
+++ b/src/trading/monte_carlo.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Monte Carlo simulation worker for gold and BTC price prediction."""
+"""Monte Carlo simulation worker for gold and BTC price prediction.
+
+Data fetching, the macro adjustment and the HTTP surface live here. The pricing
+ARITHMETIC lives in simulation.py and is imported, see that module's docstring
+for why the split exists.
+"""
 
 from flask import Flask, request, jsonify
 import yfinance as yf
@@ -7,7 +12,36 @@ import numpy as np
 from scipy import stats
 from datetime import datetime, timedelta
 import math
-import re
+
+# PM2 runs this file as a SCRIPT (`python3 /root/QClaw/src/trading/monte_carlo.py`,
+# cwd /root/QClaw), which puts src/trading on sys.path but NOT the repo root, so
+# the packaged import fails there. The test suite and any future in-process
+# caller import it the packaged way. Both forms are supported explicitly rather
+# than relying on whichever one happens to work.
+try:
+    from src.trading.simulation import (
+        MAX_STEPS,
+        MIN_HORIZON_MODEL_DAYS,
+        NUM_SIMULATIONS,
+        STEPS_PER_DAY,
+        coerce_horizon,
+        detect_market_type,
+        simulate_paths,
+        steps_for_horizon,
+        wilson_interval,
+    )
+except ImportError:  # pragma: no cover - exercised by the PM2 script invocation
+    from simulation import (  # type: ignore[no-redef]
+        MAX_STEPS,
+        MIN_HORIZON_MODEL_DAYS,
+        NUM_SIMULATIONS,
+        STEPS_PER_DAY,
+        coerce_horizon,
+        detect_market_type,
+        simulate_paths,
+        steps_for_horizon,
+        wilson_interval,
+    )
 
 app = Flask(__name__)
 
@@ -27,44 +61,12 @@ MACRO_TICKERS = {
     "tnx": "^TNX",
 }
 
-NUM_SIMULATIONS = 10_000
 TRADING_DAYS_YEAR = 252
 
-
-def wilson_interval(successes, total, z=1.96):
-    """Wilson score interval for binomial proportion."""
-    if total == 0:
-        return 0.0, 0.0, 0.0
-    p_hat = successes / total
-    denom = 1 + z**2 / total
-    centre = (p_hat + z**2 / (2 * total)) / denom
-    spread = z * math.sqrt((p_hat * (1 - p_hat) + z**2 / (4 * total)) / total) / denom
-    return round(centre, 4), round(max(0, centre - spread), 4), round(min(1, centre + spread), 4)
-
-
-def detect_market_type(question, target, current_price):
-    """
-    Detect whether this is a touch market or close-on-date market.
-
-    Touch market: "will X dip to/reach/hit Y" — checks any path touch
-    Close-on-date: "will X be above/below Y on [date]" — checks final price only
-
-    Returns: 'touch_above' | 'touch_below' | 'close_above' | 'close_below'
-    """
-    q = (question or '').lower()
-
-    # Close-on-date patterns: "above X on [date]" or "over X on [date]"
-    if re.search(r'\b(above|over)\b', q) and re.search(r'\bon\b', q):
-        return 'close_above'
-
-    # Close-on-date patterns: "below X on [date]" or "under X on [date]"
-    if re.search(r'\b(below|under)\b', q) and re.search(r'\bon\b', q):
-        return 'close_below'
-
-    # Touch market: direction based on target vs current price
-    if target < current_price:
-        return 'touch_below'
-    return 'touch_above'
+# NUM_SIMULATIONS, STEPS_PER_DAY, MAX_STEPS, MIN_HORIZON_MODEL_DAYS,
+# wilson_interval, detect_market_type, coerce_horizon, steps_for_horizon and
+# simulate_paths are imported from simulation.py above. They are re-exported by
+# that import so existing callers of monte_carlo.<name> keep working.
 
 
 def fetch_macro():
@@ -86,7 +88,7 @@ def fetch_macro():
     return factors
 
 
-def run_simulation(asset, target, horizon_days=30, question=''):
+def run_simulation(asset, target, horizon_days=30.0, question=''):
     """Run Monte Carlo simulation for an asset."""
     ticker_symbol = TICKERS.get(asset)
     if not ticker_symbol:
@@ -118,35 +120,16 @@ def run_simulation(asset, target, horizon_days=30, question=''):
     if not np.isfinite(mu) or not np.isfinite(sigma) or sigma <= 0:
         return None, f"Invalid statistics for {asset}: mu={mu}, sigma={sigma} (possible NaN/sparse data)"
 
-    dt = 1.0  # mu and sigma are daily, so dt=1 day per step
-    steps = horizon_days
-
-    # Generate Monte Carlo paths using GBM
-    np.random.seed(None)
-    Z = np.random.standard_normal((NUM_SIMULATIONS, steps))
-    drift = (mu - 0.5 * sigma**2) * dt
-    diffusion = sigma * np.sqrt(dt) * Z
-
-    # Build price paths
-    log_increments = drift + diffusion
-    log_paths = np.cumsum(log_increments, axis=1)
-    paths = current_price * np.exp(log_paths)
-
-    # Determine market type and count hits
+    # mu and sigma are per DAY. horizon_days is a total time in days, not a
+    # step count, dt comes out of simulate_paths as horizon/steps.
     market_type = detect_market_type(question, target, current_price)
-    if market_type == 'close_above':
-        hits = (paths[:, -1] >= target).sum()
-    elif market_type == 'close_below':
-        hits = (paths[:, -1] <= target).sum()
-    elif market_type == 'touch_above':
-        hits = np.any(paths >= target, axis=1).sum()
-    else:  # touch_below
-        hits = np.any(paths <= target, axis=1).sum()
+    priced = simulate_paths(
+        current_price, target, mu, sigma, horizon_days, market_type,
+        num_simulations=NUM_SIMULATIONS,
+    )
 
     market_type_used = market_type
-
-    hits = int(hits)
-    prob, ci_lower, ci_upper = wilson_interval(hits, NUM_SIMULATIONS)
+    prob, ci_lower, ci_upper = wilson_interval(priced.hits, priced.total)
 
     # Macro adjustment for gold
     macro = fetch_macro()
@@ -171,6 +154,12 @@ def run_simulation(asset, target, horizon_days=30, question=''):
         "target": target,
         "asset": asset,
         "horizon_days": horizon_days,
+        # What was actually priced. horizon_days is what the caller asked for;
+        # these three say how it was discretised, so a stored simulation row
+        # can be re-derived later instead of guessed at.
+        "horizon_days_model": priced.horizon_days_model,
+        "steps": priced.steps,
+        "steps_per_day": STEPS_PER_DAY,
         "market_type": market_type_used,
         "question": question or f"Will {asset} hit ${target}?",
         "simulations": NUM_SIMULATIONS,
@@ -187,16 +176,24 @@ def simulate():
         body = request.get_json(force=True, silent=True) or {}
         asset = body.get("asset", "gold").lower()
         target = body.get("target")
-        horizon = body.get("horizon_days", 30)
+        horizon = body.get("horizon_days", 30.0)
 
         if target is None:
             return jsonify({"error": "target is required"}), 400
 
         try:
             target = float(target)
-            horizon = int(horizon)
         except (ValueError, TypeError):
             return jsonify({"error": "target must be numeric"}), 400
+        if not math.isfinite(target):
+            return jsonify({"error": "target must be finite"}), 400
+
+        # coerce_horizon, NOT int(). See simulation.coerce_horizon for why the
+        # int() this replaced was a second, independent truncation that failed
+        # SILENTLY on touch markets.
+        horizon, horizon_error = coerce_horizon(horizon)
+        if horizon_error:
+            return jsonify({"error": horizon_error}), 400
 
         question = body.get("question", "")
         result, error = run_simulation(asset, target, horizon, question)

--- a/src/trading/monte_carlo.py
+++ b/src/trading/monte_carlo.py
@@ -11,7 +11,6 @@ import yfinance as yf
 import numpy as np
 from scipy import stats
 from datetime import datetime, timedelta
-import math
 
 # PM2 runs this file as a SCRIPT (`python3 /root/QClaw/src/trading/monte_carlo.py`,
 # cwd /root/QClaw), which puts src/trading on sys.path but NOT the repo root, so
@@ -25,6 +24,7 @@ try:
         NUM_SIMULATIONS,
         STEPS_PER_DAY,
         coerce_horizon,
+        coerce_target,
         detect_market_type,
         simulate_paths,
         steps_for_horizon,
@@ -37,6 +37,7 @@ except ImportError:  # pragma: no cover - exercised by the PM2 script invocation
         NUM_SIMULATIONS,
         STEPS_PER_DAY,
         coerce_horizon,
+        coerce_target,
         detect_market_type,
         simulate_paths,
         steps_for_horizon,
@@ -186,12 +187,12 @@ def simulate():
         if target is None:
             return jsonify({"error": "target is required"}), 400
 
-        try:
-            target = float(target)
-        except (ValueError, TypeError):
-            return jsonify({"error": "target must be numeric"}), 400
-        if not math.isfinite(target):
-            return jsonify({"error": "target must be finite"}), 400
+        # Both coercions live in simulation.py so the suite can reach them;
+        # see coerce_target's docstring for why an inline guard here was not a
+        # guard at all.
+        target, target_error = coerce_target(target)
+        if target_error:
+            return jsonify({"error": target_error}), 400
 
         # coerce_horizon, NOT int(). See simulation.coerce_horizon for why the
         # int() this replaced was a second, independent truncation that failed

--- a/src/trading/monte_carlo.py
+++ b/src/trading/monte_carlo.py
@@ -159,7 +159,12 @@ def run_simulation(asset, target, horizon_days=30.0, question=''):
         # can be re-derived later instead of guessed at.
         "horizon_days_model": priced.horizon_days_model,
         "steps": priced.steps,
-        "steps_per_day": STEPS_PER_DAY,
+        # priced.steps_per_day, NOT the module constant. simulate_paths takes
+        # steps_per_day as an argument, so the constant is only the default;
+        # reporting it would make a persisted row claim a density that was not
+        # used the moment anything passes an override. Issue #119 is exactly
+        # that change.
+        "steps_per_day": priced.steps_per_day,
         "market_type": market_type_used,
         "question": question or f"Will {asset} hit ${target}?",
         "simulations": NUM_SIMULATIONS,

--- a/src/trading/simulation.py
+++ b/src/trading/simulation.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Pricing kernel for the Monte Carlo worker. Pure, no network, no Flask.
+
+Split out of monte_carlo.py on 2026-09-07 so the pricing ARITHMETIC can be
+tested directly against known parameters. monte_carlo.py keeps the Flask app,
+the yfinance fetching and the macro adjustment, and calls into here for the
+maths, so the served path and the tested path cannot diverge.
+
+The split is also what makes the tests runnable: CI installs only
+src/trade_engine/requirements.txt, and importing monte_carlo.py drags in flask,
+yfinance and scipy. This module needs numpy and the stdlib, which is why the
+module that prices real money finally has a test suite.
+
+NOTHING IN HERE MAY IMPORT flask, yfinance OR scipy.
+"""
+
+from collections import namedtuple
+import math
+import re
+
+import numpy as np
+
+NUM_SIMULATIONS = 10_000
+
+# --- horizon discretisation --------------------------------------------------
+#
+# `horizon_days` is a FLOAT and is a TOTAL TIME, not a step count.
+#
+# Until 2026-09-07 the scanner rounded it up with math.ceil before it ever
+# arrived here, and the worker then used the result as both the total time AND
+# the step count with dt hardwired to 1.0. A 3,558-second market (0.0412d) was
+# therefore priced over a full day: P 0.0648 -> 0.4834, edge +3.9pts ->
+# +45.8pts, and position e09b82fe fired at the $10 cap for a total loss. The
+# error direction was constant, a shorter real horizon rounded up means the
+# price diffuses for longer than the market has, which overstates the
+# probability of reaching the target, which inflates the edge, which maximises
+# position size.
+#
+# STEPS_PER_DAY is deliberately 1, which is the density that has always been in
+# force (steps == whole days). RAISING IT IS A SIZING DECISION, NOT A TUNING
+# KNOB. It needs its own approval before it ships, and the reason is not
+# conservatism:
+#
+# A discrete path only observes the barrier at step boundaries, so it
+# undercounts crossings, and undercounts more at coarser grids. Refining the
+# grid therefore RAISES every touch_* probability, which raises edge, which
+# raises position size and, the effect that actually matters, recruits
+# markets that currently sit below the 7-point edge floor. Measured on the four
+# historical touch_* positions (400k paths, 2026-09-07), an hourly grid lifts
+# edges by +0.7 to +6.4 points against a 7-point floor; cee4eacd moves from
+# 6.13 to 6.80 points, i.e. 0.2 points short of qualifying. On that sample it
+# roughly doubles the population of markets that would propose while barely
+# resizing the ones already taken. That is an exposure change wearing the
+# costume of an accuracy fix.
+#
+# close_above / close_below are unaffected by this constant either way: summing
+# n increments of N(nu*dt, sigma^2*dt) gives N(nu*T, sigma^2*T) for any n, so
+# the terminal law, and every close_* probability, is step-invariant.
+# test_monte_carlo_horizon.py asserts both halves of that claim.
+STEPS_PER_DAY = 1
+
+# Bound on the path array so a future STEPS_PER_DAY increase cannot silently
+# allocate gigabytes: the arrays are (NUM_SIMULATIONS x steps) float64, so at
+# the 35-day scanner ceiling an hourly grid is already ~200MB per call.
+MAX_STEPS = 2_000
+
+# NUMERICAL SAFETY FLOOR ONLY. This is NOT a validity threshold, and relaxing
+# it does not make short-horizon pricing sound.
+#
+# As T -> 0 the diffusion term sigma*sqrt(T) -> 0 and the model collapses into a
+# step function. At e09b82fe's own parameters, measured 2026-09-07: an
+# out-of-the-money target gives P = 0.0008 at T = 0.01d and 0.0000 by T = 0.001d,
+# while an in-the-money target gives P = 0.9995 at T = 0.01d and 1.0000 below
+# that, a confident, maximum-size +97-point edge. That is the same bug as the
+# ceil() above with the sign flipped.
+#
+# 0.01 SITS INSIDE THAT DEGENERATE REGION BY DESIGN. Its job is to stop T = 0
+# and to stop the simulator emitting a hard 0.0000/1.0000. No single value can
+# make the model valid, because degeneracy depends on sigma*sqrt(T) relative to
+# the distance to target, which is per-market.
+#
+# The control that actually protects the money path is
+# MIN_HORIZON_TRADEABLE_DAYS = 1.0, enforced in PolymarketScanner.analyse_edge
+# and again in TradeExecutor GATE 7. If you are reading this because a
+# short-dated market was refused, THAT is the constant you are looking for.
+# Lowering this one instead would strip the arithmetic guard and leave the
+# refusal exactly where it was.
+MIN_HORIZON_MODEL_DAYS = 0.01
+
+# What the kernel actually priced, carried back so a persisted simulation row
+# records its own discretisation. The ceil() bug survived 5,649 stored rows
+# partly because none of them recorded the effective horizon or the step count.
+PricedPaths = namedtuple("PricedPaths", "hits total steps dt horizon_days_model")
+
+
+def wilson_interval(successes, total, z=1.96):
+    """Wilson score interval for binomial proportion."""
+    if total == 0:
+        return 0.0, 0.0, 0.0
+    p_hat = successes / total
+    denom = 1 + z**2 / total
+    centre = (p_hat + z**2 / (2 * total)) / denom
+    spread = z * math.sqrt((p_hat * (1 - p_hat) + z**2 / (4 * total)) / total) / denom
+    return round(centre, 4), round(max(0, centre - spread), 4), round(min(1, centre + spread), 4)
+
+
+def detect_market_type(question, target, current_price):
+    """
+    Detect whether this is a touch market or close-on-date market.
+
+    Touch market: "will X dip to/reach/hit Y", checks any path touch
+    Close-on-date: "will X be above/below Y on [date]", checks final price only
+
+    Returns: 'touch_above' | 'touch_below' | 'close_above' | 'close_below'
+    """
+    q = (question or '').lower()
+
+    # Close-on-date patterns: "above X on [date]" or "over X on [date]"
+    if re.search(r'\b(above|over)\b', q) and re.search(r'\bon\b', q):
+        return 'close_above'
+
+    # Close-on-date patterns: "below X on [date]" or "under X on [date]"
+    if re.search(r'\b(below|under)\b', q) and re.search(r'\bon\b', q):
+        return 'close_below'
+
+    # Touch market: direction based on target vs current price
+    if target < current_price:
+        return 'touch_below'
+    return 'touch_above'
+
+
+def coerce_horizon(raw):
+    """Parse a request's horizon_days. Returns (value, error), never raises.
+
+    float(), NOT int(). The int() this replaced was a SECOND, independent
+    truncation sitting downstream of the scanner's math.ceil, and fixing only
+    the scanner would have made things WORSE rather than better:
+
+      int(0.0412) == 0  ->  steps == 0  ->  a (num_simulations x 0) path array.
+
+    np.any(empty, axis=1) is all-False, so every touch_* market would have
+    priced at a SILENT P = 0.0 and been persisted as real data. close_* markets
+    fail loudly instead, paths[:, -1] raises IndexError on the empty axis.
+    A silent wrong number is the worse of the two, so this rejects rather than
+    coerces anything that is not a usable positive horizon.
+    """
+    try:
+        value = float(raw)
+    except (ValueError, TypeError):
+        return None, "horizon_days must be numeric"
+    if not math.isfinite(value):
+        return None, "horizon_days must be finite"
+    if value <= 0:
+        return None, "horizon_days must be greater than zero"
+    return value, None
+
+
+def steps_for_horizon(horizon_days, steps_per_day=STEPS_PER_DAY):
+    """Step count for a horizon, decoupled from the horizon's magnitude.
+
+    At the default STEPS_PER_DAY = 1 this returns exactly the old
+    `steps = horizon_days` for whole-day horizons, so the discretisation of
+    every market at or above the 1-day tradeable floor is unchanged by the
+    fractional fix, that is what makes this a pure arithmetic correction and
+    not a re-pricing. Sub-day horizons get 1 step rather than the 0 that
+    truncation used to produce.
+    """
+    return int(min(MAX_STEPS, max(1, math.ceil(horizon_days * steps_per_day))))
+
+
+def simulate_paths(current_price, target, mu, sigma, horizon_days, market_type,
+                   num_simulations=NUM_SIMULATIONS, steps_per_day=STEPS_PER_DAY,
+                   rng=None):
+    """Price one market by GBM path simulation.
+
+    `mu` and `sigma` are per DAY. `horizon_days` is the TOTAL time in days and
+    may be fractional; dt is DERIVED from it as horizon/steps rather than
+    assumed to be 1.0, so drift scales with dt and diffusion with sqrt(dt).
+    Getting that pair the wrong way round is the whole bug class this function
+    exists to contain, so it is asserted directly in the tests.
+
+    `rng` is injectable so a test can be deterministic. Production leaves it
+    None, which reseeds from the OS per call, matching the np.random.seed(None)
+    the old inline implementation did.
+    """
+    horizon_model = max(float(horizon_days), MIN_HORIZON_MODEL_DAYS)
+    steps = steps_for_horizon(horizon_model, steps_per_day)
+    dt = horizon_model / steps
+
+    if rng is None:
+        rng = np.random.default_rng()
+    Z = rng.standard_normal((num_simulations, steps))
+
+    drift = (mu - 0.5 * sigma**2) * dt
+    diffusion = sigma * np.sqrt(dt) * Z
+
+    log_increments = drift + diffusion
+    log_paths = np.cumsum(log_increments, axis=1)
+    paths = current_price * np.exp(log_paths)
+
+    if market_type == 'close_above':
+        hits = (paths[:, -1] >= target).sum()
+    elif market_type == 'close_below':
+        hits = (paths[:, -1] <= target).sum()
+    elif market_type == 'touch_above':
+        hits = np.any(paths >= target, axis=1).sum()
+    else:  # touch_below
+        hits = np.any(paths <= target, axis=1).sum()
+
+    return PricedPaths(int(hits), num_simulations, steps, dt, horizon_model)

--- a/src/trading/simulation.py
+++ b/src/trading/simulation.py
@@ -91,7 +91,9 @@ MIN_HORIZON_MODEL_DAYS = 0.01
 # What the kernel actually priced, carried back so a persisted simulation row
 # records its own discretisation. The ceil() bug survived 5,649 stored rows
 # partly because none of them recorded the effective horizon or the step count.
-PricedPaths = namedtuple("PricedPaths", "hits total steps dt horizon_days_model")
+PricedPaths = namedtuple(
+    "PricedPaths", "hits total steps dt horizon_days_model steps_per_day"
+)
 
 
 def wilson_interval(successes, total, z=1.96):
@@ -208,4 +210,6 @@ def simulate_paths(current_price, target, mu, sigma, horizon_days, market_type,
     else:  # touch_below
         hits = np.any(paths <= target, axis=1).sum()
 
-    return PricedPaths(int(hits), num_simulations, steps, dt, horizon_model)
+    return PricedPaths(
+        int(hits), num_simulations, steps, dt, horizon_model, steps_per_day
+    )

--- a/src/trading/simulation.py
+++ b/src/trading/simulation.py
@@ -158,6 +158,30 @@ def coerce_horizon(raw):
     return value, None
 
 
+def coerce_target(raw):
+    """Parse a request's target price. Returns (value, error), never raises.
+
+    Lives here rather than inline in monte_carlo.py's route for one reason:
+    importing monte_carlo.py needs flask, yfinance and scipy, none of which CI
+    installs, so a guard written there is unreachable by the test suite. It was
+    written there first, and deleting it left the suite green. A guard CI cannot
+    reach is not a guard.
+
+    Rejects rather than coerces a non-finite target. NaN would propagate
+    silently through every comparison in simulate_paths: `paths >= nan` is
+    all-False, so a touch market would price at P = 0.0 and a close market the
+    same, which is the identical silent-zero failure that int(0.0412) produced
+    on the horizon side.
+    """
+    try:
+        value = float(raw)
+    except (ValueError, TypeError):
+        return None, "target must be numeric"
+    if not math.isfinite(value):
+        return None, "target must be finite"
+    return value, None
+
+
 def steps_for_horizon(horizon_days, steps_per_day=STEPS_PER_DAY):
     """Step count for a horizon, decoupled from the horizon's magnitude.
 

--- a/src/trading/simulation.py
+++ b/src/trading/simulation.py
@@ -51,7 +51,8 @@ NUM_SIMULATIONS = 10_000
 # 6.13 to 6.80 points, i.e. 0.2 points short of qualifying. On that sample it
 # roughly doubles the population of markets that would propose while barely
 # resizing the ones already taken. That is an exposure change wearing the
-# costume of an accuracy fix.
+# costume of an accuracy fix. Tracked with the full table as issue #119;
+# docs/trade-engine-horizon-rebaseline.md has the method.
 #
 # close_above / close_below are unaffected by this constant either way: summing
 # n increments of N(nu*dt, sigma^2*dt) gives N(nu*T, sigma^2*T) for any n, so

--- a/tests/test_analyst.py
+++ b/tests/test_analyst.py
@@ -205,6 +205,39 @@ class TestHistoryPopulated(unittest.TestCase):
         self.assertNotIn("None", prompt.split("Recent trades")[1])
 
 
+class TestPromptHorizonFormatting(unittest.TestCase):
+    """The horizon line in the Claude prompt, which nothing asserted on.
+
+    approval.py's identical `:.2f` is covered by
+    test_fractional_horizon_renders_readably in tests/test_approval.py, and
+    reverting analyst.py's left the suite green. Same change, same reason, one
+    of them tested. horizon_days is fractional since 2026-09-08, so unformatted
+    it renders as 20.582881944444444: unreadable, and wasted prompt tokens on a
+    money-path decision.
+    """
+
+    def build(self, horizon):
+        patch_history(self, [])
+        analyst = TradeAnalyst(client=StubClient(text=VALID_JSON))
+        ctx = run(analyst.get_trade_history_context())
+        return analyst.build_prompt(make_candidate(horizon_days=horizon), ctx)
+
+    def test_fractional_horizon_is_rounded_for_the_prompt(self):
+        prompt = self.build(20.582881944444444)
+        self.assertIn("Horizon: 20.58 days", prompt)
+        self.assertNotIn("20.582", prompt)
+
+    def test_sub_day_horizon_still_renders_a_value(self):
+        """e09b82fe's own horizon. It must not render as "Horizon: 0 days",
+        which would read to Claude as a market with no time left rather than
+        one with an hour."""
+        prompt = self.build(0.04117943363425926)
+        self.assertIn("Horizon: 0.04 days", prompt)
+
+    def test_whole_day_horizon_is_unsurprising(self):
+        self.assertIn("Horizon: 21.00 days", self.build(21.0))
+
+
 # 4. Happy path parse
 class TestAnalyseParsesJson(unittest.TestCase):
     def test_parses_structured_response(self):

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -192,7 +192,7 @@ class SendApprovalRequestTest(unittest.TestCase):
         self.assertIn("Will Bitcoin reach $100,000 in July?", text)
         self.assertIn("Direction: BUY YES", text)
         self.assertIn("Edge: +18.0% (Sim: 36.0% vs Market: 18.0%)", text)
-        self.assertIn("Volume: $26,352 | Horizon: 4d", text)
+        self.assertIn("Volume: $26,352 | Horizon: 4.00d", text)
         self.assertIn("Position: $10.00", text)
         self.assertIn("📊 Analyst: PROCEED (72% confidence)", text)
         self.assertIn('"Edge is wide and the horizon is short."', text)
@@ -214,6 +214,21 @@ class SendApprovalRequestTest(unittest.TestCase):
 
         self.assertEqual(pending.message_id, 4201)
         self.assertEqual(gate.pending_count, 1)
+
+    def test_fractional_horizon_renders_readably(self):
+        """horizon_days is fractional since 2026-09-07.
+
+        This is the number a human reads while deciding whether to spend money,
+        so an unformatted 20.582881944444444d is not a cosmetic problem. The
+        message must stay scannable at both ends of the range.
+        """
+        gate = StubGate()
+        run(gate.send_approval_request(
+            make_candidate(horizon_days=20.58289546928241), make_recommendation()
+        ))
+        text = gate.calls_to("sendMessage")[0]["text"]
+        self.assertIn("Horizon: 20.58d", text)
+        self.assertNotIn("20.582", text)
 
     def test_negative_edge_renders_signed_not_double_signed(self):
         gate = StubGate()

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -12,6 +12,7 @@ Run:
 """
 
 import asyncio
+import contextlib
 import json
 import os
 import subprocess
@@ -75,7 +76,28 @@ def make_candidate(**overrides) -> ScannerCandidate:
     return ScannerCandidate(**base)
 
 
-def make_approval(status=ApprovalStatus.approved, **cand) -> ApprovalResult:
+@contextlib.contextmanager
+def frozen_clock(moment):
+    """Freeze executor.datetime.now() at `moment` for the duration.
+
+    Only .now() is controlled; horizon.py keeps its own real datetime, so
+    end_date parsing is untouched and the test varies exactly one thing.
+
+    executor._staleness_reason reads the same clock, which is why every caller
+    also pins decided_at to `moment`: otherwise moving the clock forward trips
+    stale_approval first and the horizon gate is never reached.
+    """
+    real = executor_mod.datetime
+    executor_mod.datetime = type(
+        "FrozenDatetime", (), {"now": staticmethod(lambda tz=None: moment)}
+    )
+    try:
+        yield
+    finally:
+        executor_mod.datetime = real
+
+
+def make_approval(status=ApprovalStatus.approved, decided_at=None, **cand) -> ApprovalResult:
     return ApprovalResult(
         approval_id="ap-1",
         status=status,
@@ -84,7 +106,7 @@ def make_approval(status=ApprovalStatus.approved, **cand) -> ApprovalResult:
             recommendation="reduce", confidence=0.45,
             reasoning="Edge is wide but history is thin.", flags=[],
         ),
-        decided_at=datetime.now(timezone.utc),
+        decided_at=decided_at or datetime.now(timezone.utc),
         decision_source="user",
     )
 
@@ -357,6 +379,50 @@ class GateTest(unittest.TestCase):
         # The executor, now, must refuse it.
         self.assert_blocked(
             "horizon_below_minimum", end_date=end_date, horizon_days=at_scan
+        )
+
+    def test_gate7_is_evaluated_at_execution_time_not_at_import(self):
+        """Hold the candidate FIXED and move the CLOCK. One variable.
+
+        The decay test above moves the END DATE back 2100s. That separates
+        "recomputed from end_date" from "reads the frozen horizon_days", and it
+        cannot separate "recomputed at execution" from "recomputed at import":
+        every other gate-7 test builds end_date relative to the instant it runs,
+        so an import-time clock and an execution-time clock are milliseconds
+        apart and agree on every one of them.
+
+        A build that captured the clock once at module scope therefore passed
+        the entire suite 75/75, including the decay sentinel run alone, while
+        being a real regression: at T+2.5s it places an order the correct build
+        refuses.
+
+        The SAME candidate, byte for byte, must be admitted at t and refused at
+        t+2100s. Nothing but the clock changes.
+        """
+        base = datetime.now(timezone.utc)
+        # 1.0007d at base: over the floor, and under it after 2100s of decay.
+        end_date = (base + timedelta(days=1.0, seconds=60)).strftime(
+            "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+
+        admitted = StubExecutor()
+        with DBStub(), frozen_clock(base):
+            ok = run(admitted.execute(
+                make_approval(end_date=end_date, decided_at=base)
+            ))
+        self.assertTrue(ok.success, "must be admitted at t")
+        self.assertEqual(len(admitted.argv_calls), 1)
+
+        later = base + timedelta(seconds=2100)
+        refused = StubExecutor()
+        with DBStub(), frozen_clock(later):
+            blocked = run(refused.execute(
+                make_approval(end_date=end_date, decided_at=later)
+            ))
+        self.assertFalse(blocked.success, "must be refused at t+2100s")
+        self.assertEqual(blocked.gate_blocked, "horizon_below_minimum")
+        self.assertEqual(
+            refused.argv_calls, [], "a blocked trade must not run the script"
         )
 
     def test_gate7_uses_the_clock_not_the_frozen_field(self):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -280,6 +280,45 @@ class GateTest(unittest.TestCase):
     def test_gate6_rejects_malformed_hex(self):
         self.assert_blocked("invalid_market_identifier", condition_id="0xdeadbeef")
 
+    # --- GATE 7, the tradeable-horizon floor ------------------------------
+    #
+    # These deliberately DO NOT go through the scanner. The scanner refuses
+    # sub-day markets too, but the whole point of gate 7 is that the executor
+    # refuses independently: a candidate can reach execute() from a 30-minute-
+    # old approval, from a persisted ApprovalResult, or from a scanner running
+    # older code. Constructing the candidate directly is what proves the two
+    # layers are independent rather than one guard tested twice.
+
+    def test_gate7_refuses_the_e09b82fe_horizon(self):
+        """0.0412d, the 3,558-second market that cost $10.69.
+
+        Edge is left at the fixture's healthy 0.2164 on purpose: this must be
+        refused on horizon ALONE, with nothing wrong with the edge.
+        """
+        self.assert_blocked("horizon_below_minimum", horizon_days=0.041181)
+
+    def test_gate7_refuses_just_under_the_floor(self):
+        self.assert_blocked("horizon_below_minimum", horizon_days=0.999)
+
+    def test_gate7_admits_exactly_the_floor(self):
+        """1.0d is tradeable, the floor is a minimum, not an exclusive bound."""
+        ex = StubExecutor()
+        with DBStub():
+            result = run(ex.execute(make_approval(horizon_days=1.0)))
+        self.assertTrue(result.success)
+
+    def test_gate7_admits_a_fractional_horizon_above_the_floor(self):
+        """20.58d must trade normally; this gate refuses SHORT, not FRACTIONAL."""
+        ex = StubExecutor()
+        with DBStub():
+            result = run(ex.execute(make_approval(horizon_days=20.582881944)))
+        self.assertTrue(result.success)
+
+    def test_gate7_fails_closed_on_non_finite_horizon(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(horizon=bad):
+                self.assert_blocked("horizon_below_minimum", horizon_days=bad)
+
     def test_unapproved_status_refused(self):
         for status in (ApprovalStatus.skipped, ApprovalStatus.timeout,
                        ApprovalStatus.analyst_skip, ApprovalStatus.pending):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -61,6 +61,13 @@ def make_candidate(**overrides) -> ScannerCandidate:
         market_probability=0.0875,
         volume=37494.25,
         horizon_days=1,
+        # GATE 7 recomputes the horizon from end_date against the live clock,
+        # so every candidate needs one. Far future by default; the GATE 7 tests
+        # below override it to put the market at a specific distance from the
+        # floor.
+        end_date=(datetime.now(timezone.utc) + timedelta(days=21)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        ),
         market_url="https://polymarket.com/market/eth-above-1900",
         amount_usdc=5.0,
     )
@@ -282,12 +289,16 @@ class GateTest(unittest.TestCase):
 
     # --- GATE 7, the tradeable-horizon floor ------------------------------
     #
-    # These deliberately DO NOT go through the scanner. The scanner refuses
-    # sub-day markets too, but the whole point of gate 7 is that the executor
-    # refuses independently: a candidate can reach execute() from a 30-minute-
-    # old approval, from a persisted ApprovalResult, or from a scanner running
-    # older code. Constructing the candidate directly is what proves the two
-    # layers are independent rather than one guard tested twice.
+    # GATE 7 RECOMPUTES the horizon from end_date against the clock at
+    # execution. It does not read candidate.horizon_days, which is frozen at
+    # scan time. These tests drive it by end_date for that reason, and the
+    # decay test below is the one that distinguishes the two.
+
+    @staticmethod
+    def ends_in(**delta):
+        return (datetime.now(timezone.utc) + timedelta(**delta)).strftime(
+            "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
 
     def test_gate7_refuses_the_e09b82fe_horizon(self):
         """0.0412d, the 3,558-second market that cost $10.69.
@@ -295,29 +306,80 @@ class GateTest(unittest.TestCase):
         Edge is left at the fixture's healthy 0.2164 on purpose: this must be
         refused on horizon ALONE, with nothing wrong with the edge.
         """
-        self.assert_blocked("horizon_below_minimum", horizon_days=0.041181)
+        self.assert_blocked("horizon_below_minimum", end_date=self.ends_in(seconds=3558))
 
     def test_gate7_refuses_just_under_the_floor(self):
-        self.assert_blocked("horizon_below_minimum", horizon_days=0.999)
+        self.assert_blocked("horizon_below_minimum", end_date=self.ends_in(days=0.999))
 
-    def test_gate7_admits_exactly_the_floor(self):
-        """1.0d is tradeable, the floor is a minimum, not an exclusive bound."""
+    def test_gate7_refuses_a_market_that_has_already_resolved(self):
+        self.assert_blocked("horizon_below_minimum", end_date=self.ends_in(days=-1))
+
+    def test_gate7_admits_a_market_with_headroom(self):
+        """The gate refuses SHORT markets, not fractional ones."""
         ex = StubExecutor()
         with DBStub():
-            result = run(ex.execute(make_approval(horizon_days=1.0)))
+            result = run(ex.execute(make_approval(end_date=self.ends_in(days=20.58))))
         self.assertTrue(result.success)
 
-    def test_gate7_admits_a_fractional_horizon_above_the_floor(self):
-        """20.58d must trade normally; this gate refuses SHORT, not FRACTIONAL."""
-        ex = StubExecutor()
-        with DBStub():
-            result = run(ex.execute(make_approval(horizon_days=20.582881944)))
-        self.assertTrue(result.success)
+    # --- the decay case, which is the whole reason GATE 7 exists -----------
 
-    def test_gate7_fails_closed_on_non_finite_horizon(self):
-        for bad in (float("nan"), float("inf"), float("-inf")):
-            with self.subTest(horizon=bad):
-                self.assert_blocked("horizon_below_minimum", horizon_days=bad)
+    def test_gate7_refuses_a_market_that_decayed_below_the_floor_since_the_scan(self):
+        """THE independence test. The scanner admitted it; the executor must not.
+
+        A market at EXACTLY the 1.00d floor when the scanner proposed it is
+        0.976d by the time the order can go out: APPROVAL_TIMEOUT_SECONDS
+        (1800) plus APPROVAL_MAX_AGE_SECONDS (300) is 2100s of decay. Reading
+        the frozen candidate.horizon_days passes it. Recomputing refuses it.
+
+        The candidate carries horizon_days=1.0, the honest scan-time value, so
+        this fails the moment the gate goes back to trusting that field. That is
+        what makes the two layers independent rather than one check written
+        twice: they evaluate the same property against different clocks.
+        """
+        decay = executor_mod.APPROVAL_MAX_AGE_SECONDS + 1800
+        self.assertEqual(decay, 2100)
+        scan_time = datetime.now(timezone.utc) - timedelta(seconds=decay)
+        end_date = (scan_time + timedelta(days=1.0)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+        # The scanner, at scan time, would have admitted this: exactly the floor.
+        at_scan = PolymarketScanner._horizon_days(end_date, scan_time)
+        self.assertAlmostEqual(at_scan, 1.0, places=6)
+        self.assertGreaterEqual(at_scan, executor_mod.config.min_horizon_tradeable_days)
+
+        # The executor, now, must refuse it.
+        self.assert_blocked(
+            "horizon_below_minimum", end_date=end_date, horizon_days=at_scan
+        )
+
+    def test_gate7_uses_the_clock_not_the_frozen_field(self):
+        """Same property from the other side: a stale field must not save it.
+
+        horizon_days claims a healthy 21 days. end_date says 10 minutes. The
+        gate must believe end_date.
+        """
+        self.assert_blocked(
+            "horizon_below_minimum",
+            end_date=self.ends_in(minutes=10),
+            horizon_days=21.0,
+        )
+
+    # --- fail closed -------------------------------------------------------
+
+    def test_gate7_fails_closed_on_missing_end_date(self):
+        """An unknown resolution time is refused, never backfilled from the
+        scan-time snapshot."""
+        for absent in (None, ""):
+            with self.subTest(end_date=absent):
+                self.assert_blocked(
+                    "horizon_below_minimum", end_date=absent, horizon_days=21.0
+                )
+
+    def test_gate7_fails_closed_on_unparseable_end_date(self):
+        for bad in ("not-a-date", "2026-13-45T99:99:99Z", "soon"):
+            with self.subTest(end_date=bad):
+                self.assert_blocked(
+                    "horizon_below_minimum", end_date=bad, horizon_days=21.0
+                )
 
     def test_unapproved_status_refused(self):
         for status in (ApprovalStatus.skipped, ApprovalStatus.timeout,

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -315,10 +315,18 @@ class GateTest(unittest.TestCase):
         self.assert_blocked("horizon_below_minimum", end_date=self.ends_in(days=-1))
 
     def test_gate7_admits_a_market_with_headroom(self):
-        """The gate refuses SHORT markets, not fractional ones."""
+        """The gate refuses SHORT markets, not fractional ones.
+
+        horizon_days is fractional here as well as end_date, because every real
+        candidate carries one since 2026-09-08 and the money path must accept it
+        end to end. Without this the executor suite passes with
+        ScannerCandidate.horizon_days back as an int.
+        """
         ex = StubExecutor()
         with DBStub():
-            result = run(ex.execute(make_approval(end_date=self.ends_in(days=20.58))))
+            result = run(ex.execute(make_approval(
+                end_date=self.ends_in(days=20.58), horizon_days=20.582881944,
+            )))
         self.assertTrue(result.success)
 
     # --- the decay case, which is the whole reason GATE 7 exists -----------

--- a/tests/test_monte_carlo_horizon.py
+++ b/tests/test_monte_carlo_horizon.py
@@ -299,6 +299,44 @@ class StepPolicyTest(unittest.TestCase):
             with self.subTest(days=days):
                 self.assertEqual(steps_for_horizon(float(days)), days)
 
+    def test_steps_for_horizon_rounds_UP_not_to_nearest(self):
+        """ceil, not round. The whole-day cases above cannot tell them apart.
+
+        Every value there has no fractional part, so `round` passes all of them
+        and the distinction only shows on a fraction below 0.5. That matters
+        because steps is the sizing lever: rounding to nearest gives a 20.333d
+        market 20 barrier observations instead of 21, and fewer observations
+        means a lower touch probability, a smaller edge and a smaller position.
+        Silent, and in the direction that looks like caution.
+
+        20.333 and 11.416 are the real horizons of positions 71f8a608 and
+        f4be9ee8 from the re-baseline table, both of which `round` gets wrong.
+        """
+        for horizon, ceil_steps, round_steps in (
+            (20.333, 21, 20),   # 71f8a608, BTC touch_below
+            (11.416, 12, 11),   # f4be9ee8, ETH touch_above
+            (4.2, 5, 4),
+            (1.001, 2, 1),
+            (0.0412, 1, 0),     # `round` gives 0 here: the empty-array path
+        ):
+            with self.subTest(horizon=horizon):
+                self.assertNotEqual(
+                    ceil_steps, round_steps, "test case cannot distinguish them"
+                )
+                self.assertEqual(steps_for_horizon(horizon), ceil_steps)
+
+    def test_steps_for_horizon_reports_the_density_it_used(self):
+        """PricedPaths carries steps_per_day so a persisted row cannot claim a
+        density that was not used. See issue #119."""
+        for spd in (1, 4, 24):
+            with self.subTest(steps_per_day=spd):
+                priced = simulate_paths(
+                    SPOT, TARGET, MU, SIGMA, 5.0, MARKET_TYPE,
+                    num_simulations=100, steps_per_day=spd, rng=rng(),
+                )
+                self.assertEqual(priced.steps_per_day, spd)
+                self.assertEqual(priced.steps, steps_for_horizon(5.0, spd))
+
     def test_steps_for_horizon_is_capped(self):
         self.assertEqual(steps_for_horizon(35.0, steps_per_day=10_000), MAX_STEPS)
 

--- a/tests/test_monte_carlo_horizon.py
+++ b/tests/test_monte_carlo_horizon.py
@@ -32,6 +32,7 @@ from src.trading.simulation import (  # noqa: E402
     MIN_HORIZON_MODEL_DAYS,
     STEPS_PER_DAY,
     coerce_horizon,
+    coerce_target,
     simulate_paths,
     steps_for_horizon,
 )
@@ -385,6 +386,50 @@ class ModelFloorTest(unittest.TestCase):
         )
         self.assertLess(out_of_money, 0.01)
         self.assertGreater(in_the_money, 0.99)
+
+
+class CoerceTargetTest(unittest.TestCase):
+    """The finite-target guard, now somewhere the suite can reach it.
+
+    This lived inline in monte_carlo.py's /simulate route, where deleting it
+    left the whole suite green: CI installs neither flask nor yfinance nor
+    scipy, so nothing could import the module it was written in. It is asserted
+    here for the same reason coerce_horizon is.
+    """
+
+    def test_ordinary_targets_pass_through(self):
+        for raw, expected in ((2500.0, 2500.0), (60000, 60000.0), ("1.01", 1.01)):
+            with self.subTest(raw=raw):
+                value, error = coerce_target(raw)
+                self.assertIsNone(error)
+                self.assertEqual(value, expected)
+
+    def test_non_finite_targets_are_refused(self):
+        """NaN is the dangerous one: `paths >= nan` is all-False, so it would
+        price every market at P = 0.0 rather than erroring. That is the same
+        silent-zero shape int(0.0412) produced on the horizon side."""
+        for raw in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(raw=raw):
+                value, error = coerce_target(raw)
+                self.assertIsNone(value)
+                self.assertEqual(error, "target must be finite")
+
+    def test_nan_would_otherwise_price_at_zero(self):
+        """Shows what the guard prevents, rather than only that it fires."""
+        for market_type in ("touch_above", "close_above"):
+            with self.subTest(market_type=market_type):
+                priced = simulate_paths(
+                    SPOT, float("nan"), MU, SIGMA, 5.0, market_type,
+                    num_simulations=1000, rng=rng(),
+                )
+                self.assertEqual(priced.hits, 0, "nan comparisons are all-False")
+
+    def test_garbage_is_refused(self):
+        for raw in (None, "", "abc", [], {}):
+            with self.subTest(raw=raw):
+                value, error = coerce_target(raw)
+                self.assertIsNone(value)
+                self.assertEqual(error, "target must be numeric")
 
 
 class CoerceHorizonTest(unittest.TestCase):

--- a/tests/test_monte_carlo_horizon.py
+++ b/tests/test_monte_carlo_horizon.py
@@ -1,0 +1,390 @@
+"""Tests for the Monte Carlo pricing kernel (src/trading/simulation.py).
+
+This module priced real money for months with no test coverage at all: CI
+installs only src/trade_engine/requirements.txt, and importing monte_carlo.py
+drags in flask, yfinance and scipy, so any test of it failed at import. The
+pricing arithmetic was split into simulation.py (numpy + stdlib only) so this
+file can exist.
+
+The centrepiece is a replay of position e09b82fe, the 3,558-second Ethereum
+market of 2026-08-31 that math.ceil priced as a full day. Its parameters are
+not invented, they are the values persisted in trading_simulations row
+de289c86-c1da-41c2-8a82-2115cc367053, read live on 2026-09-07.
+
+No network, no yfinance, no Flask. Every rng is seeded, so these are
+deterministic rather than "usually green".
+
+Run:
+    python3 -m unittest tests/test_monte_carlo_horizon.py
+"""
+
+import math
+import os
+import sys
+import unittest
+
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.trading.simulation import (  # noqa: E402
+    MAX_STEPS,
+    MIN_HORIZON_MODEL_DAYS,
+    STEPS_PER_DAY,
+    coerce_horizon,
+    simulate_paths,
+    steps_for_horizon,
+)
+
+# --- position e09b82fe, from trading_simulations de289c86 -------------------
+# "Will the price of Ethereum be above $2,500 on August 31?"
+# sim row created 2026-08-31T15:00:42Z, market endDate 2026-08-31T16:00:00Z.
+SPOT = 2467.93
+TARGET = 2500.0
+MU = 0.012066
+SIGMA = 0.040456
+MARKET_TYPE = "close_above"          # NOT a touch market, see the class docstring
+IMPLIED_ODDS = 0.0255                # what Polymarket was charging
+HORIZON_TRUE = 0.04117943363425926   # 3,557.903 seconds, exactly
+HORIZON_CEIL = 1.0                   # what math.ceil handed the simulator
+
+STORED_PROBABILITY = 0.4834          # what the worker actually returned that day
+HIGH_EDGE_THRESHOLD = 0.07           # config.high_edge_threshold, live value
+
+PATHS = 200_000                      # SE ~0.0005 at p=0.065; production runs 10k
+SEED = 20260907
+
+
+def rng():
+    return np.random.default_rng(SEED)
+
+
+def norm_cdf(x):
+    """Standard normal CDF. math.erf so this file needs no scipy."""
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def terminal_closed_form(spot, target, mu, sigma, horizon, market_type):
+    """Exact P for a close_* market under GBM.
+
+    Independent of the code under test and of the step count: log(S_T/S_0) is
+    N(nu*T, sigma^2*T), so this is the analytic answer the simulation must
+    reproduce. It is what turns "P is about 0.065" from a golden number into a
+    statement about whether drift and diffusion are scaled correctly.
+    """
+    nu = mu - 0.5 * sigma**2
+    z = (math.log(target / spot) - nu * horizon) / (sigma * math.sqrt(horizon))
+    return 1.0 - norm_cdf(z) if market_type == "close_above" else norm_cdf(z)
+
+
+def probability(horizon, market_type=MARKET_TYPE, steps_per_day=STEPS_PER_DAY,
+                spot=SPOT, target=TARGET, paths=PATHS):
+    priced = simulate_paths(
+        spot, target, MU, SIGMA, horizon, market_type,
+        num_simulations=paths, steps_per_day=steps_per_day, rng=rng(),
+    )
+    return priced.hits / priced.total
+
+
+class AcceptanceTest(unittest.TestCase):
+    """Replay of e09b82fe. This trade must not be placeable again.
+
+    e09b82fe is a close_above market, not a touch market, which matters twice
+    over: the lognormal closed form below is EXACT for it, and its probability
+    is invariant to the step count (StepPolicyTest proves that separately), so
+    these assertions cannot be perturbed by any future STEPS_PER_DAY decision.
+    """
+
+    def test_priced_at_the_true_horizon_it_is_below_the_edge_floor(self):
+        """THE acceptance test. P about 0.065, edge about 0.040, no proposal."""
+        p = probability(HORIZON_TRUE)
+        edge = p - IMPLIED_ODDS
+
+        self.assertAlmostEqual(p, 0.065, delta=0.005, msg=f"P={p:.4f}")
+        self.assertAlmostEqual(edge, 0.040, delta=0.005, msg=f"edge={edge:.4f}")
+        self.assertLess(
+            edge, HIGH_EDGE_THRESHOLD,
+            f"edge {edge:.4f} must fall below the {HIGH_EDGE_THRESHOLD} floor, "
+            "this is the trade that cost $10.69",
+        )
+
+    def test_the_old_ceil_horizon_would_still_fire(self):
+        """The counterfactual, asserted so the fix cannot be quietly reverted.
+
+        At the ceil()-rounded 1-day horizon the same market clears the floor by
+        a mile. If this ever stops being true the bug has been misdiagnosed.
+        """
+        p = probability(HORIZON_CEIL)
+        edge = p - IMPLIED_ODDS
+
+        self.assertGreater(edge, HIGH_EDGE_THRESHOLD)
+        self.assertGreater(edge, 0.40, f"edge={edge:.4f}")
+
+    def test_the_ceil_horizon_reproduces_the_persisted_probability(self):
+        """Ties this file to production ground truth.
+
+        trading_simulations.de289c86 stored probability = 0.4834 from a 10,000
+        path run. Reproducing it here is what proves the kernel models what the
+        worker actually did, rather than what this test wishes it did.
+        """
+        p = probability(HORIZON_CEIL)
+        self.assertAlmostEqual(
+            p, STORED_PROBABILITY, delta=0.01,
+            msg=f"kernel {p:.4f} vs persisted {STORED_PROBABILITY}",
+        )
+
+    def test_simulation_matches_the_exact_closed_form(self):
+        """Catches a wrongly-scaled dt that still produces a plausible number."""
+        for horizon in (HORIZON_TRUE, HORIZON_CEIL, 5.0, 20.583):
+            with self.subTest(horizon=horizon):
+                mc = probability(horizon)
+                exact = terminal_closed_form(
+                    SPOT, TARGET, MU, SIGMA, horizon, MARKET_TYPE
+                )
+                self.assertAlmostEqual(
+                    mc, exact, delta=0.006,
+                    msg=f"horizon={horizon}: MC {mc:.4f} vs exact {exact:.4f}",
+                )
+
+    def test_the_error_direction_is_one_way(self):
+        """Rounding a horizon UP always overstates P for this market.
+
+        The loss was not bad luck on a noisy estimate, the bias has a fixed
+        sign, which is why it produced a maximum-size position rather than a
+        random one.
+        """
+        previous = 0.0
+        for horizon in (HORIZON_TRUE, 0.1, 0.25, 0.5, HORIZON_CEIL):
+            p = probability(horizon)
+            self.assertGreater(
+                p, previous,
+                f"P must increase monotonically with horizon (at {horizon})",
+            )
+            previous = p
+
+
+class DtScalingTest(unittest.TestCase):
+    """dt is derived, and drift/diffusion scale by dt and sqrt(dt).
+
+    Asserted on the moments of the terminal log-return rather than on a
+    probability, because that isolates the scaling from everything else. If
+    drift and diffusion are swapped, or dt is pinned back to 1.0, the variance
+    check fails immediately and unambiguously.
+    """
+
+    def terminal_log_returns(self, horizon, steps_per_day):
+        priced = simulate_paths(
+            SPOT, TARGET, MU, SIGMA, horizon, MARKET_TYPE,
+            num_simulations=PATHS, steps_per_day=steps_per_day, rng=rng(),
+        )
+        # Re-derive the same paths to inspect their terminal values.
+        r = rng()
+        steps = priced.steps
+        dt = priced.dt
+        Z = r.standard_normal((PATHS, steps))
+        increments = (MU - 0.5 * SIGMA**2) * dt + SIGMA * np.sqrt(dt) * Z
+        return np.cumsum(increments, axis=1)[:, -1], priced
+
+    def test_dt_is_horizon_over_steps_not_one(self):
+        for horizon, spd in ((HORIZON_TRUE, 1), (20.583, 1), (4.666, 1), (12.0, 1)):
+            with self.subTest(horizon=horizon):
+                priced = simulate_paths(
+                    SPOT, TARGET, MU, SIGMA, horizon, MARKET_TYPE,
+                    num_simulations=100, steps_per_day=spd, rng=rng(),
+                )
+                self.assertAlmostEqual(
+                    priced.dt * priced.steps, horizon, places=9,
+                    msg="steps * dt must reconstruct the horizon exactly",
+                )
+
+    def test_terminal_variance_is_sigma_squared_times_T(self):
+        """Diffusion scales with sqrt(dt): Var[log S_T/S_0] = sigma^2 * T."""
+        for horizon in (HORIZON_TRUE, 5.0, 20.583):
+            with self.subTest(horizon=horizon):
+                terminal, _ = self.terminal_log_returns(horizon, 1)
+                expected = SIGMA**2 * horizon
+                self.assertAlmostEqual(
+                    float(np.var(terminal)) / expected, 1.0, delta=0.02,
+                    msg=f"var {np.var(terminal):.8f} vs sigma^2*T {expected:.8f}",
+                )
+
+    def test_terminal_mean_is_nu_times_T(self):
+        """Drift scales with dt: E[log S_T/S_0] = (mu - sigma^2/2) * T."""
+        for horizon in (5.0, 20.583):
+            with self.subTest(horizon=horizon):
+                terminal, _ = self.terminal_log_returns(horizon, 1)
+                expected = (MU - 0.5 * SIGMA**2) * horizon
+                self.assertAlmostEqual(
+                    float(np.mean(terminal)), expected,
+                    delta=4 * SIGMA * math.sqrt(horizon) / math.sqrt(PATHS),
+                    msg=f"mean {np.mean(terminal):.8f} vs nu*T {expected:.8f}",
+                )
+
+    def test_variance_is_invariant_to_step_count(self):
+        """Refining the grid must not change the total variance, only the
+        resolution at which the path is observed."""
+        variances = []
+        for spd in (1, 4, 24):
+            terminal, _ = self.terminal_log_returns(20.583, spd)
+            variances.append(float(np.var(terminal)))
+        for v in variances[1:]:
+            self.assertAlmostEqual(v / variances[0], 1.0, delta=0.03)
+
+
+class StepPolicyTest(unittest.TestCase):
+    """STEPS_PER_DAY is a sizing control, and the tests say so."""
+
+    def test_steps_per_day_is_one(self):
+        """Tripwire. Raising this re-prices every touch_* market UPWARD.
+
+        Measured on the four historical touch_* positions (400k paths,
+        2026-09-07), an hourly grid lifts edges by +0.7 to +6.4 points against
+        a 7-point floor and roughly doubles the population of markets that
+        would qualify. That is an exposure decision requiring sign-off, not a
+        tuning change. If you are changing this, the approval comes first and
+        this assertion changes with it.
+        """
+        self.assertEqual(STEPS_PER_DAY, 1)
+
+    def test_close_markets_are_step_invariant(self):
+        """Why the acceptance test above cannot be disturbed by a step change.
+
+        Summing n increments of N(nu*dt, sigma^2*dt) gives N(nu*T, sigma^2*T)
+        for any n, so the terminal law does not depend on the grid.
+        """
+        baseline = probability(HORIZON_CEIL, steps_per_day=1)
+        for spd in (2, 8, 32, 128):
+            with self.subTest(steps_per_day=spd):
+                p = probability(HORIZON_CEIL, steps_per_day=spd)
+                self.assertAlmostEqual(
+                    p, baseline, delta=0.006,
+                    msg=f"close_above moved {baseline:.4f} -> {p:.4f} at {spd}/day",
+                )
+
+    def test_touch_markets_are_step_sensitive_and_only_increase(self):
+        """The re-baseline finding, pinned as a test.
+
+        A discrete path only observes the barrier at step boundaries, so it
+        undercounts crossings and undercounts more at coarser grids. Refining
+        the grid therefore only ever RAISES a touch probability. This is the
+        exact reason STEPS_PER_DAY is held at 1.
+        """
+        probabilities = [
+            probability(HORIZON_CEIL, market_type="touch_above", steps_per_day=spd)
+            for spd in (1, 2, 8, 32, 128)
+        ]
+        for coarse, fine in zip(probabilities, probabilities[1:]):
+            self.assertGreater(
+                fine, coarse,
+                f"refining the grid must not lower a touch probability: {probabilities}",
+            )
+        self.assertGreater(
+            probabilities[-1], probabilities[0] * 1.5,
+            f"expected a material step effect on touch markets: {probabilities}",
+        )
+
+    def test_steps_for_horizon_never_returns_zero(self):
+        """int(0.0412) == 0 was the second blocker. steps must never be 0:
+        a (paths x 0) array makes np.any(..., axis=1) all-False, which prices
+        every touch market at a silent P = 0.0."""
+        for horizon in (HORIZON_TRUE, 0.001, 0.01, 0.5, 0.999):
+            with self.subTest(horizon=horizon):
+                self.assertGreaterEqual(steps_for_horizon(horizon), 1)
+
+    def test_steps_for_horizon_preserves_the_old_whole_day_density(self):
+        """At STEPS_PER_DAY = 1 a whole-day horizon gets exactly the step count
+        it always did, which is what makes this an arithmetic fix and not a
+        re-pricing of the markets we actually trade."""
+        for days in (1, 2, 5, 12, 21, 30, 35):
+            with self.subTest(days=days):
+                self.assertEqual(steps_for_horizon(float(days)), days)
+
+    def test_steps_for_horizon_is_capped(self):
+        self.assertEqual(steps_for_horizon(35.0, steps_per_day=10_000), MAX_STEPS)
+
+    def test_priced_paths_reports_its_own_discretisation(self):
+        priced = simulate_paths(
+            SPOT, TARGET, MU, SIGMA, 20.583, MARKET_TYPE,
+            num_simulations=1000, rng=rng(),
+        )
+        self.assertEqual(priced.steps, 21)
+        self.assertEqual(priced.total, 1000)
+        self.assertAlmostEqual(priced.horizon_days_model, 20.583, places=9)
+
+
+class ModelFloorTest(unittest.TestCase):
+    """MIN_HORIZON_MODEL_DAYS is numerical safety, not a validity threshold."""
+
+    def test_floor_is_applied_to_the_simulated_horizon(self):
+        priced = simulate_paths(
+            SPOT, TARGET, MU, SIGMA, 1e-9, MARKET_TYPE,
+            num_simulations=100, rng=rng(),
+        )
+        self.assertEqual(priced.horizon_days_model, MIN_HORIZON_MODEL_DAYS)
+
+    def test_floor_does_not_touch_the_acceptance_horizon(self):
+        """0.0412d is above the floor, so the acceptance test exercises the
+        real value rather than a clamped one."""
+        self.assertGreater(HORIZON_TRUE, MIN_HORIZON_MODEL_DAYS)
+        priced = simulate_paths(
+            SPOT, TARGET, MU, SIGMA, HORIZON_TRUE, MARKET_TYPE,
+            num_simulations=100, rng=rng(),
+        )
+        self.assertAlmostEqual(priced.horizon_days_model, HORIZON_TRUE, places=9)
+
+    def test_the_floor_sits_inside_the_degenerate_region_by_design(self):
+        """Documents WHY this is not the control that protects the money path.
+
+        At the floor the model is already a step function, near 0 out of the
+        money and near 1 in the money, both with enormous apparent edge. No
+        single horizon value fixes that, because degeneracy depends on
+        sigma*sqrt(T) against the distance to target. MIN_HORIZON_TRADEABLE_DAYS
+        is what actually refuses these markets.
+        """
+        out_of_money = probability(MIN_HORIZON_MODEL_DAYS)
+        in_the_money = probability(
+            MIN_HORIZON_MODEL_DAYS, target=SPOT * 0.987, paths=20_000
+        )
+        self.assertLess(out_of_money, 0.01)
+        self.assertGreater(in_the_money, 0.99)
+
+
+class CoerceHorizonTest(unittest.TestCase):
+    """The /simulate endpoint's second, independent coercion."""
+
+    def test_a_sub_day_horizon_survives_intact(self):
+        """The regression: int() turned this into 0."""
+        value, error = coerce_horizon(HORIZON_TRUE)
+        self.assertIsNone(error)
+        self.assertAlmostEqual(value, HORIZON_TRUE, places=9)
+        self.assertNotEqual(value, 0)
+
+    def test_numeric_strings_are_accepted(self):
+        value, error = coerce_horizon("0.041181")
+        self.assertIsNone(error)
+        self.assertAlmostEqual(value, 0.041181, places=9)
+
+    def test_whole_days_are_unchanged(self):
+        for raw in (1, 21, 30, "35"):
+            with self.subTest(raw=raw):
+                value, error = coerce_horizon(raw)
+                self.assertIsNone(error)
+                self.assertEqual(value, float(raw))
+
+    def test_non_positive_and_non_finite_are_refused(self):
+        for raw in (0, -1, -0.5, float("nan"), float("inf"), float("-inf")):
+            with self.subTest(raw=raw):
+                value, error = coerce_horizon(raw)
+                self.assertIsNone(value)
+                self.assertIsNotNone(error)
+
+    def test_garbage_is_refused(self):
+        for raw in (None, "", "abc", [], {}):
+            with self.subTest(raw=raw):
+                value, error = coerce_horizon(raw)
+                self.assertIsNone(value)
+                self.assertIsNotNone(error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_monte_carlo_horizon.py
+++ b/tests/test_monte_carlo_horizon.py
@@ -242,7 +242,7 @@ class StepPolicyTest(unittest.TestCase):
         a 7-point floor and roughly doubles the population of markets that
         would qualify. That is an exposure decision requiring sign-off, not a
         tuning change. If you are changing this, the approval comes first and
-        this assertion changes with it.
+        this assertion changes with it. Tracked as issue #119.
         """
         self.assertEqual(STEPS_PER_DAY, 1)
 

--- a/tests/test_scanner_horizon.py
+++ b/tests/test_scanner_horizon.py
@@ -41,6 +41,7 @@ from src.trade_engine.config import (  # noqa: E402
     Config,
     config,
 )
+from src.trade_engine.horizon import horizon_days  # noqa: E402
 from src.trade_engine.models import ScannerCandidate  # noqa: E402
 from src.trade_engine.scanner import (  # noqa: E402
     DEFAULT_HORIZON_DAYS,
@@ -232,6 +233,46 @@ class TradeableFloorTest(unittest.TestCase):
                 os.environ.pop("MIN_HORIZON_TRADEABLE_DAYS", None)
             else:
                 os.environ["MIN_HORIZON_TRADEABLE_DAYS"] = saved
+
+
+class CandidateCarriesEndDateTest(unittest.TestCase):
+    """The scanner must hand the executor what GATE 7 needs to recompute.
+
+    GATE 7 fails closed on a missing end_date, so if _to_candidate stopped
+    carrying it the result would not be a wrong trade, it would be EVERY trade
+    refused: a total outage that looks like a working safety gate. Nothing
+    tested this until a mutant removing the field survived the whole suite.
+    """
+
+    def test_to_candidate_carries_end_date_from_the_scanner_row(self):
+        end_date = "2026-09-30T04:00:00Z"
+        row = {
+            "market_id": "3257355",
+            "condition_id": "0x" + "ab" * 32,
+            "slug": "bitcoin-above-60000",
+            "question": "Will Bitcoin reach $60,000 in September?",
+            "asset": "btc",
+            "yes_price": 0.42,
+            "volume": 279582.74,
+            "horizon_days": 20.333,
+            "end_date": end_date,
+        }
+        candidate = PolymarketScanner._to_candidate(row, 0.14, 0.56)
+        self.assertEqual(candidate.end_date, end_date)
+
+    def test_the_pipeline_produces_a_candidate_the_executor_can_gate(self):
+        """End to end through analyse_edge, so the field survives the real path."""
+        end_date = (datetime.now(timezone.utc) + timedelta(days=10)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        selected = run(PolymarketScanner().analyse_edge([make_market(end_date)]))
+        self.assertEqual(len(selected), 1)
+        candidate = PolymarketScanner._to_candidate(selected[0], 0.14, 0.56)
+        self.assertEqual(candidate.end_date, end_date)
+        # And it is parseable by the same helper GATE 7 uses.
+        self.assertIsNotNone(
+            horizon_days(candidate.end_date, datetime.now(timezone.utc))
+        )
 
 
 class CandidateModelTest(unittest.TestCase):

--- a/tests/test_scanner_horizon.py
+++ b/tests/test_scanner_horizon.py
@@ -1,0 +1,267 @@
+"""Tests for the scanner's horizon arithmetic and tradeable-horizon refusal.
+
+src/trade_engine/scanner.py had no test file at all before this one, which is
+how PolymarketScanner._horizon_days shipped a math.ceil that rounded a
+3,558-second market up to a full day and priced position e09b82fe into a
+maximum-size loss.
+
+Two separate things are covered:
+
+  * _horizon_days now returns exact fractional days, and the guards downstream
+    of it are UNCHANGED by that (they were equivalent under ceil, and the tests
+    assert the equivalence rather than assuming it).
+  * MIN_HORIZON_TRADEABLE_DAYS is a hard refusal, enforced here before the
+    market is ever simulated. TradeExecutor GATE 7 enforces the same floor
+    independently, see tests/test_executor.py.
+
+No network: analyse_edge is driven with hand-built Gamma market dicts.
+
+Run:
+    python3 -m unittest tests/test_scanner_horizon.py
+"""
+
+import asyncio
+import math
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+for _key in (
+    "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "ANTHROPIC_API_KEY",
+    "TELEGRAM_BOT_TOKEN", "OWNER_TELEGRAM_CHAT_ID",
+    "POLYMARKET_PRIVATE_KEY", "POLYMARKET_FUNDER_ADDRESS",
+):
+    os.environ.setdefault(_key, f"test-{_key.lower()}")
+
+from src.trade_engine.config import (  # noqa: E402
+    DEFAULT_MIN_HORIZON_TRADEABLE_DAYS,
+    Config,
+    config,
+)
+from src.trade_engine.models import ScannerCandidate  # noqa: E402
+from src.trade_engine.scanner import (  # noqa: E402
+    DEFAULT_HORIZON_DAYS,
+    HORIZON_MAX_DAYS,
+    PolymarketScanner,
+)
+
+NOW = datetime(2026, 8, 31, 15, 0, 42, 96934, tzinfo=timezone.utc)
+E09B82FE_END = "2026-08-31T16:00:00Z"     # 3,557.903 seconds after NOW
+E09B82FE_HORIZON = 0.04117943363425926    # exactly 3557.903066 / 86400
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def make_market(end_date, **overrides):
+    """A Gamma market dict that clears every filter except the one under test.
+
+    btc so the weekend filter never applies (crypto trades at weekends), volume
+    and yes_price comfortably inside their bands, target above the btc price
+    floor of 10,000.
+    """
+    market = {
+        "id": "3257355",
+        "conditionId": "0x" + "ab" * 32,
+        "slug": "bitcoin-above-60000",
+        "question": "Will Bitcoin reach $60,000 in September?",
+        "description": "",
+        "endDate": end_date,
+        "outcomePrices": '["0.50", "0.50"]',
+        "volume": "279582.74",
+        "event_slug": "what-price-will-bitcoin-hit",
+    }
+    market.update(overrides)
+    return market
+
+
+class HorizonDaysTest(unittest.TestCase):
+    """_horizon_days returns exact fractional days."""
+
+    def test_the_e09b82fe_horizon_is_not_rounded_up(self):
+        """The bug, stated as a test: 3,558 seconds is not one day."""
+        horizon = PolymarketScanner._horizon_days(E09B82FE_END, NOW)
+        self.assertAlmostEqual(horizon, E09B82FE_HORIZON, places=9)
+        self.assertNotEqual(horizon, 1)
+        self.assertLess(horizon, 0.05)
+
+    def test_returns_a_float(self):
+        horizon = PolymarketScanner._horizon_days(E09B82FE_END, NOW)
+        self.assertIsInstance(horizon, float)
+
+    def test_fractional_multi_day_horizons_are_exact(self):
+        """The four historical touch_* positions were all rounded up too, by
+        0.33 to 0.67 days. Values taken from their persisted simulation rows."""
+        cases = [
+            # simulation row, scan time, exact horizon, what ceil() used
+            ("cee4eacd", datetime(2026, 8, 11, 14, 0, 37, 831454,
+                                  tzinfo=timezone.utc), 20.58289546928241, 21),
+            ("d0892076", datetime(2026, 8, 11, 20, 0, 29, 266616,
+                                  tzinfo=timezone.utc), 20.33299459935185, 21),
+            ("d23ba1d9", datetime(2026, 8, 20, 18, 1, 0, 531793,
+                                  tzinfo=timezone.utc), 11.415966067210649, 12),
+            ("d9905812", datetime(2026, 8, 27, 12, 0, 45, 952146,
+                                  tzinfo=timezone.utc), 4.666134813125, 5),
+        ]
+        for sim_id, now, expected, old in cases:
+            with self.subTest(simulation=sim_id):
+                horizon = PolymarketScanner._horizon_days(
+                    "2026-09-01T04:00:00Z", now
+                )
+                self.assertAlmostEqual(horizon, expected, places=9)
+                self.assertEqual(math.ceil(horizon), old)
+                self.assertLess(horizon, old)
+
+    def test_absent_end_date_defaults_to_a_float(self):
+        for absent in (None, ""):
+            with self.subTest(end_date=absent):
+                horizon = PolymarketScanner._horizon_days(absent, NOW)
+                self.assertEqual(horizon, DEFAULT_HORIZON_DAYS)
+                self.assertIsInstance(horizon, float)
+
+    def test_unparseable_end_date_defaults_to_a_float(self):
+        horizon = PolymarketScanner._horizon_days("not-a-date", NOW)
+        self.assertEqual(horizon, DEFAULT_HORIZON_DAYS)
+        self.assertIsInstance(horizon, float)
+
+    def test_naive_timestamps_are_treated_as_utc(self):
+        aware = PolymarketScanner._horizon_days("2026-08-31T16:00:00Z", NOW)
+        naive = PolymarketScanner._horizon_days("2026-08-31T16:00:00", NOW)
+        self.assertAlmostEqual(aware, naive, places=9)
+
+    def test_a_past_end_date_is_negative(self):
+        """Feeds the `horizon_days <= 0` rejection below."""
+        self.assertLess(PolymarketScanner._horizon_days("2026-08-30T16:00:00Z", NOW), 0)
+
+
+class GuardEquivalenceTest(unittest.TestCase):
+    """The two downstream guards are UNCHANGED by the fractional horizon.
+
+    ceil(T) <= 0 iff T <= 0, and ceil(T) <= 35 iff T <= 35. Asserting the
+    equivalence directly is what justifies leaving those guards alone: it
+    proves the fix changes only the VALUE passed downstream, not which markets
+    survive filtering.
+    """
+
+    def test_zero_guard_is_equivalent_under_ceil(self):
+        for t in (-5.0, -1.0, -0.5, -1e-9, 0.0, 1e-9, 0.0412, 0.5, 1.0, 2.5):
+            with self.subTest(t=t):
+                self.assertEqual(t <= 0, math.ceil(t) <= 0)
+
+    def test_max_days_guard_is_equivalent_under_ceil(self):
+        for t in (0.5, 1.0, 34.0, 34.2, 34.999, 35.0, 35.0001, 35.4, 36.0, 40.0):
+            with self.subTest(t=t):
+                self.assertEqual(
+                    t > HORIZON_MAX_DAYS, math.ceil(t) > HORIZON_MAX_DAYS
+                )
+
+    def test_lookback_selector_is_equivalent_under_ceil(self):
+        """monte_carlo picks a 21d vol window when horizon <= 35."""
+        for t in (0.0412, 1.0, 34.9, 35.0, 35.1, 90.0):
+            with self.subTest(t=t):
+                self.assertEqual(t <= 35, math.ceil(t) <= 35)
+
+
+class TradeableFloorTest(unittest.TestCase):
+    """MIN_HORIZON_TRADEABLE_DAYS: a refusal, not a penalty."""
+
+    def analyse(self, *markets):
+        scanner = PolymarketScanner()
+        return run(scanner.analyse_edge(list(markets)))
+
+    def end_in(self, **delta):
+        return (datetime.now(timezone.utc) + timedelta(**delta)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+
+    def test_default_floor_is_one_day(self):
+        self.assertEqual(DEFAULT_MIN_HORIZON_TRADEABLE_DAYS, 1.0)
+        self.assertEqual(config.min_horizon_tradeable_days, 1.0)
+
+    def test_a_sub_day_market_is_refused(self):
+        """A 59-minute market, e09b82fe's shape, never reaches the simulator."""
+        selected = self.analyse(make_market(self.end_in(seconds=3558)))
+        self.assertEqual(selected, [])
+
+    def test_refused_across_the_sub_day_range(self):
+        for seconds in (60, 3558, 3600 * 6, 3600 * 23):
+            with self.subTest(seconds=seconds):
+                self.assertEqual(self.analyse(make_market(self.end_in(seconds=seconds))), [])
+
+    def test_a_market_above_the_floor_survives(self):
+        """The floor refuses SHORT markets, not fractional ones."""
+        selected = self.analyse(make_market(self.end_in(days=20, hours=13)))
+        self.assertEqual(len(selected), 1)
+        self.assertAlmostEqual(selected[0]["horizon_days"], 20.54, delta=0.02)
+
+    def test_the_surviving_horizon_is_fractional_not_rounded(self):
+        selected = self.analyse(make_market(self.end_in(days=4, hours=16)))
+        self.assertEqual(len(selected), 1)
+        horizon = selected[0]["horizon_days"]
+        self.assertNotEqual(horizon, math.ceil(horizon))
+        self.assertAlmostEqual(horizon, 4.666, delta=0.01)
+
+    def test_refusal_is_independent_of_edge(self):
+        """No simulation has run at the point of refusal, so no edge exists yet.
+
+        This is what makes the floor a second, independent control rather than
+        a restatement of the edge threshold: analyse_edge drops the market
+        before run_simulations is ever called.
+        """
+        selected = self.analyse(make_market(self.end_in(seconds=3558)))
+        self.assertEqual(selected, [])
+        # And the market is otherwise perfectly valid, same dict, longer clock.
+        self.assertEqual(len(self.analyse(make_market(self.end_in(days=10)))), 1)
+
+    def test_env_can_raise_the_floor_but_never_lower_it(self):
+        """A typo or an over-eager override must not re-open the sub-day path."""
+        saved = os.environ.get("MIN_HORIZON_TRADEABLE_DAYS")
+        try:
+            for attempt in ("0", "0.0", "-5", "0.5", "0.041"):
+                with self.subTest(value=attempt):
+                    os.environ["MIN_HORIZON_TRADEABLE_DAYS"] = attempt
+                    self.assertEqual(Config().min_horizon_tradeable_days, 1.0)
+            os.environ["MIN_HORIZON_TRADEABLE_DAYS"] = "3"
+            self.assertEqual(Config().min_horizon_tradeable_days, 3.0)
+        finally:
+            if saved is None:
+                os.environ.pop("MIN_HORIZON_TRADEABLE_DAYS", None)
+            else:
+                os.environ["MIN_HORIZON_TRADEABLE_DAYS"] = saved
+
+
+class CandidateModelTest(unittest.TestCase):
+    """ScannerCandidate.horizon_days must accept a fractional value.
+
+    Left as int, pydantic v2 raises int_from_float and _to_candidate takes down
+    the entire scan rather than one market, because it runs for every high-edge
+    AND no-edge row.
+    """
+
+    def make(self, horizon):
+        return ScannerCandidate(
+            market_id="3257355", condition_id="0x" + "ab" * 32,
+            question="Will Bitcoin reach $60,000 in September?", asset="btc",
+            direction="YES", edge=0.14, sim_probability=0.56,
+            market_probability=0.42, volume=279582.74, horizon_days=horizon,
+            market_url="https://polymarket.com/market/x", amount_usdc=9.5,
+        )
+
+    def test_accepts_a_fractional_horizon(self):
+        for horizon in (E09B82FE_HORIZON, 4.666135, 20.582884, 1.0, 30.0):
+            with self.subTest(horizon=horizon):
+                self.assertAlmostEqual(
+                    self.make(horizon).horizon_days, horizon, places=9
+                )
+
+    def test_an_int_horizon_still_validates(self):
+        """Persisted approvals written before this change must still load."""
+        self.assertEqual(self.make(21).horizon_days, 21.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the horizon arithmetic that priced position `e09b82fe` into a maximum-size
loss on 2026-08-31.

**Trading stays DISABLED. Nothing here re-enables it.** `trading_config.trading_enabled`
is untouched (read live 2026-09-07: `false`), and executor GATE 1 still re-reads
that brake before every order. Per the standing remediation gate, nothing
re-enables until item 1 and items 7+2 are all merged and verified.

## The bug

`PolymarketScanner._horizon_days` returned `math.ceil((endDate - now) / 86400)`,
ported verbatim from the n8n node. The rounding was not conservative, it was
wrong in one fixed direction:

> shorter real horizon, rounded up, means the simulator diffuses the price for
> longer than the market actually has, which overstates the probability of
> reaching the target, which inflates the edge, which maximises position size.

On 2026-08-31 a 3,557.9-second market (0.0412d) was priced as a full day:

| | P | edge vs implied 0.0255 | 7-point floor |
|---|---|---|---|
| as priced (`ceil` to 1d) | 0.4834 | +45.83 pts | fires, $10 cap |
| at the real horizon | 0.0648 | **+3.93 pts** | no proposal |

Result: `e09b82fe`, `-$10.69`.

## Second, independent finding: `monte_carlo.py` truncated too

`/simulate` did `int(horizon)`. **A fix that only touched `scanner.py` would
have made things worse, not better.** `int(0.0412)` is `0`, giving `steps = 0`
and a `(paths x 0)` array:

* `touch_*` markets: `np.any` over an empty axis is all-False, so every one of
  them would have priced at a **silent `P = 0.0`** and been persisted as real
  data.
* `close_*` markets: `paths[:, -1]` raises `IndexError` on the empty axis,
  caught by the blanket handler and returned as a 500.

Both verified by execution, not by reading. `float()` via a shared
`coerce_horizon` now, which rejects zero, negative and non-finite rather than
coercing them.

A third would-be blocker: `ScannerCandidate.horizon_days: int`. Pydantic 2.12.4
raises `int_from_float` on a fractional value, and `_to_candidate` runs for
every high-edge **and** no-edge row, so leaving it as `int` turns the fix into a
ValidationError that takes down the whole scan rather than one market.

## Two minimums, deliberately not conflated

**`MIN_HORIZON_TRADEABLE_DAYS = 1.0`** is the control. Making the arithmetic
exact does not make `daily_sigma` (21 daily closes) valid intraday, so sub-day
markets are refused outright rather than sized. Enforced in **two independent
places**: the scanner drops them before simulation, and executor **GATE 7**
re-checks against live state immediately before the order. A control that lives
in one layer only is not a control, and an approval can be 30 minutes stale by
the time it is acted on. Env can raise the floor, never lower it.

**`MIN_HORIZON_MODEL_DAYS = 0.01`** is numerical safety only, and the comment
says so at length. As T goes to 0 the model becomes a step function: at
e09b82fe's own parameters, `P = 0.0008` at T = 0.01d out of the money and
`0.9995` in the money, i.e. a confident maximum-size +97-point edge, the same
bug with the sign flipped. 0.01 sits inside that degenerate region by design.
Anyone reading it without that context would assume it is a validity threshold
and relax the wrong one.

## Re-baseline: STEPS_PER_DAY stays at 1

Full numbers in [`docs/trade-engine-horizon-rebaseline.md`](https://github.com/tysonven/QClaw/blob/fix/fractional-horizon/docs/trade-engine-horizon-rebaseline.md).

Decoupling steps from the horizon makes step density a real choice, and it is a
**sizing** choice. A discrete path only observes the barrier at step boundaries,
so refining the grid raises every `touch_*` probability. Measured on the four
historical touch positions (400k paths):

* correcting the horizon alone **lowers** touch probabilities by 0.7 to 2.7 points
* an hourly grid **raises** them by 0.7 to 6.4 points on top of that

Under what shipped, exactly one historical verdict changes: `e09b82fe` would not
have fired. One resize, `71f8a608` $9.50 to $8.33. Nothing that did not fire
begins to.

An hourly grid flips no historical verdict either, and that understates it:
sizing saturates at $10 above 15 points, so its real effect is **recruitment**.
`cee4eacd` moves 6.13 to 6.80 points, stopping 0.2 points short of the floor.
That is an exposure change wearing the costume of an accuracy fix, so it is held
at 1 behind a test that names the approval requirement, and tracked as #119.

## Verification

Every test was proven able to fail. Eight mutants, each reintroducing one shape
of the bug or removing one new guard, **all killed**:

| mutant | killed by |
|---|---|
| M1 revert the `ceil` | `test_scanner_horizon` |
| M2 remove the scanner tradeable-horizon refusal | `test_scanner_horizon` |
| M3 invert the dt scaling (drift by `sqrt(dt)`, diffusion by `dt`) | `test_monte_carlo_horizon` |
| M4 pin `dt = 1.0` while keeping the float signature (partial fix) | `test_monte_carlo_horizon` |
| M5 `steps = int(horizon_days)`, the empty-array silent-zero | `test_monte_carlo_horizon` |
| M6 restore `horizon_days: int` | `test_scanner_horizon`, `test_executor` |
| M7 remove GATE 7, scanner guard left intact | `test_executor` |
| M8 let env lower the tradeable floor | `test_scanner_horizon` |

M7 is the one that matters for the two-layer claim: with the scanner guard fully
intact, removing GATE 7 still goes red, so the layers are independent rather
than one guard tested twice.

**Acceptance test** replays e09b82fe's persisted parameters (spot 2467.93,
target 2500.0, mu 0.012066, sigma 0.040456, horizon 0.0412d) against the real
kernel: `P = 0.0651`, `edge = +0.0396`, below the floor, no proposal. Also
asserted against the exact lognormal closed form, and against the 0.4834 that
production actually stored, so it is anchored to ground truth at both ends.
Re-run on the host's numpy 2.4.4: same numbers.

**One trap worth recording, because it briefly produced a false result here.**
Python validates a `.pyc` against the source's `(mtime_seconds, size)`. The M8
mutant is `max(` -> `min(`, byte-identical in length, and `git checkout` restored
the original within the same second, so `__pycache__` kept serving the MUTANT's
bytecode afterwards: config.py at `mtime=1788793323 size=11203` with a `.pyc`
recording exactly that pair. A subsequent suite run reported 6 failures against
code that was correct on disk. The harness now purges `__pycache__` on both
sides of every mutation, and the full run above is post-fix, so M7 in particular
(the two-layer independence proof) is not an artefact of a stale `models.py`
cache. CI is unaffected: it checks out fresh.

Suite: 24 new in `test_monte_carlo_horizon`, 19 new in `test_scanner_horizon`,
6 new GATE 7 cases plus a fractional-render case in the existing files. All
green. Three suite files fail locally on missing `anthropic`/`fastapi`, verified
identical on clean `origin/main`, so pre-existing and environment-only.

## Deployment: TWO PM2 processes

This spans both, and both are restarted by the deploy step (all six are named
there already):

```
trade-engine     /root/QClaw/src/trade_engine/main.py     scanner + API :4003
trading-worker   /root/QClaw/src/trading/monte_carlo.py   simulator :4001
```

`monte_carlo.py` is run by PM2 as a **script**, so `sys.path[0]` is
`src/trading` and the packaged import does not resolve. Both import forms are
supported explicitly and **both were verified on the host** against its real
flask/yfinance/scipy/numpy, in a temp dir, without touching `/root/QClaw`.

`numpy` is added to `requirements.txt` for CI only. The deploy job never runs
`pip install`, and the host already has numpy 2.4.4, so this adds no runtime
dependency.

**Restart-window transient, and it fails safe.** The two processes restart
sequentially, so for a few seconds a NEW `trade-engine` can call an OLD
`trading-worker` that still does `int(horizon)`. A sub-day market in that window
would hit the old truncation: `close_*` errors out and the market is skipped,
`touch_*` prices at a silent `P = 0.0`, which produces a large NEGATIVE edge and
lands in the `no_edge` bucket. Both outcomes are "no trade". The window is
seconds against an hourly-at-most scan cadence, and trading is disabled anyway,
but it is the reason this is safe to merge in one PR rather than two.

Old-worker responses also simply lack `horizon_days_model` / `steps` /
`steps_per_day`; the scanner reads them with `.get`, so they persist as null
rather than raising.

## Notes, not changes

* `raw_output.horizon_days` becomes fractional. The 5,649 existing rows keep
  ceil-rounded integers, so a calibration query spanning 2026-09-07 compares two
  different quantities. Schemaless `jsonb`, no migration, no consumer reads it
  back (checked `monitor.py`, `analyst.py`, `ui.html`). New rows also carry
  `horizon_days_model`, `steps` and `steps_per_day`: the absence of exactly
  those fields is part of why this bug stayed invisible.
* `src/dashboard/ui.html` still sends `parseInt` on the horizon input, so the
  dashboard cannot express a fractional horizon. Harmless, left alone.
* `HORIZON_MAX_DAYS`, the `horizon_days <= 0` guard and the 21-vs-90-day lookback
  selector are **unchanged and unchangeable by this fix**: `ceil(T) <= 0` iff
  `T <= 0` and `ceil(T) <= 35` iff `T <= 35`. The equivalence is asserted in
  `GuardEquivalenceTest` rather than assumed, which is what bounds the blast
  radius to the value handed downstream.
* `MonteCarloResponse` is dead code (nothing constructs it). Updated for
  consistency rather than deleted.

## Review status

**DRAFT.** Awaiting a cold adversarial review in a separate session against this
branch, and Tyson's sign-off on the re-baseline, before it goes ready.




---

# Review round 1: what changed

Cold review found seven items. Six fixed here, one filed (#122), one left as out of scope.

## F1, BLOCKER: GATE 7 could not see the decay its own comment described

GATE 7 read `candidate.horizon_days`, frozen when the scanner proposed the
trade. `APPROVAL_TIMEOUT_SECONDS` (1800) plus `APPROVAL_MAX_AGE_SECONDS` (300)
is 2100s of decay, so **a market at exactly the 1.00d floor at scan is 0.976d at
execution and passed.** 0.976d is intraday by precisely the argument the floor
exists for. Worse, `test_gate7_admits_exactly_the_floor` asserted that pass as
correct.

GATE 7 now computes `(end_date - now)` against the clock at execution.
`end_date` is carried onto `ScannerCandidate` from the scanner row where it
already existed. It fails CLOSED when `end_date` is absent or unparseable, and
specifically never falls back to the frozen field.

`src/trade_engine/horizon.py` is new and holds the shared parser, because
`scanner.py` imports `executor.py` and the executor cannot import back without a
cycle. It returns `None` rather than a default: the scanner treats an unknown
end date as a 30-day market and carries on, GATE 7 refuses, and a shared default
would be wrong for one of the two callers.

The bad test is replaced by the decay test above. M7 was reworked from "a second
assertion exists" into that property.

## F3: the step tests could not tell `ceil` from `round`

Every case used whole days, where they agree, so `round` survived. Added 20.333
and 11.416, the real horizons of 71f8a608 and f4be9ee8 from the re-baseline
table, plus 1.001 and 0.0412. Rounding to nearest gives a 20.333d market 20
barrier observations instead of 21: lower touch probability, smaller edge,
smaller position. Silent, and in the direction that looks like caution. Mutant
M9 now covers it.

## F5: `steps_per_day` was re-asserted rather than reported

`simulate_paths` takes `steps_per_day` as an argument, so the module constant is
only a default. `PricedPaths` now carries what was actually used and
`monte_carlo` reports that. Issue #119 is exactly the change that would have
made a persisted row claim a density it did not use.

## F2: Charlie would have said six gates

`trading.md` claimed SIX pre-flight gates, so after this merged Charlie could
not have explained a `horizon_below_minimum` refusal. Fixed the gate table (row
7 added), the 35-day cap line (now a 1.0 to 35 window naming both enforcement
points), the six-gates prose, and `main.py`'s `/execute` docstring. All of them
now state that a trade valid at approval can be refused at execution purely
because time passed, and that this is the gate working.

## F6: the n8n scanner still has the original bug

Filed as **#122** rather than fixed here. Verified live rather than assumed. See
the corrected scope line in Appendix B.

## F4: two guards with no test, one asymmetric with a covered sibling

**The substantive half.** `if not math.isfinite(target)` lived inline in
monte_carlo.py's `/simulate` route, and deleting it left the suite green. CI
installs only `src/trade_engine/requirements.txt`, so nothing can import a
module needing flask, yfinance and scipy. **A guard CI cannot reach is not a
guard.** It moves to `simulation.py` as `coerce_target`, beside
`coerce_horizon`, which is where the horizon coercion already lives for exactly
this reason. Behaviour unchanged: numeric and finite, rejected not coerced.

Worth saying why it matters, because it reads as defensive boilerplate. NaN does
not raise in numpy, it compares False. `paths >= nan` is all-False, so a NaN
target prices every market at `P = 0.0` and persists it as real data: the same
silent-zero failure `int(0.0412)` produced on the horizon side. A test asserts
that consequence directly, not just that the guard fires.

**The trivial half, where the asymmetry is the point.** Reverting
`{candidate.horizon_days:.2f}` at `analyst.py:212` left the suite green, while
the identical change in `approval.py` is caught by
`test_fractional_horizon_renders_readably`. Same change, same reason, one of them
tested. Sweep row 8 is the one that goes into the Claude prompt, where
unformatted it renders as `20.582881944444444`.

`import math` drops out of `monte_carlo.py`, having no remaining use.

Both mutants verified red, the analyst one in a throwaway venv with `anthropic`
installed, because that suite cannot run on this machine otherwise and asserting
it without executing it would have been the exact failure F4 is about:

```
F4a: delete the finite-target guard        -> FAILED (failures=3)
F4b: revert the .2f in analyst.py:212      -> FAILED (failures=3)
control: the covered sibling in approval.py -> FAILED (failures=2)
```

## F7

Left, out of scope per instruction.

## Two process notes, both about the harness rather than the code

**The harness destroyed uncommitted work twice.** `git checkout -- .` between
mutations restores to HEAD, so running it against a dirty tree deletes exactly
the changes under test. It happened once during the F1 fixes and again during
F4. Everything was scripted, so both were fully recoverable.

**The second time it also produced a WRONG ANSWER.** After the wipe, mutant F4b
reported SURVIVED, which reads as "this test is vacuous". The test was not
vacuous; it had been deleted by the previous mutant's restore. That is a false
GREEN, and it is the direction recorded as unobserved and unmeasured in the
build log's thirteenth-instance entry two hours earlier, reached by a different
mechanism than the one described there. Same shape: a suite reporting a result
about source that was not what was believed to be on disk.

The harness now refuses to run against a dirty tree rather than relying on
remembering to commit first, which was already written down as the safe order
and was not followed.


---

# Review round 3: the suite did not lock the property

Two findings and one correction to our own diagnosis.

## Finding 1, fix before merge: the tests could not see an import-time clock

The reviewer built a mutant not in the table. GATE 7 keeps its entire shape:
still calls `horizon_days()`, still compares the floor, still fails closed on
absent and unparseable. It changes only WHICH clock, to a module-scope
`_IMPORT_NOW` captured once. **Full suite green, 75/75, decay sentinel passing
alone**, and a real regression: at T+2.5s the correct build refuses and that
build places the order.

The reason is exact. Every gate-7 test built `end_date` relative to the instant
it ran, so an import-time clock and an execution-time clock are milliseconds
apart and agree on all of them.

`test_gate7_is_evaluated_at_execution_time_not_at_import` holds the candidate
fixed and moves the clock: admitted at t, refused at t+2100s.
`executor_mod.datetime` is swapped for the duration; `horizon.py` keeps its own
real datetime, so `end_date` parsing is untouched and exactly one thing varies.
`_staleness_reason` reads the same clock, so `decided_at` is pinned to the
frozen moment, or `stale_approval` fires first and the horizon gate is never
reached. M11 is now permanent in the table.

## Finding 2: an ambiguous mutant definition is not acceptable here

M6's published anchor was `horizon_days: float`, which matches
`MonteCarloResponse` first. Applied literally it mutates dead code and returns a
clean false SURVIVED. Pinned to the `ScannerCandidate` comment line. This
harness has now been wrong twice, so the definitions have to be exact.

## RECORD: the floor half of the original F1 diagnosis was vacuous

Correcting our own reasoning rather than dropping it.

F1 argued GATE 7 must re-read live state, by analogy with GATE 1. That is right
for the horizon and **wrong for the floor**.
`config.min_horizon_tradeable_days` is read from the environment ONCE in
`Config.__init__` at import, is not a `trading_config` column, and nothing
reloads `Config`. Its import-time and execution-time values are always the same
number.

So GATE 7 is not the parallel to GATE 1 it was written to look like: GATE 1
re-reads `trading_config` from Supabase on every call and can genuinely change
underneath it; this floor needs a process restart. The gate comment said or
implied otherwise and now states which half is live and which is not.

---

# Appendix: everything needed to review this without asking the author

Added so the PR stands alone. Nothing load-bearing should live in a chat
transcript.

## A. The mutants, exactly

The harness is a session scratch script, not a repo artefact, so the mutations
are written out here verbatim and can be applied by hand. Each is a single
replacement, applied alone, then reverted.

**Purge `__pycache__` before AND after every one of these.** See the `.pyc` note
in the Verification section above; without the purge these results are not
trustworthy, which is exactly what happened once already.

```
find . -path ./node_modules -prune -o -name __pycache__ -type d -exec rm -rf {} +
```

| id | file | replace | with |
|---|---|---|---|
| M1 | `src/trade_engine/scanner.py` | `return (parsed - now).total_seconds() / 86400.0` | `return math.ceil((parsed - now).total_seconds() / 86400.0)` |
| M2 | `src/trade_engine/scanner.py` | `if horizon_days < config.min_horizon_tradeable_days:` | `if False:` |
| M3 | `src/trading/simulation.py` | `drift = (mu - 0.5 * sigma**2) * dt`<br>`diffusion = sigma * np.sqrt(dt) * Z` | `drift = (mu - 0.5 * sigma**2) * np.sqrt(dt)`<br>`diffusion = sigma * dt * Z` |
| M4 | `src/trading/simulation.py` | `dt = horizon_model / steps` | `dt = 1.0` |
| M5 | `src/trading/simulation.py` | `return int(min(MAX_STEPS, max(1, math.ceil(horizon_days * steps_per_day))))` | `return int(horizon_days * steps_per_day)` |
| M6 | `src/trade_engine/models.py` | `horizon_days: float`<br>`# Market resolution time as Gamma reports it` | `horizon_days: int`<br>(same comment line) |

**M6's anchor must include that comment line.** `horizon_days: float` on its own
matches `MonteCarloResponse` FIRST, which this PR's own sweep calls dead code,
so applying it literally mutates nothing that runs and produces a clean false
SURVIVED. Round-3 review found that; it is why the row above is two lines.
| M7 | `src/trade_engine/executor.py` | `remaining = horizon_days(candidate.end_date, datetime.now(timezone.utc))` | `remaining = candidate.horizon_days` |
| M7b | `src/trade_engine/executor.py` | `if remaining is None:` | fall back to `candidate.horizon_days` |
| M7c | `src/trade_engine/executor.py` | `if remaining < floor:` | `if False:` |
| M9 | `src/trading/simulation.py` | `math.ceil(horizon_days * steps_per_day)` | `round(horizon_days * steps_per_day)` |
| M10 | `src/trade_engine/scanner.py` | `end_date=row.get("end_date"),` | `end_date=None,` |
| M11 | `src/trade_engine/executor.py` | two edits: add `_IMPORT_NOW = datetime.now(timezone.utc)` at module scope, then `datetime.now(timezone.utc)` -> `_IMPORT_NOW` in GATE 7 | keeps every other property of the gate |
| M8 | `src/trade_engine/config.py` | `min_horizon_tradeable_days: float = max(` | `min_horizon_tradeable_days: float = min(` |

M8 is the one that caused the cache incident: `max` to `min` is size-preserving,
so the `.pyc` header's `(mtime, size)` pair still matched after the restore.

Expected kills: M1, M2, M6, M8, M10 -> `tests.test_scanner_horizon`;
M3, M4, M5, M9 -> `tests.test_monte_carlo_horizon`; M6, M7, M7b, M7c, M11 ->
`tests.test_executor`. All 13 killed on a from-scratch run, with `__pycache__`
purged and a dirty-tree refusal on both sides of every mutation.
Run with `python3 -m unittest tests.test_<name>` (`pytest` is not required).

**M7 and M11 together are the independence proof. M7 alone was not one.**

An earlier version of this section claimed M7 made the proof "a property rather
than a second assertion". That was not true as measured, and round-3 review was
right to say so: M7 is a STRONGER assertion, not a property. It separates
"recomputed from `end_date`" from "reads the frozen `horizon_days`", and it
cannot separate "recomputed at execution" from "recomputed at import", because
every gate-7 test built `end_date` relative to the instant it ran.

It becomes a property with **M11**, which keeps the gate's entire shape and
changes only which clock. M7 is killed by
`test_gate7_refuses_a_market_that_decayed_below_the_floor_since_the_scan`,
verified in isolation:

```
$ python3 -m unittest tests.test_executor.GateTest.\
    test_gate7_refuses_a_market_that_decayed_below_the_floor_since_the_scan
AssertionError: True is not false
FAILED (failures=1)
```

That test asserts the scanner WOULD have admitted the market at scan time and
the executor refuses it now.

M11 is killed by `test_gate7_is_evaluated_at_execution_time_not_at_import`,
which holds the candidate fixed byte for byte and moves the CLOCK. Under M11 the
decay sentinel still passes alone, which is the whole point:

```
FULL suite under M11        FAILED (failures=1)   <- only the clock test
decay sentinel alone        OK                    <- cannot see it
clock test alone            FAILED (failures=1)
```

The decay test moves the END DATE back 2100s. It never moves the clock forward.
Varying the clock is the only thing that distinguishes an execution-time read
from an import-time one, and M11 is a real regression: at T+2.5s the correct
build refuses and the mutant places the order.

## B. The int-assumption sweep, in full

What was searched and what was found, so "did the sweep miss anything" is
answerable rather than a matter of trust. Every row was checked; the first three
were defects, the rest were either fixed as follow-on or deliberately left.

| # | site | disposition |
|---|---|---|
| 1 | `models.py` `ScannerCandidate.horizon_days: int` | **blocker**, fixed. pydantic `int_from_float` takes down the whole scan |
| 2 | `monte_carlo.py` `/simulate` `int(horizon)` | **blocker**, fixed. silent `P = 0.0` on touch, `IndexError` on close |
| 3 | `monte_carlo.py` `dt = 1.0; steps = horizon_days` | core fix |
| 4 | `scanner.py` `_horizon_days` `math.ceil`, `-> int` | core fix |
| 5 | `scanner.py` absent/unparseable `end_date` -> `30` | fixed, `DEFAULT_HORIZON_DAYS = 30.0` |
| 6 | `models.py` `MonteCarloResponse.horizon_days: int` | fixed. dead code, nothing constructs it |
| 7 | `approval.py:250` `Horizon: {horizon_days}d` | fixed, `.2f`. money path, human-facing |
| 8 | `analyst.py:212` `Horizon: {horizon_days} days` | fixed, `.2f`. goes into the Claude prompt |
| 9 | `scanner.py` `raw_output.horizon_days` persisted | left. schemaless jsonb, no consumer reads it back |
| 10 | `src/dashboard/ui.html:2493` `parseInt` | left. dashboard cannot express a fractional horizon, harmless |

Also checked and found to contain no horizon assumption: `main.py`,
`monitor.py`, `database.py`, `scheduler.py`, `manual.py`, and every
`.ts`/`.tsx`/`.html` under `src/`. (`src/agents/skills/trading*.md` DID need
changes; see the review-fix section above.)

**Scope explicitly EXCLUDES `n8n-workflows/`, and that exclusion is not
harmless.** The n8n scanner this was ported from, `3YahxqOguET3pifj`, still has
`Math.ceil`, no tradeable-horizon floor and no gate equivalent anywhere in its
path. Verified live against the n8n Postgres on 2026-09-08: `active=false`,
`Math.ceil=true`, one workflow_history row and it contains the ceil too.
Dormant, so latent rather than live, but **reactivating it reproduces
e09b82fe**. Filed as #122 rather than fixed here, because n8n executes the
PUBLISHED history row and editing the draft is a silent runtime no-op.

Three guards were checked for equivalence rather than changed, because
`ceil(T) <= 0` iff `T <= 0` and `ceil(T) <= 35` iff `T <= 35`: the
`horizon_days <= 0` rejection, `HORIZON_MAX_DAYS`, and monte_carlo's
21-vs-90-day lookback selector. `GuardEquivalenceTest` asserts the equivalence
directly, which is what bounds the blast radius of this change to the value
handed downstream.

## C. Host verification the reviewer cannot re-run

`monte_carlo.py` is executed by PM2 as a script, so `sys.path[0]` is
`src/trading` and the packaged import does not resolve; both forms are supported
explicitly. This was checked against the real host's flask / yfinance / scipy /
numpy, in `/tmp`, without touching `/root/QClaw`. Recorded here because it is
not reproducible locally (flask, yfinance and scipy are not in
`requirements.txt` by design) and should not be taken on trust silently:

```
--- SCRIPT-STYLE import (sys.path[0]=src/trading, what PM2 gets):
  OK  STEPS_PER_DAY= 1 MIN_HORIZON_MODEL_DAYS= 0.01
--- PACKAGED import (repo root, what the tests get):
  OK  (0.0412, None)

host numpy 2.4.4
  true 0.0412d   steps=1 dt=0.041179 P=0.0651 edge=+0.0396
  ceil 1d        steps=1 dt=1.000000 P=0.4839 edge=+0.4584
```

Host package versions at the time: numpy 2.4.4, flask 3.1.3, yfinance 1.2.0,
scipy 1.17.1, pydantic 2.12.5, fastapi 0.135.3.

## D. Pre-existing local failures, not findings

`tests/test_analyst.py`, `tests/test_manual_position.py` and
`tests/test_relay_settlement.py` fail at import without `anthropic` / `fastapi`
installed. Verified identical on clean `main`. CI installs both and they pass
there.

## E. Branch state

Behind `main` by one docs-only commit (`4c17a23`). Branch protection is
`strict: true`, so this needs updating before it can merge. Deliberately not
done yet, so the branch does not move under a review in progress. No conflict:
that commit touches only `QCLAW_BUILD_LOG.md`, which this PR does not.



