### PR TITLE
ci: move actions off Node 20, and record the two identifier-width bugs

### DIFF
--- a/.github/workflows/build-cognee-venv.yml
+++ b/.github/workflows/build-cognee-venv.yml
@@ -11,20 +11,20 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build Cognee venv
         run: |
           bash scripts/build-cognee-venv.sh
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cognee-venv-arm64
           path: /tmp/cognee-venv-arm64.tar.xz
 
       - name: Attach to release
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: /tmp/cognee-venv-arm64.tar.xz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
         node-version: [20, 22]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -40,10 +40,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -80,10 +80,10 @@ jobs:
     # look like Python was covered.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -25907,3 +25907,81 @@ Pinned to include the class-specific comment line. A mutation harness publishes
 instructions for reproducing its own results, and an ambiguous anchor is a
 result nobody else can check. Given this harness produced two confident wrong
 answers earlier the same day, that is not a stylistic point.
+
+---
+
+## 2026-09-08: two identifier-width bugs, and why only one of them was dangerous
+
+A footnote to the CI/CD rollout, recorded because the pair is more instructive
+than either bug alone.
+
+Both are the same defect: an identifier compared or supplied at the wrong width.
+They landed hours apart in the same repo, `flowos-sms-delivery`. Their
+consequences were not remotely comparable, and the reason is the whole point.
+
+**The dangerous one, caught before shipping.** The deploy job tags each uploaded
+Worker version with `${GITHUB_SHA:0:8}`, EIGHT characters: commit `ffb2218` is
+tagged `ffb22182`. The drift check compares that tag against main's HEAD. Had it
+used `git rev-parse --short HEAD` or `git log --oneline`, both of which produce
+SEVEN characters by default, the comparison would never have matched. The check
+would have reported drift permanently, on a repo where drift is expected after
+every merge, and it would have been ignored inside a week. A check everyone
+ignores asserts nothing, which is the defect the whole rollout removed.
+
+Nothing would have failed. Nothing would have logged. The check would have run
+daily, green or red as designed, and been wrong every time.
+
+**The annoying one, hit in practice.** Promoting a version needs the full UUID.
+Supplying the 8-character prefix gets:
+
+```
+The requested Worker version could not be found
+```
+
+Same class. Opposite outcome. The system named the problem immediately, nobody
+was misled, and the cost was a few seconds.
+
+### What separates them
+
+Not severity, and not how carefully either was written. **Whether the wrong
+answer was distinguishable from the right one.**
+
+A prefix passed to `wrangler versions deploy` either resolves or it does not, so
+being wrong is loud by construction. A string comparison between two identifiers
+of different widths returns `false`, which is a perfectly valid answer that
+happens to be the answer the check is designed to produce sometimes. The failure
+hides inside the check's own normal output.
+
+That generalises past identifiers. **A check is dangerous in proportion to how
+much its failure mode resembles its success mode.** Worth asking of anything
+that compares two values derived by different routes: if this were wrong, what
+would it look like, and would that be distinguishable from it being right?
+
+The 7-versus-8 comparison now carries a comment at the line itself, not only
+here, because that is where someone would reintroduce it by tidying. It is also
+asserted in `test/deploy-drift.test.js`, so a future edit fails rather than goes
+quiet. The comment explains, the test enforces, and neither alone would be
+enough.
+
+### Related, from the same pass: actions off Node 20
+
+Every workflow in all six repos was emitting `Node.js 20 is deprecated ... forced
+to run on Node.js 24`. Advisory now, breaking when GitHub drops the shim.
+
+Bumped to the minimum major that actually reports `using: node24`, verified per
+action against its `action.yml` rather than assumed. That verification mattered,
+because two are not what a one-major bump would suggest:
+
+```
+actions/checkout             v4 -> v5
+actions/setup-node           v4 -> v5
+actions/setup-python         v5 -> v6     (v5 is node20)
+pnpm/action-setup            v4 -> v5     (v4 is node20)
+actions/upload-artifact      v4 -> v6     (v5 is STILL node20)
+softprops/action-gh-release  v2 -> v3
+appleboy/ssh-action          v1 unchanged (composite, no node runtime)
+```
+
+Bumping only the two actions the warning named would have left `setup-python`
+and `pnpm/action-setup` warning. Bumping `upload-artifact` by one major would
+have fixed nothing at all while appearing to.


### PR DESCRIPTION
Part of a six-repo pass. **Not merging this myself.**

## Actions off Node 20

Bumped to the **minimum major that actually reports `using: node24`**, verified per action against its `action.yml` rather than assumed. That verification earned its keep, because two are not what a one-major bump would suggest:

| action | from | to | note |
|---|---|---|---|
| actions/checkout | v4 | v5 | |
| actions/setup-node | v4 | v5 | |
| actions/setup-python | v5 | **v6** | v5 is node20 |
| actions/upload-artifact | v4 | **v6** | **v5 is still node20** |
| softprops/action-gh-release | v2 | v3 | |
| appleboy/ssh-action | v1 | v1 | composite, no node runtime |

Bumping only the two the warning named would have left `setup-python` warning. Bumping `upload-artifact` by one major would have fixed **nothing at all while appearing to**, which is its own small instance of the pattern this log keeps recording.

## Build log: why one identifier bug was dangerous and the other was not

Two bugs, same defect, hours apart in `flowos-sms-delivery`. Both an identifier at the wrong width.

| | failure mode | consequence |
|---|---|---|
| 7-vs-8 SHA in the drift comparison | **silent**: never matches, reports drift forever | check ignored within a week, asserts nothing |
| prefix-vs-UUID in the promote command | **loud**: `The requested Worker version could not be found` | seconds lost |

What separates them is not severity, and not how carefully either was written. It is **whether the wrong answer was distinguishable from the right one**. A prefix passed to wrangler either resolves or it does not, so being wrong is loud by construction. A comparison between identifiers of different widths returns `false`, which is a perfectly valid answer the check is designed to produce sometimes, so the failure hides inside the check's own normal output.

Generalised, and worth asking of anything comparing two values derived by different routes: **a check is dangerous in proportion to how much its failure mode resembles its success mode.** If this were wrong, what would it look like, and would that be distinguishable from it being right?