### PR TITLE
feat(sizing): fractional Kelly on the debit, and refuse below the exchange minimum

### DIFF
--- a/src/agents/skills/trading.md
+++ b/src/agents/skills/trading.md
@@ -115,7 +115,7 @@ Monte Carlo worker — http://localhost:4001 (PM2: trading-worker):
 
 Trade execution path (rewritten 2026-08-14): execution belongs entirely to the
 standalone trade engine, src/trade_engine/executor.py, which invokes
-src/trading/execute_trade.py as a subprocess behind SEVEN pre-flight gates.
+src/trading/execute_trade.py as a subprocess behind EIGHT pre-flight gates.
 Verified against the code 2026-09-08. Every one of these can refuse a trade
 the Analyst and Tyson have already approved, so check them before telling
 Tyson a trade "will" go through:
@@ -129,10 +129,30 @@ Tyson a trade "will" go through:
 | 5 | invalid_amount | size ≤ 0, above config, or above a hard ceiling | `max_position_usdc` (10) AND **ABSOLUTE_MAX_POSITION_USDC = 25.0** (hardcoded ceiling that config cannot raise) |
 | 6 | invalid_market_identifier | no well-formed Polymarket conditionId | — |
 | 7 | horizon_below_minimum | the market resolves too soon, RECOMPUTED from `end_date` at execution, or `end_date` is missing/unparseable | **MIN_HORIZON_TRADEABLE_DAYS = 1.0** (`config`; env may raise it, never lower it) |
+| 8 | below_exchange_minimum | the order is under the market's own `orderMinSize`, in SHARES, read LIVE from Gamma at execution; or that value cannot be read | **5 shares** on every market sampled, but read per market, never hardcoded |
 
 Gates 2 and 5's hard limits are code constants, not database config: raising
 `max_position_usdc` above 25 does NOT raise the real ceiling, and there is no
 config key for the 2-position cap.
+
+**Gate 8 is why almost nothing trades, and that is correct.** Position size is
+fractional Kelly (`KELLY_FRACTION` 0.10) against a `bankroll_usdc` of 25, sized
+so the WALLET DEBIT hits the cap: the fee is `0.07 * (1 - price)` of notional,
+so `notional = cap / (1 + 0.07 * (1 - price))`. The largest possible stake at
+this bankroll is therefore $2.50, at certainty.
+
+Polymarket enforces a minimum order size in SHARES (`orderMinSize`, 5). Clearing
+it needs `edge >= 2 * price * (1 - price)`, and since edge can never exceed
+`1 - price`, **no market priced above 0.5 can be placed at any edge, including
+certainty**. Below 0.5 it needs a very large edge: at price 0.10 a simulated
+probability of 0.29, at 0.20 it is 0.54, at 0.40 it is 0.90. All four historical
+positions are refused under this sizing.
+
+If Tyson asks why nothing is trading, that is the answer, and it is arithmetic
+rather than a fault. NEVER propose raising `bankroll_usdc` to fix it: 25 comes
+from $29.24 of measured spendable collateral, and the ~$180 that would make
+Kelly and the exchange compatible at mid prices is a DEPOSIT of about $155, a
+capital decision for Tyson, not a config edit.
 
 **Gate 7 uses the clock, not the candidate.** It recomputes days-to-resolution
 from `end_date` at the moment of execution rather than reading the horizon the
@@ -256,7 +276,9 @@ Credentials: POLYMARKET_PRIVATE_KEY + POLYMARKET_FUNDER_ADDRESS
 3. Judge armed state from the trade engine, never from n8n. If the engine is
    down, surface that and stop; do not conclude trading is safe because an n8n
    workflow is inactive.
-4. Max position is $10 USDC (`max_position_usdc`), with a hardcoded
+4. Position size is FRACTIONAL KELLY on the debit, not a fixed amount. See
+   the sizing section below before quoting any number. Max position is $10 USDC
+   (`max_position_usdc`), with a hardcoded
    $25 ceiling that config cannot exceed. Never suggest or execute trades
    above the config value without approval.
 5. Daily loss limit is $20 USDC. If this is hit, trading must stop for the day.
@@ -265,7 +287,7 @@ Credentials: POLYMARKET_PRIVATE_KEY + POLYMARKET_FUNDER_ADDRESS
    markets below this edge.
 7. There is no HTTP execution route and no TRADING_WEBHOOK_SECRET path any
    more (both retired 2026-08-14). Execution runs only through the trade
-   engine's executor, behind its seven gates plus the Telegram approval gate.
+   engine's executor, behind its eight gates plus the Telegram approval gate.
    Never propose reinstating an HTTP execution route.
 8. The Monte Carlo worker must be running (PM2: trading-worker) before any
    simulation or execution calls.

--- a/src/agents/skills/trading.md
+++ b/src/agents/skills/trading.md
@@ -141,12 +141,24 @@ so the WALLET DEBIT hits the cap: the fee is `0.07 * (1 - price)` of notional,
 so `notional = cap / (1 + 0.07 * (1 - price))`. The largest possible stake at
 this bankroll is therefore $2.50, at certainty.
 
-Polymarket enforces a minimum order size in SHARES (`orderMinSize`, 5). Clearing
-it needs `edge >= 2 * price * (1 - price)`, and since edge can never exceed
-`1 - price`, **no market priced above 0.5 can be placed at any edge, including
-certainty**. Below 0.5 it needs a very large edge: at price 0.10 a simulated
-probability of 0.29, at 0.20 it is 0.54, at 0.40 it is 0.90. All four historical
-positions are refused under this sizing.
+Polymarket enforces a minimum order size in SHARES (`orderMinSize`, 5, read per
+market). Clearing it needs `edge >= 2 * price * (1 - price)`, and since edge can
+never exceed `1 - price`, **no market priced above 0.482521 can be placed at any
+edge, including certainty**.
+
+Quote 0.482521, not 0.5. 0.5 is the fee-free answer; the code is fee-aware and
+the exact cut solves `0.14 * price^2 - 2.14 * price + 1 >= 0`. The band between
+them, 0.4826 to 0.4999, is refused by the code and would be reported as
+tradeable by the coarser number.
+
+Below that it needs a very large edge. Minimum simulated probability by price:
+
+| price | 0.10 | 0.20 | 0.30 | 0.40 | 0.45 | 0.4825 |
+|---|---|---|---|---|---|---|
+| p needed | 0.291 | 0.538 | 0.741 | 0.900 | 0.964 | 1.000 |
+
+All four historical positions are refused. The widest of them was an edge of
+0.336 at price 0.279, which needed **0.4226**.
 
 If Tyson asks why nothing is trading, that is the answer, and it is arithmetic
 rather than a fault. NEVER propose raising `bankroll_usdc` to fix it: 25 comes

--- a/src/trade_engine/config.py
+++ b/src/trade_engine/config.py
@@ -157,18 +157,34 @@ class Config:
         self.min_alert_volume: float = self._float_env(
             "MIN_ALERT_VOLUME", DEFAULT_MIN_ALERT_VOLUME
         )
+        # CLAMPED, like min_horizon_tradeable_days below, and for the same
+        # reason. The docstring on DEFAULT_BANKROLL_USDC says raising it is a
+        # capital decision and "not a config edit" — which was false while this
+        # was a bare env read: BANKROLL_USDC=200 in /root/.quantumclaw/.env was
+        # exactly a config edit, with no clamp, no ceiling and no log line. Two
+        # paragraphs of prose were the only guard on the number this whole
+        # sizing model rests on.
+        #
+        # Env may only make these MORE conservative. Bankroll may be lowered,
+        # never raised; the Kelly fraction may be lowered, never raised. An
+        # attempt to go the other way is clamped and logged rather than
+        # silently accepted, because a silently ignored override is its own
+        # failure mode.
+        self.bankroll_usdc: float = self._clamped_env(
+            "BANKROLL_USDC", DEFAULT_BANKROLL_USDC, direction="max"
+        )
+        self.kelly_fraction: float = self._clamped_env(
+            "KELLY_FRACTION", DEFAULT_KELLY_FRACTION, direction="max"
+        )
+        # The price floor may only be RAISED: a higher floor proposes fewer,
+        # more liquid markets, which is the conservative direction.
+        self.sizing_price_floor: float = self._clamped_env(
+            "SIZING_PRICE_FLOOR", DEFAULT_SIZING_PRICE_FLOOR, direction="min"
+        )
+
         # Clamped at the floor, never below: an env typo (0, negative, or an
         # over-eager 0.5) must not be able to re-open the sub-day path that
         # cost position e09b82fe. Raising it is allowed, lowering it is not.
-        self.bankroll_usdc: float = self._float_env(
-            "BANKROLL_USDC", DEFAULT_BANKROLL_USDC
-        )
-        self.kelly_fraction: float = self._float_env(
-            "KELLY_FRACTION", DEFAULT_KELLY_FRACTION
-        )
-        self.sizing_price_floor: float = self._float_env(
-            "SIZING_PRICE_FLOOR", DEFAULT_SIZING_PRICE_FLOOR
-        )
         self.min_horizon_tradeable_days: float = max(
             DEFAULT_MIN_HORIZON_TRADEABLE_DAYS,
             self._float_env(
@@ -194,6 +210,30 @@ class Config:
             return float(raw)
         except ValueError as exc:
             raise ConfigError(f"{key} must be a number, got {raw!r}") from exc
+
+    def _clamped_env(self, key: str, default: float, *, direction: str) -> float:
+        """Env override that may only move a value in the SAFE direction.
+
+        direction="max": the default is a ceiling, env may only lower it.
+        direction="min": the default is a floor, env may only raise it.
+
+        A rejected override is LOGGED rather than silently ignored. Silently
+        discarding an operator's setting is its own failure mode: the next
+        person reads the .env, believes it, and reasons from a number that is
+        not in force.
+        """
+        value = self._float_env(key, default)
+        if direction == "max":
+            clamped = min(default, value)
+        else:
+            clamped = max(default, value)
+        if clamped != value:
+            logging.getLogger("trade_engine.config").warning(
+                "%s=%s ignored: clamped to %s. This value may only move in the "
+                "conservative direction; changing it beyond that is a decision, "
+                "not a config edit.", key, value, clamped,
+            )
+        return clamped
 
     @staticmethod
     def _int_env(key: str, default: int) -> int:

--- a/src/trade_engine/config.py
+++ b/src/trade_engine/config.py
@@ -75,6 +75,32 @@ DEFAULT_MIN_ALERT_VOLUME = 5000.0
 # stale by the time it is acted on.
 DEFAULT_MIN_HORIZON_TRADEABLE_DAYS = 1.0
 
+# --- position sizing (fractional Kelly, fee aware) --------------------------
+#
+# BANKROLL_USDC IS A MEASUREMENT, NOT A DIAL. 25 comes from $29.24 of real
+# spendable collateral observed on the funder wallet, rounded down. Raising it
+# sizes Kelly against money that does not exist, which is precisely what turns
+# Kelly from conservative into dangerous.
+#
+# You will be tempted. At this bankroll the exchange's 5-share minimum is
+# coarser than the entire Kelly budget, so almost nothing can be placed (see
+# src/trade_engine/sizing.py for the arithmetic). The number that would make
+# Kelly and the exchange compatible at mid prices is about $180. Getting there
+# is a CAPITAL decision, a deposit of roughly $155, and it belongs to Tyson.
+# It is not a config edit, and editing this constant to reach it would be the
+# same act as deleting the guard.
+DEFAULT_BANKROLL_USDC = 25.0
+
+# Fraction of full Kelly. Full Kelly maximises long-run growth only if the
+# probability estimate is right; ours was 7x wrong six weeks ago, so a tenth.
+DEFAULT_KELLY_FRACTION = 0.10
+
+# Sizing-only price floor, deliberately SEPARATE from scanner.YES_PRICE_MIN
+# (0.01), which governs inclusion. Markets below this are still scanned,
+# simulated, bucketed and reported; they are just never sized or proposed. That
+# keeps "how much flow sits down there" answerable from data later.
+DEFAULT_SIZING_PRICE_FLOOR = 0.10
+
 VERSION = "0.1.0"
 
 
@@ -134,6 +160,15 @@ class Config:
         # Clamped at the floor, never below: an env typo (0, negative, or an
         # over-eager 0.5) must not be able to re-open the sub-day path that
         # cost position e09b82fe. Raising it is allowed, lowering it is not.
+        self.bankroll_usdc: float = self._float_env(
+            "BANKROLL_USDC", DEFAULT_BANKROLL_USDC
+        )
+        self.kelly_fraction: float = self._float_env(
+            "KELLY_FRACTION", DEFAULT_KELLY_FRACTION
+        )
+        self.sizing_price_floor: float = self._float_env(
+            "SIZING_PRICE_FLOOR", DEFAULT_SIZING_PRICE_FLOOR
+        )
         self.min_horizon_tradeable_days: float = max(
             DEFAULT_MIN_HORIZON_TRADEABLE_DAYS,
             self._float_env(

--- a/src/trade_engine/executor.py
+++ b/src/trade_engine/executor.py
@@ -42,7 +42,7 @@ import httpx
 from src.trade_engine.approval import _scrub
 from src.trade_engine.config import config, install_bot_token_redaction
 from src.trade_engine.horizon import horizon_days
-from src.trade_engine.sizing import FEE_RATE, size_position
+from src.trade_engine.sizing import FEE_RATE, side_price_for
 from src.trade_engine.database import (
     SupabaseError,
     count_open_positions,
@@ -86,11 +86,34 @@ ABSOLUTE_MAX_POSITION_USDC = 25.0
 # more than 70x at high prices, which meant "the fee schedule changed" was only
 # ever detectable on the cheapest markets. FEE_TOLERANCE is headroom for
 # rounding and partial fills, not for a second fee.
-FEE_TOLERANCE = 0.01
+# Tolerance has BOTH a ratio and an absolute floor, and the floor is the one
+# that matters now. A ratio alone was worth half a cent on a $0.25 position and
+# 2.5 cents on a $2.50 one, while the error sources it must absorb do NOT shrink
+# with position size:
+#
+#   - a multi-price fill. The fee is charged per fill at that fill's price, so
+#     an order half-filled at 0.30 and half at 0.32 differs from the
+#     single-price estimate by about 0.07 * dP * shares. At $2 notional and
+#     dP = 0.02 that is roughly $0.009, which a 1% ratio ($0.02) barely covers
+#     and a 1% ratio on a $0.25 order ($0.0025) does not.
+#   - decoder rounding across several ERC1155 transfers.
+#
+# A FALSE TRIP is not harmless: it records the notional, which EXCLUDES the fee,
+# understating cost basis, overstating pnl, and under-triggering GATE 3's
+# daily-loss brake. That is the unsafe direction, so the floor is set to cover a
+# plausible two-price fill with headroom rather than to be tight.
+#
+# 0.03 is about 1.2% of a $2.50 position and 12% of a $0.25 one, deliberately
+# generous at the small end. It is NOT slack in the fee model: that is fitted to
+# eight receipts spanning 1.5c to 90c with a maximum residual of 4e-6 (build log
+# 2026-09-05, "Polymarket's fee, solved"), so model error is ~1e-5 of notional
+# and irrelevant here. The floor exists for fill structure, not for the formula.
+FEE_TOLERANCE_RATIO = 0.01
+FEE_TOLERANCE_ABS = 0.03
 
 # Fallback only, for when no price is available to compute the real bound. The
 # worst case across all admissible prices is 1 + 0.07 * (1 - 0) = 1.07.
-MAX_CASH_OUT_NOTIONAL_FACTOR = 1.07 + FEE_TOLERANCE
+MAX_CASH_OUT_NOTIONAL_FACTOR = 1.07 + FEE_TOLERANCE_RATIO
 
 MAX_CONCURRENT_POSITIONS = 2
 
@@ -384,8 +407,18 @@ class TradeExecutor:
             )
             raise ExecutionGateError("below_exchange_minimum")
 
-        live_minimum, live_price = limits
-        price_for_shares = live_price or candidate.market_probability
+        live_minimum, live_yes_price = limits
+        # Convert at the price of the side ACTUALLY BEING BOUGHT. sizing.py
+        # complements the price for NO; this did not, so it divided a NO
+        # notional by the YES price and refused sizeable NO candidates. Today
+        # best_trade only comes from the high-edge bucket so the direction is
+        # always YES and the bug is unreachable, but "unreachable" is exactly
+        # what the NO branch in sizing.py was written to stop anyone having to
+        # remember.
+        yes_price = live_yes_price or candidate.market_probability
+        price_for_shares = (
+            side_price_for(candidate.direction, float(yes_price)) if yes_price else None
+        )
         if not price_for_shares or not 0 < float(price_for_shares) <= 1:
             log.error(
                 "gate 8: no usable price to convert $%.4f into shares "
@@ -727,10 +760,10 @@ class TradeExecutor:
                     "distrusting it and recording the notional", cash_out, notional,
                 )
                 usdc_amount = notional
-            elif anchor is not None and cash_out > anchor * cls._cash_out_ceiling(price):
-                ceiling = cls._cash_out_ceiling(price)
+            elif anchor is not None and cash_out > cls._max_believable_cash_out(anchor, price):
+                ceiling = cls._max_believable_cash_out(anchor, price)
                 log.error(
-                    "relay cash_out %.6f exceeds %.4fx the %s %.6f (price %s, "
+                    "relay cash_out %.6f exceeds the believable ceiling %.6f for %s %.6f (price %s, "
                     "expected fee ratio %s), distrusting it and recording that "
                     "instead. A persistent residual here means the fee schedule "
                     "changed, not that one decode was wrong",
@@ -795,6 +828,23 @@ class TradeExecutor:
         if not isinstance(market, dict):
             return None
 
+        # IS THIS THE MARKET WE ASKED FOR? Gamma ignores unrecognised query
+        # params and returns its default page, so if `condition_ids` is ever
+        # renamed, deprecated or misspelled this does not fail closed: it
+        # returns a STRANGER's orderMinSize and a stranger's price, and GATE 8
+        # uses both. A returned price of 0.02 against a real 0.40 inflates the
+        # implied share count twentyfold and waves through an order the real
+        # market rejects. Fail-open by wrong target, which is a variant this
+        # repo has already recorded once.
+        returned = str(market.get("conditionId") or "")
+        if returned.lower() != str(condition_id).lower():
+            log.error(
+                "gate 8: gamma returned market %s... for a request for %s..., "
+                "refusing rather than sizing against the wrong market",
+                returned[:12] or "<none>", str(condition_id)[:12],
+            )
+            return None
+
         raw_min = market.get("orderMinSize")
         try:
             minimum = float(raw_min)
@@ -811,23 +861,31 @@ class TradeExecutor:
                 candidate_price = float(prices[0])
                 if 0 < candidate_price <= 1:
                     price = candidate_price
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, KeyError, IndexError):
+            # KeyError/IndexError: outcomePrices arriving as an object, or an
+            # empty list. Previously these escaped to execute()'s blanket
+            # handler and were reported as gate_error rather than
+            # below_exchange_minimum, which is the wrong diagnosis in exactly
+            # the logs decision (c) exists to mine.
             price = None
 
         return minimum, price
 
     @staticmethod
-    def _cash_out_ceiling(price: Optional[float]) -> float:
-        """Largest believable cash_out as a multiple of notional, for this price.
+    def _max_believable_cash_out(anchor: float, price: Optional[float]) -> float:
+        """Largest believable wallet debit for this anchor, in USDC.
 
-        1 + 0.07 * (1 - price) is the exact fee ratio; FEE_TOLERANCE is headroom
-        for rounding and partial fills. Falls back to the all-prices worst case
-        when price is unknown, which is the only case the old flat constant ever
-        described correctly.
+        Absolute rather than a multiplier, because the tolerance has an absolute
+        floor: at the position sizes fractional Kelly now produces, a ratio
+        alone is worth fractions of a cent. See FEE_TOLERANCE_ABS.
+
+        Falls back to the all-prices worst case when price is unknown, which is
+        the only case the old flat constant ever described correctly.
         """
+        tolerance = max(FEE_TOLERANCE_RATIO * anchor, FEE_TOLERANCE_ABS)
         if price is None or not math.isfinite(float(price)) or not 0 < float(price) <= 1:
-            return MAX_CASH_OUT_NOTIONAL_FACTOR
-        return 1.0 + FEE_RATE * (1.0 - float(price)) + FEE_TOLERANCE
+            return anchor * MAX_CASH_OUT_NOTIONAL_FACTOR + FEE_TOLERANCE_ABS
+        return anchor * (1.0 + FEE_RATE * (1.0 - float(price))) + tolerance
 
     @staticmethod
     def _extract_tx_hash(payload: dict[str, Any]) -> Optional[str]:

--- a/src/trade_engine/executor.py
+++ b/src/trade_engine/executor.py
@@ -2,7 +2,7 @@
 """Trade executor — the only component in this repo that spends real money.
 
 Sits behind the approval gate: nothing here runs until a human has tapped
-Execute on a Telegram message. Even then, seven independent gates are re-checked
+Execute on a Telegram message. Even then, eight independent gates are re-checked
 against LIVE state before the order goes out, because the approval may be up to
 30 minutes stale by the time it is acted on and the world moves in between.
 
@@ -30,6 +30,7 @@ well-formed conditionId is refused rather than sent with the wrong identifier.
 import asyncio
 import json
 import logging
+import math
 import re
 import subprocess
 from datetime import datetime, timezone
@@ -41,6 +42,7 @@ import httpx
 from src.trade_engine.approval import _scrub
 from src.trade_engine.config import config, install_bot_token_redaction
 from src.trade_engine.horizon import horizon_days
+from src.trade_engine.sizing import FEE_RATE, size_position
 from src.trade_engine.database import (
     SupabaseError,
     count_open_positions,
@@ -72,14 +74,23 @@ SUBPROCESS_TIMEOUT_SECONDS = 60
 # something absurd, this still refuses. Defence in depth against a bad write.
 ABSOLUTE_MAX_POSITION_USDC = 25.0
 
-# M1 (PR #94 review): the relay's cash_out is sanity-bounded on BOTH sides.
-# Below the matched notional means a negative fee (impossible); above it by
-# more than this factor means the decode over-counted (a batched settlement,
-# a double-transfer chain, a new event shape) and would silently poison pnl
-# and Gate 3. The real 2026-08-20 fee was 5% of notional (10.501189 vs 10.00,
-# a 1.05x ratio), so 1.5x accepts any plausible fee with wide margin while
-# refusing anything that looks like double-counting.
-MAX_CASH_OUT_NOTIONAL_FACTOR = 1.5
+# The relay's cash_out is sanity-bounded on BOTH sides (M1, PR #94 review).
+# Below the matched notional means a negative fee, which is impossible; above
+# the expected fee by more than a tolerance means the decode over-counted (a
+# batched settlement, a double-transfer chain, a new event shape) and would
+# silently poison pnl and Gate 3.
+#
+# The ceiling is now COMPUTED PER TRADE, not flat. The fee is exactly
+# 0.07 * (1 - price) of notional, so the true bound is 1 + 0.07 * (1 - price):
+# 1.063 at price 0.10 but only 1.007 at 0.90. The old flat 1.5 was loose by
+# more than 70x at high prices, which meant "the fee schedule changed" was only
+# ever detectable on the cheapest markets. FEE_TOLERANCE is headroom for
+# rounding and partial fills, not for a second fee.
+FEE_TOLERANCE = 0.01
+
+# Fallback only, for when no price is available to compute the real bound. The
+# worst case across all admissible prices is 1 + 0.07 * (1 - 0) = 1.07.
+MAX_CASH_OUT_NOTIONAL_FACTOR = 1.07 + FEE_TOLERANCE
 
 MAX_CONCURRENT_POSITIONS = 2
 
@@ -100,6 +111,10 @@ APPROVAL_MAX_SKEW_SECONDS = 60
 CONDITION_ID_RE = re.compile(r"0x[0-9a-fA-F]{64}")
 
 TELEGRAM_API_BASE = "https://api.telegram.org"
+GAMMA_MARKETS_URL = "https://gamma-api.polymarket.com/markets"
+
+# Short: a gate must not hang the money path. Failure is a refusal, not a wait.
+MARKET_LIMITS_TIMEOUT_SECONDS = 10.0
 
 
 class TradeExecutor:
@@ -213,7 +228,7 @@ class TradeExecutor:
     # --- gates ------------------------------------------------------------
 
     async def _run_gates(self, candidate: ScannerCandidate) -> None:
-        """Seven checks against live state. Raises ExecutionGateError on refusal.
+        """Eight checks against live state. Raises ExecutionGateError on refusal.
 
         Ordered cheapest-and-most-decisive first: the global brake before the
         per-trade arithmetic, so a disabled system does not spend three
@@ -334,6 +349,66 @@ class TradeExecutor:
         log.debug(
             "gate 7 ok: horizon=%.4fd now (%.4fd at scan) >= %.2fd",
             remaining, candidate.horizon_days, floor,
+        )
+
+        # GATE 8, the order must be large enough for the exchange to accept.
+        #
+        # Polymarket enforces a per-market minimum order size in SHARES
+        # (`orderMinSize`, 5 on every market sampled 2026-09-08), server-side:
+        #
+        #     order 0x... is invalid. Size (1.08) lower than the minimum: 5
+        #
+        # Without this gate a correctly-sized Kelly position of $0.25 passes
+        # every other check, gets approved by a human, commits the money path,
+        # and is refused by the exchange after all of that. Same argument as
+        # GATE 7: the scanner proposes and the executor executes, so the
+        # constraint has to exist in both places.
+        #
+        # The minimum is read LIVE rather than trusted from the candidate. It is
+        # a remote per-market value; hardcoding 5 or trusting a scan-time copy is
+        # the manual-allowlist pattern this codebase has been caught by four
+        # times. Unavailable FAILS CLOSED, and is never assumed to be satisfied.
+        if candidate.sizing_refusal:
+            log.error(
+                "gate 8: candidate was never sizeable (%s), refusing "
+                "(market_id=%s)", candidate.sizing_refusal, candidate.market_id,
+            )
+            raise ExecutionGateError("below_exchange_minimum")
+
+        limits = await self._fetch_market_limits(candidate.condition_id)
+        if limits is None:
+            log.error(
+                "gate 8: could not read live orderMinSize for %s..., refusing "
+                "rather than assuming the usual 5",
+                (candidate.condition_id or "")[:12],
+            )
+            raise ExecutionGateError("below_exchange_minimum")
+
+        live_minimum, live_price = limits
+        price_for_shares = live_price or candidate.market_probability
+        if not price_for_shares or not 0 < float(price_for_shares) <= 1:
+            log.error(
+                "gate 8: no usable price to convert $%.4f into shares "
+                "(market_id=%s), refusing", candidate.amount_usdc, candidate.market_id,
+            )
+            raise ExecutionGateError("below_exchange_minimum")
+
+        implied_shares = candidate.amount_usdc / float(price_for_shares)
+        if implied_shares < live_minimum:
+            # Every number a later capital decision needs, on the refusal line.
+            log.error(
+                "gate 8: order is below the exchange minimum. "
+                "price=%.4f edge=%+.4f notional=%.4f shares=%.4f "
+                "required_shares=%.4f min_notional=%.4f (market_id=%s). "
+                "NOT rounded up: a stake raised to clear an exchange floor is a "
+                "stake chosen by the exchange, not by the edge",
+                float(price_for_shares), candidate.edge, candidate.amount_usdc,
+                implied_shares, live_minimum,
+                live_minimum * float(price_for_shares), candidate.market_id,
+            )
+            raise ExecutionGateError("below_exchange_minimum")
+        log.debug(
+            "gate 8 ok: %.4f shares >= %.4f required", implied_shares, live_minimum,
         )
 
     # --- execution --------------------------------------------------------
@@ -652,13 +727,18 @@ class TradeExecutor:
                     "distrusting it and recording the notional", cash_out, notional,
                 )
                 usdc_amount = notional
-            elif anchor is not None and cash_out > anchor * MAX_CASH_OUT_NOTIONAL_FACTOR:
+            elif anchor is not None and cash_out > anchor * cls._cash_out_ceiling(price):
+                ceiling = cls._cash_out_ceiling(price)
                 log.error(
-                    "relay cash_out %.6f exceeds %.1fx the %s %.6f, "
-                    "distrusting it and recording that instead",
-                    cash_out, MAX_CASH_OUT_NOTIONAL_FACTOR,
+                    "relay cash_out %.6f exceeds %.4fx the %s %.6f (price %s, "
+                    "expected fee ratio %s), distrusting it and recording that "
+                    "instead. A persistent residual here means the fee schedule "
+                    "changed, not that one decode was wrong",
+                    cash_out, ceiling,
                     "matched notional" if notional is not None else "proposed amount",
                     anchor,
+                    f"{price:.4f}" if price else "unknown",
+                    f"{1 + FEE_RATE * (1 - price):.4f}" if price else "unknown",
                 )
                 usdc_amount = anchor
             else:
@@ -678,6 +758,76 @@ class TradeExecutor:
             usdc_amount = requested
 
         return price, shares, usdc_amount
+
+    async def _fetch_market_limits(
+        self, condition_id: Optional[str]
+    ) -> Optional[tuple[float, Optional[float]]]:
+        """Live (orderMinSize, yes_price) from Gamma, or None.
+
+        None means "could not determine", which GATE 8 treats as a refusal. It
+        deliberately does NOT fall back to the candidate's scan-time copy or to
+        a hardcoded 5: an unknown exchange minimum is refused, exactly as an
+        unknown horizon is in GATE 7.
+        """
+        if not condition_id:
+            return None
+        try:
+            response = await self._get_client().get(
+                GAMMA_MARKETS_URL,
+                params={"condition_ids": condition_id},
+                timeout=MARKET_LIMITS_TIMEOUT_SECONDS,
+            )
+            if response.status_code >= 300:
+                log.warning(
+                    "gate 8: gamma HTTP %s for %s...",
+                    response.status_code, condition_id[:12],
+                )
+                return None
+            payload = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            log.warning(
+                "gate 8: gamma lookup failed for %s...: %s",
+                condition_id[:12], type(exc).__name__,
+            )
+            return None
+
+        market = payload[0] if isinstance(payload, list) and payload else payload
+        if not isinstance(market, dict):
+            return None
+
+        raw_min = market.get("orderMinSize")
+        try:
+            minimum = float(raw_min)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(minimum) or minimum <= 0:
+            return None
+
+        price: Optional[float] = None
+        raw_prices = market.get("outcomePrices")
+        try:
+            prices = json.loads(raw_prices) if isinstance(raw_prices, str) else raw_prices
+            if prices and prices[0] is not None:
+                candidate_price = float(prices[0])
+                if 0 < candidate_price <= 1:
+                    price = candidate_price
+        except (TypeError, ValueError):
+            price = None
+
+        return minimum, price
+
+    @staticmethod
+    def _cash_out_ceiling(price: Optional[float]) -> float:
+        """Largest believable cash_out as a multiple of notional, for this price.
+
+        1 + 0.07 * (1 - price) is the exact fee ratio; FEE_TOLERANCE is headroom
+        for rounding and partial fills. Falls back to the all-prices worst case
+        when price is unknown, which is the only case the old flat constant ever
+        described correctly.
+        """
+        if price is None or not math.isfinite(float(price)) or not 0 < float(price) <= 1:
+            return MAX_CASH_OUT_NOTIONAL_FACTOR
+        return 1.0 + FEE_RATE * (1.0 - float(price)) + FEE_TOLERANCE
 
     @staticmethod
     def _extract_tx_hash(payload: dict[str, Any]) -> Optional[str]:

--- a/src/trade_engine/models.py
+++ b/src/trade_engine/models.py
@@ -243,7 +243,18 @@ class ScannerCandidate(BaseModel):
     # validates; GATE 7 refuses when it is absent rather than assuming.
     end_date: Optional[str] = None
     market_url: str
+    # The NOTIONAL handed to the relay, not the wallet debit. The debit is
+    # amount_usdc * (1 + 0.07 * (1 - price)); sizing solves for the notional
+    # whose debit hits the cap, so this is always slightly under it.
     amount_usdc: float
+    # The market's own orderMinSize, in SHARES, read from Gamma at scan time.
+    # Carried for logging and for the scanner's own refusal; executor GATE 8
+    # re-reads it live and does not trust this copy.
+    min_order_size: Optional[float] = None
+    # None when the trade is sizeable. Otherwise why it was not: one of
+    # price_below_sizing_floor, below_exchange_minimum, no_positive_edge,
+    # unknown_min_order_size, invalid_price, invalid_input, invalid_bankroll.
+    sizing_refusal: Optional[str] = None
 
 
 class AnalystRecommendation(BaseModel):

--- a/src/trade_engine/scanner.py
+++ b/src/trade_engine/scanner.py
@@ -34,7 +34,11 @@ import httpx
 
 from src.trade_engine.config import config
 from src.trade_engine.approval import ApprovalGate, ApprovalGateBusy
-from src.trade_engine.database import SupabaseError, write_simulation
+from src.trade_engine.database import (
+    SupabaseError,
+    get_trading_config,
+    write_simulation,
+)
 from src.trade_engine.horizon import horizon_days
 from src.trade_engine.sizing import size_position
 from src.trade_engine.executor import ABSOLUTE_MAX_POSITION_USDC, TradeExecutor
@@ -557,11 +561,18 @@ class PolymarketScanner:
 
             probability = sim.get("probability")
             if probability is None or not isinstance(probability, (int, float)) \
-                    or not math.isfinite(float(probability)):
+                    or isinstance(probability, bool) \
+                    or not math.isfinite(float(probability)) \
+                    or not 0.0 <= float(probability) <= 1.0:
                 # monte_carlo sanitises non-finite floats to null before jsonify.
                 errors += 1
+                # RANGE, not just finiteness. This is a remote HTTP service
+                # with no asserted response schema, and everything downstream
+                # treats the value as a probability: the sizing model's central
+                # result depends on p <= 1. sizing.size_position re-checks it,
+                # because a guard on the money path belongs at both ends.
                 log.warning(
-                    "simulate returned non-finite probability for market %s (%s): %r",
+                    "simulate returned an unusable probability for market %s (%s): %r",
                     candidate["market_id"], candidate["asset"], probability,
                 )
                 continue
@@ -589,6 +600,25 @@ class PolymarketScanner:
         no_edge: list[ScannerCandidate] = []
         neutral_count = 0
 
+        # The ceiling GATE 5 enforces FIRST, read once per run rather than per
+        # candidate. Sizing against the hard 25 while the executor refuses above
+        # trading_config's 10 would propose a figure the system will not honour.
+        # Unreadable config falls back to the hard ceiling and logs: Kelly at
+        # this bankroll tops out at $2.50 so neither bound can bind, and GATE 5
+        # re-reads the real value live before any order regardless.
+        ceiling = ABSOLUTE_MAX_POSITION_USDC
+        try:
+            cfg = await get_trading_config()
+            configured = float(cfg.max_position_usdc or 0)
+            if configured > 0:
+                ceiling = min(configured, ABSOLUTE_MAX_POSITION_USDC)
+        except (SupabaseError, ValueError, TypeError) as exc:
+            log.warning(
+                "could not read max_position_usdc for sizing (%s), sizing "
+                "against the hard ceiling $%.2f; GATE 5 still enforces the "
+                "configured value live", exc, ceiling,
+            )
+
         for row in simulated:
             sim = row["simulation"]
             sim_probability = float(sim["probability"])
@@ -596,9 +626,9 @@ class PolymarketScanner:
             volume = row["volume"]
 
             if edge >= config.high_edge_threshold and volume >= config.min_alert_volume:
-                high_edge.append(self._to_candidate(row, edge, sim_probability))
+                high_edge.append(self._to_candidate(row, edge, sim_probability, ceiling))
             elif edge <= config.no_edge_threshold and volume >= config.min_alert_volume:
-                no_edge.append(self._to_candidate(row, edge, sim_probability))
+                no_edge.append(self._to_candidate(row, edge, sim_probability, ceiling))
             else:
                 neutral_count += 1
 
@@ -622,7 +652,8 @@ class PolymarketScanner:
 
     @staticmethod
     def _to_candidate(
-        row: dict[str, Any], edge: float, sim_probability: float
+        row: dict[str, Any], edge: float, sim_probability: float,
+        ceiling: float = ABSOLUTE_MAX_POSITION_USDC,
     ) -> ScannerCandidate:
         slug = row.get("slug") or ""
         condition_id = row.get("condition_id")
@@ -634,7 +665,8 @@ class PolymarketScanner:
             min_order_size=row.get("min_order_size"),
             bankroll=config.bankroll_usdc,
             kelly_fraction=config.kelly_fraction,
-            max_position_usdc=ABSOLUTE_MAX_POSITION_USDC,
+            max_position_usdc=ceiling,
+            absolute_max_usdc=ABSOLUTE_MAX_POSITION_USDC,
             price_floor=config.sizing_price_floor,
         )
         if not sizing.tradeable:

--- a/src/trade_engine/scanner.py
+++ b/src/trade_engine/scanner.py
@@ -36,7 +36,8 @@ from src.trade_engine.config import config
 from src.trade_engine.approval import ApprovalGate, ApprovalGateBusy
 from src.trade_engine.database import SupabaseError, write_simulation
 from src.trade_engine.horizon import horizon_days
-from src.trade_engine.executor import TradeExecutor
+from src.trade_engine.sizing import size_position
+from src.trade_engine.executor import ABSOLUTE_MAX_POSITION_USDC, TradeExecutor
 from src.trade_engine.models import (
     ApprovalStatus,
     ScannerCandidate,
@@ -122,11 +123,10 @@ YES_PRICE_MAX = 0.99
 RUNGS_PER_EVENT = 3
 GLOBAL_CAP = 30
 
-# Position sizing: $3 at the high-edge threshold, $10 at edge 0.15+.
-AMOUNT_MIN_USDC = 3.0
-AMOUNT_MAX_USDC = 10.0
-AMOUNT_EDGE_FLOOR = 0.07
-AMOUNT_EDGE_CEILING = 0.15
+# Position sizing is fractional Kelly on the DEBIT, in sizing.py. The linear
+# $3-to-$10 ramp on edge that used to live here is gone: it had no relationship
+# to bankroll or to what the trade could lose, and it sized the notional while
+# the wallet pays notional plus fee. AMOUNT_EDGE_FLOOR/CEILING went with it.
 
 # Session 5 will enforce this before any execution; here it only gates the
 # best_trade suggestion.
@@ -195,18 +195,23 @@ def _outcome_yes_price(market: dict[str, Any]) -> Optional[float]:
     return None
 
 
-def _amount_usdc(edge: float) -> float:
-    """Linear $3-$10 on edge magnitude, clamped.
+def _market_min_order_size(market: dict[str, Any]) -> Optional[float]:
+    """The market's own orderMinSize, in SHARES, from the Gamma payload.
 
-    Uses abs(edge) so a NO-side candidate sizes on conviction too. For the
-    high-edge bucket (edge > 0) this is identical to the briefed formula; only
-    best_trade ever drives money, and best_trade only comes from high_edge.
+    Read per market rather than hardcoded to 5. It is a REMOTE value: baking a
+    copy into the code is the manual-allowlist pattern this codebase has been
+    caught by repeatedly, and it would silently size against the wrong floor the
+    day Polymarket changes it for one market. Absent means unknown, which
+    sizing.size_position fails closed on.
     """
-    span = AMOUNT_EDGE_CEILING - AMOUNT_EDGE_FLOOR
-    scaled = AMOUNT_MIN_USDC + (abs(edge) - AMOUNT_EDGE_FLOOR) / span * (
-        AMOUNT_MAX_USDC - AMOUNT_MIN_USDC
-    )
-    return round(max(AMOUNT_MIN_USDC, min(AMOUNT_MAX_USDC, scaled)), 2)
+    raw = market.get("orderMinSize")
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if math.isfinite(value) and value > 0 else None
 
 
 class PolymarketScanner:
@@ -423,6 +428,10 @@ class PolymarketScanner:
                 "horizon_days": horizon_days,
                 "end_date": end_date,
                 "volume": volume,
+                # The exchange's per-market share minimum, read from the Gamma
+                # payload we already have. None when absent, which sizing fails
+                # closed on rather than assuming the usual 5.
+                "min_order_size": _market_min_order_size(market),
                 "needs_simulation": True,
                 "source": market.get("source") or "polymarket",
                 "event_slug": market.get("event_slug"),
@@ -617,6 +626,26 @@ class PolymarketScanner:
     ) -> ScannerCandidate:
         slug = row.get("slug") or ""
         condition_id = row.get("condition_id")
+        direction = "YES" if edge > 0 else "NO"
+        sizing = size_position(
+            sim_probability=sim_probability,
+            yes_price=row["yes_price"],
+            direction=direction,
+            min_order_size=row.get("min_order_size"),
+            bankroll=config.bankroll_usdc,
+            kelly_fraction=config.kelly_fraction,
+            max_position_usdc=ABSOLUTE_MAX_POSITION_USDC,
+            price_floor=config.sizing_price_floor,
+        )
+        if not sizing.tradeable:
+            # Measurement, not noise. Item (c) of the sizing decision is to find
+            # out how often correct sizing lands under the exchange floor and at
+            # what prices, because that is the input to any future capital
+            # decision. Every refusal carries its own arithmetic.
+            log.info(
+                "not sizeable (%s): %s | %s",
+                sizing.refusal, row.get("question"), sizing.log_fields(),
+            )
         return ScannerCandidate(
             market_id=str(row["market_id"]),
             # Carried separately from market_id because they are different
@@ -626,7 +655,7 @@ class PolymarketScanner:
             condition_id=str(condition_id) if condition_id else None,
             question=row["question"] or "",
             asset=row["asset"],
-            direction="YES" if edge > 0 else "NO",
+            direction=direction,
             edge=edge,
             sim_probability=sim_probability,
             market_probability=row["yes_price"],
@@ -639,7 +668,9 @@ class PolymarketScanner:
             # floor to below it.
             end_date=row.get("end_date"),
             market_url=POLYMARKET_MARKET_URL.format(slug=slug) if slug else "",
-            amount_usdc=_amount_usdc(edge),
+            amount_usdc=sizing.notional,
+            min_order_size=row.get("min_order_size"),
+            sizing_refusal=sizing.refusal,
         )
 
     # --- select -----------------------------------------------------------
@@ -653,13 +684,24 @@ class PolymarketScanner:
         """
         if not summary.high_edge:
             return None
+        # A candidate that could not be sized is not a trade. It stays in the
+        # high_edge bucket and is still reported, because the sizing refusal is
+        # the measurement we want; it just cannot be proposed.
+        sizeable = [c for c in summary.high_edge if not c.sizing_refusal]
+        if not sizeable:
+            log.info(
+                "%d high-edge candidate(s), none sizeable: %s",
+                len(summary.high_edge),
+                ", ".join(sorted({c.sizing_refusal or "?" for c in summary.high_edge})),
+            )
+            return None
         if summary.open_positions >= MAX_CONCURRENT_POSITIONS:
             log.info(
                 "position cap reached (%d open >= %d), no best_trade selected",
                 summary.open_positions, MAX_CONCURRENT_POSITIONS,
             )
             return None
-        return max(summary.high_edge, key=lambda c: abs(c.edge))
+        return max(sizeable, key=lambda c: abs(c.edge))
 
     # --- analyst ----------------------------------------------------------
 
@@ -684,9 +726,28 @@ class PolymarketScanner:
             log.info("Analyst PASS: %s", recommendation.reasoning)
         elif recommendation.recommendation == "reduce":
             before = summary.best_trade.amount_usdc
-            summary.best_trade.amount_usdc = round(
-                max(AMOUNT_MIN_USDC, before / 2), 2
-            )
+            # REDUCE MUST NEVER INCREASE. This was max(AMOUNT_MIN_USDC, before/2)
+            # with a $3 floor, which on a $1.23 Kelly position returned $3.00: a
+            # 2.4x increase, on the exact path where the Analyst has just said
+            # it is less confident. A safety inversion, masked only because the
+            # old ramp never sized below $3. min() makes it structural rather
+            # than a property of the numbers.
+            summary.best_trade.amount_usdc = min(before, round(before / 2, 6))
+
+            # Halving can push a position under the exchange's share minimum.
+            # That is a refusal, not a smaller trade, and it is recorded here so
+            # nobody is asked to approve something that cannot be placed.
+            price = summary.best_trade.market_probability
+            minimum = summary.best_trade.min_order_size
+            if price and minimum:
+                side = summary.best_trade.amount_usdc / price
+                if side < float(minimum):
+                    summary.best_trade.sizing_refusal = "below_exchange_minimum"
+                    log.warning(
+                        "Analyst REDUCE put the position under the exchange "
+                        "minimum: %.4f shares < %.4f required, not tradeable",
+                        side, float(minimum),
+                    )
             log.info(
                 "Analyst REDUCE: %s, new size $%.2f (was $%.2f)",
                 recommendation.reasoning, summary.best_trade.amount_usdc, before,
@@ -762,6 +823,17 @@ class PolymarketScanner:
         summary.approval_result = None
 
         if summary.best_trade is None:
+            return
+
+        if summary.best_trade.sizing_refusal:
+            # Reachable when the Analyst's REDUCE pushed it under the exchange
+            # minimum. Executor GATE 8 would refuse it anyway; stopping here
+            # avoids putting a one-tap Execute button on a trade that cannot be
+            # placed.
+            log.info(
+                "best_trade is not sizeable (%s), no approval requested",
+                summary.best_trade.sizing_refusal,
+            )
             return
 
         recommendation = summary.analyst_recommendation

--- a/src/trade_engine/sizing.py
+++ b/src/trade_engine/sizing.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Fractional-Kelly position sizing, fee-aware, and the exchange minimum.
+
+Pure. No network, no config import, no logging. Everything is passed in, so the
+arithmetic can be tested directly and so the scanner and executor GATE 8 can run
+the SAME function against different inputs, the way horizon.py serves the
+scanner and GATE 7.
+
+WHAT REPLACED WHAT
+------------------
+Until 2026-09-08 size was a linear ramp on edge: $3 at a 7-point edge rising to
+$10 at 15 points, floored at $3. It had no relationship to bankroll, to the
+probability estimate's confidence, or to what the trade could lose. It also
+sized the NOTIONAL while the wallet is debited notional PLUS fee, so every
+position quietly overspent its own ceiling.
+
+THE THREE THINGS THIS GETS RIGHT
+--------------------------------
+1. Kelly, fractionally. For a binary contract bought at `side_price` with true
+   probability `true_prob`, the full-Kelly fraction of bankroll is
+   (true_prob - side_price) / (1 - side_price). KELLY_FRACTION scales it down.
+   Kelly ONLY sizes down from the configured maximum; it can never size up.
+
+2. The fee. fee = 0.07 * price * (1 - price) * shares, equivalently
+   fee / notional = 0.07 * (1 - price). Verified against the 2026-08-20 receipt:
+   10.501189 debited against 10.00 notional at price 0.284 is a ratio of
+   1.05012, against a predicted 1 + 0.07 * 0.716 = 1.05012. So sizing to a cap
+   means notional = cap / (1 + 0.07 * (1 - price)), and the CAP IS THE DEBIT.
+
+3. The exchange minimum, which is in SHARES and is the reason most trades will
+   now be refused rather than resized. See the module note below.
+
+WHY ALMOST NOTHING WILL TRADE, AND WHY THAT IS CORRECT
+------------------------------------------------------
+Polymarket enforces a per-market minimum order size in SHARES (`orderMinSize`,
+5 on every market sampled 2026-09-08), server-side:
+
+    order 0x... is invalid. Size (1.08) lower than the minimum: 5
+
+Ignoring the fee term, clearing that minimum requires
+
+    shares = KELLY_FRACTION * bankroll * edge / (price * (1 - price)) >= 5
+    i.e.    edge >= 2 * price * (1 - price)        at KELLY_FRACTION * bankroll = 2.5
+
+Two consequences, and the second is the one that surprises.
+
+At the 7-point edge floor the condition needs price * (1 - price) <= 0.035, so
+price <= 0.036, which the 0.10 sizing floor excludes. NOTHING sized at the
+minimum qualifying edge can ever be placed.
+
+And edge can never exceed (1 - price), since that is the payoff. Requiring
+edge >= 2 * price * (1 - price) therefore requires 2 * price <= 1. **Above
+price 0.5 the minimum is unreachable at ANY edge, including certainty.** At
+p = 1 the notional collapses to KELLY_FRACTION * bankroll = $2.50 whatever the
+price, so shares = 2.50 / price, which crosses 5 at price 0.48. Deep favourites
+are the one region that is arithmetically impossible, not the region that
+survives.
+
+What survives is a narrow band: price in [0.10, ~0.48] with a very large edge.
+Measured against this implementation, the minimum simulated probability that
+clears 5 shares is 0.29 at price 0.10, 0.54 at 0.20, 0.74 at 0.30, 0.90 at 0.40
+and 0.96 at 0.45. For comparison, the largest edge in the four historical
+positions was 0.336 at price 0.279, which needed 0.395.
+
+That is arithmetic, not a tuning error. At a $25 bankroll the exchange's share
+granularity is coarser than the entire Kelly budget. NEVER "fix" this by raising
+bankroll_usdc: that number came from $29.24 of MEASURED spendable collateral,
+and raising it to the ~$180 that would make Kelly and the exchange compatible at
+mid prices would size against money that does not exist, which is exactly what
+turns Kelly from conservative into dangerous. Making that work is a CAPITAL
+decision, a deposit of about $155, not a config edit.
+
+A system that sizes correctly and therefore almost never trades is behaving
+properly. The model was 7x wrong six weeks ago. Suppression is the discipline
+working, and every refusal is logged with its numbers so the suppression rate
+becomes data for the capital decision rather than a guess.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import NamedTuple, Optional
+
+# Polymarket's taker fee coefficient. fee = FEE_RATE * p * (1-p) * shares.
+# One fee mechanism, not two (build log 2026-09-05). Verified to 4dp against a
+# real settlement receipt; see the module docstring.
+FEE_RATE = 0.07
+
+
+class PositionSizing(NamedTuple):
+    """A sizing decision, with everything needed to log why.
+
+    `tradeable` is the only field callers should branch on. The rest exists so a
+    refusal can be recorded with its arithmetic rather than as a bare reason
+    string: the whole point of (c) is to measure how often, and at what prices,
+    correct sizing lands under the exchange floor.
+    """
+
+    tradeable: bool
+    refusal: Optional[str]
+    notional: float           # what the relay is told to spend (amount_usdc)
+    debit: float              # what actually leaves the wallet, notional + fee
+    shares: float             # notional / side_price
+    required_shares: float    # the exchange's orderMinSize for this market
+    side_price: float         # price of the side being bought
+    edge: float               # true_prob - side_price, for the side being bought
+    kelly_fraction: float     # fraction of bankroll after KELLY_FRACTION scaling
+    kelly_debit: float        # debit Kelly asked for, before any clamp
+    clamped_by: Optional[str] # set when the hard ceiling bound the size down
+    min_notional: float       # required_shares * side_price
+    min_debit: float          # the same, including fee
+
+    def log_fields(self) -> str:
+        """One line carrying every number a later capital decision needs."""
+        return (
+            f"price={self.side_price:.4f} edge={self.edge:+.4f} "
+            f"kelly_f={self.kelly_fraction:.5f} kelly_notional={self.notional:.4f} "
+            f"debit={self.debit:.4f} shares={self.shares:.4f} "
+            f"required_shares={self.required_shares:.4f} "
+            f"min_notional={self.min_notional:.4f} min_debit={self.min_debit:.4f}"
+        )
+
+
+def _refused(reason: str, **kw) -> PositionSizing:
+    base = dict(
+        tradeable=False, refusal=reason, notional=0.0, debit=0.0, shares=0.0,
+        required_shares=0.0, side_price=0.0, edge=0.0, kelly_fraction=0.0,
+        kelly_debit=0.0, clamped_by=None, min_notional=0.0, min_debit=0.0,
+    )
+    base.update(kw)
+    return PositionSizing(**base)
+
+
+def fee_ratio(side_price: float) -> float:
+    """fee / notional for a market bought at `side_price`.
+
+    Depends only on price, which is why MAX_CASH_OUT_NOTIONAL_FACTOR can be
+    computed per trade instead of held at a flat worst-case constant.
+    """
+    return FEE_RATE * (1.0 - side_price)
+
+
+def side_price_for(direction: str, yes_price: float) -> float:
+    """Price of the side actually being bought.
+
+    The old sizing used abs(edge) and apologised for it in a docstring. Buying
+    NO at (1 - yes_price) with true probability (1 - p) is the same Kelly
+    problem with both terms complemented, so sizing it correctly costs one line
+    and removes the hack. best_trade only ever comes from the high-edge bucket
+    today, so the NO branch is unreachable from the scanner; it is correct
+    rather than dead because nothing should have to remember that.
+    """
+    return yes_price if str(direction).upper() == "YES" else 1.0 - yes_price
+
+
+def size_position(
+    *,
+    sim_probability: float,
+    yes_price: float,
+    direction: str,
+    min_order_size: Optional[float],
+    bankroll: float,
+    kelly_fraction: float,
+    max_position_usdc: float,
+    price_floor: float,
+) -> PositionSizing:
+    """Size one trade, or refuse it with a reason.
+
+    `min_order_size` is the market's own `orderMinSize`, read live rather than
+    hardcoded: it is a remote value and baking in a copy is the manual-allowlist
+    pattern this codebase has been bitten by repeatedly. None means it could not
+    be read, and that FAILS CLOSED.
+
+    `max_position_usdc` bounds the DEBIT, not the notional. It sits ABOVE Kelly
+    and only ever binds downward; when it binds, `clamped_by` records it.
+    """
+    # Inputs first, so a refusal never carries arithmetic derived from garbage.
+    for name, value in (("sim_probability", sim_probability), ("yes_price", yes_price)):
+        if value is None or not isinstance(value, (int, float)) or isinstance(value, bool) \
+                or not math.isfinite(float(value)):
+            return _refused("invalid_input")
+    if not 0.0 < float(yes_price) < 1.0:
+        return _refused("invalid_price")
+    if min_order_size is None or not math.isfinite(float(min_order_size)) \
+            or float(min_order_size) <= 0:
+        # Fail closed. An unknown exchange minimum is refused, never assumed to
+        # be 5, and never assumed to be satisfied.
+        return _refused("unknown_min_order_size")
+    if not math.isfinite(float(bankroll)) or bankroll <= 0:
+        return _refused("invalid_bankroll")
+
+    price = side_price_for(direction, float(yes_price))
+    true_prob = float(sim_probability) if str(direction).upper() == "YES" \
+        else 1.0 - float(sim_probability)
+    edge = true_prob - price
+    required = float(min_order_size)
+    min_notional = required * price
+    min_debit = min_notional * (1.0 + fee_ratio(price))
+
+    common = dict(
+        side_price=price, edge=edge, required_shares=required,
+        min_notional=min_notional, min_debit=min_debit,
+    )
+
+    # The sizing price floor is a PROPOSAL filter and is deliberately separate
+    # from YES_PRICE_MIN, which governs inclusion. Sub-floor markets are still
+    # scanned, simulated and reported; they are just never sized or proposed,
+    # which keeps the question answerable from data later.
+    if price < price_floor:
+        return _refused("price_below_sizing_floor", **common)
+
+    if edge <= 0:
+        # Kelly says do not bet. Not an error; the no-edge bucket lands here.
+        return _refused("no_positive_edge", **common)
+
+    full_kelly = edge / (1.0 - price)
+    fraction = kelly_fraction * full_kelly
+    kelly_debit = fraction * bankroll
+
+    cap = kelly_debit
+    clamped_by = None
+    if cap > max_position_usdc:
+        cap = max_position_usdc
+        clamped_by = "max_position_usdc"
+
+    # Size on the DEBIT: the wallet pays notional + fee, so solve for the
+    # notional whose debit equals the cap.
+    #
+    # Round FIRST, then derive shares and debit from the rounded figure. The
+    # rounded notional is what is actually sent to the relay, so it is what the
+    # exchange divides by price to get the order size; deriving shares from the
+    # unrounded value would mean the share count checked against the minimum is
+    # not the share count the exchange computes. At the boundary that is the
+    # difference between a refusal and a rejected order.
+    notional = round(cap / (1.0 + fee_ratio(price)), 6)
+    shares = notional / price
+    debit = notional * (1.0 + fee_ratio(price))
+
+    sized = dict(
+        common, notional=notional, debit=round(debit, 6),
+        shares=shares, kelly_fraction=fraction, kelly_debit=kelly_debit,
+        clamped_by=clamped_by,
+    )
+
+    if shares < required:
+        # NEVER round up to reach the minimum. Rounding up would abandon the
+        # only property Kelly provides, which is that the stake is proportional
+        # to the edge; a stake raised to clear an exchange floor is a stake
+        # chosen by the exchange.
+        return PositionSizing(tradeable=False, refusal="below_exchange_minimum", **sized)
+
+    return PositionSizing(tradeable=True, refusal=None, **sized)

--- a/src/trade_engine/sizing.py
+++ b/src/trade_engine/sizing.py
@@ -44,23 +44,48 @@ Ignoring the fee term, clearing that minimum requires
 
 Two consequences, and the second is the one that surprises.
 
-At the 7-point edge floor the condition needs price * (1 - price) <= 0.035, so
-price <= 0.036, which the 0.10 sizing floor excludes. NOTHING sized at the
-minimum qualifying edge can ever be placed.
+FIRST. At the 7-point edge floor the condition needs price * (1 - price) <= 0.035.
+That inequality has TWO roots, and both are stated here deliberately, because an
+earlier version of this derivation reported only one of them and the other is
+where an error lived:
 
-And edge can never exceed (1 - price), since that is the payoff. Requiring
-edge >= 2 * price * (1 - price) therefore requires 2 * price <= 1. **Above
-price 0.5 the minimum is unreachable at ANY edge, including certainty.** At
-p = 1 the notional collapses to KELLY_FRACTION * bankroll = $2.50 whatever the
-price, so shares = 2.50 / price, which crosses 5 at price 0.48. Deep favourites
-are the one region that is arithmetically impossible, not the region that
-survives.
+    price <= 0.036319    excluded by the 0.10 sizing price floor
+    price >= 0.963681    excluded for a DIFFERENT reason, see below
 
-What survives is a narrow band: price in [0.10, ~0.48] with a very large edge.
-Measured against this implementation, the minimum simulated probability that
-clears 5 shares is 0.29 at price 0.10, 0.54 at 0.20, 0.74 at 0.30, 0.90 at 0.40
-and 0.96 at 0.45. For comparison, the largest edge in the four historical
-positions was 0.336 at price 0.279, which needed 0.395.
+The upper root is not a feasible region. At price 0.963681 the largest edge that
+can exist is 1 - price = 0.036319, so an edge of 0.07 is unreachable there: the
+root solves the inequality while violating the constraint edge <= 1 - price. An
+earlier audit reported that root as the surviving region. It is the opposite.
+Nothing sized at the minimum qualifying edge can be placed at any price.
+
+SECOND. Edge can never exceed (1 - price), since that is the whole payoff.
+Requiring edge >= 2 * price * (1 - price) therefore requires 2 * price <= 1, so
+ABOVE PRICE 0.5 THE MINIMUM IS UNREACHABLE AT ANY EDGE, INCLUDING CERTAINTY.
+Deep favourites are the region that is arithmetically impossible, not the region
+that survives.
+
+The exact cut is 0.482521, not 0.5. 0.5 is the FEE-FREE answer; including the
+fee the condition is
+
+    2 * price * (1 + 0.07 * (1 - price)) <= 1
+    0.14 * price^2 - 2.14 * price + 1 >= 0
+    price <= 0.482521
+
+Both numbers are correct for their own model and they are not interchangeable.
+The code is fee-aware, so 0.482521 is the one that describes it, and it is the
+only one quoted elsewhere.
+
+What survives is a narrow band: price in [0.10, 0.482521] with a very large
+edge. The minimum simulated probability that clears 5 shares, from this
+implementation:
+
+    price   0.10   0.15   0.20   0.25   0.30   0.35   0.40   0.45   0.4825
+    p_min   0.291  0.420  0.538  0.645  0.741  0.826  0.900  0.964  1.000
+
+For comparison, the largest edge in the four historical positions was 0.336 at
+price 0.279, which needed 0.4226. (An earlier version of this docstring said
+0.395. That number is wrong and is reproducible by no formula here; it appears
+to be a transcription of min_notional = 5 * 0.279 = 1.395.)
 
 That is arithmetic, not a tuning error. At a $25 bankroll the exchange's share
 granularity is coarser than the entire Kelly budget. NEVER "fix" this by raising
@@ -112,12 +137,16 @@ class PositionSizing(NamedTuple):
 
     def log_fields(self) -> str:
         """One line carrying every number a later capital decision needs."""
+        # sized_notional, not "kelly_notional": this is the figure AFTER any
+        # clamp, and the pre-clamp Kelly ask is kelly_debit. The two differ
+        # whenever clamped_by is set, and the old label named the wrong one.
         return (
             f"price={self.side_price:.4f} edge={self.edge:+.4f} "
-            f"kelly_f={self.kelly_fraction:.5f} kelly_notional={self.notional:.4f} "
-            f"debit={self.debit:.4f} shares={self.shares:.4f} "
-            f"required_shares={self.required_shares:.4f} "
-            f"min_notional={self.min_notional:.4f} min_debit={self.min_debit:.4f}"
+            f"kelly_f={self.kelly_fraction:.5f} kelly_debit={self.kelly_debit:.4f} "
+            f"sized_notional={self.notional:.4f} debit={self.debit:.4f} "
+            f"shares={self.shares:.4f} required_shares={self.required_shares:.4f} "
+            f"min_notional={self.min_notional:.4f} min_debit={self.min_debit:.4f} "
+            f"clamped_by={self.clamped_by or 'none'}"
         )
 
 
@@ -163,6 +192,7 @@ def size_position(
     kelly_fraction: float,
     max_position_usdc: float,
     price_floor: float,
+    absolute_max_usdc: Optional[float] = None,
 ) -> PositionSizing:
     """Size one trade, or refuse it with a reason.
 
@@ -181,6 +211,16 @@ def size_position(
             return _refused("invalid_input")
     if not 0.0 < float(yes_price) < 1.0:
         return _refused("invalid_price")
+    # A PROBABILITY, so range-checked and not merely finite. The whole
+    # "impossible above price 0.5" result rests on edge <= 1 - price, which
+    # rests on p <= 1; nothing upstream enforced it and the Monte Carlo worker
+    # is a remote HTTP service with no asserted response schema. Measured before
+    # this check existed: p = 1.05 at price 0.98 returned a TRADEABLE $8.74
+    # notional, inside the region this module calls arithmetically impossible.
+    # The old linear ramp clamped every input to $10 no matter what; Kelly is
+    # linear in the edge, so the same unit slip now runs to the ceiling.
+    if not 0.0 <= float(sim_probability) <= 1.0:
+        return _refused("invalid_probability")
     if min_order_size is None or not math.isfinite(float(min_order_size)) \
             or float(min_order_size) <= 0:
         # Fail closed. An unknown exchange minimum is refused, never assumed to
@@ -188,6 +228,12 @@ def size_position(
         return _refused("unknown_min_order_size")
     if not math.isfinite(float(bankroll)) or bankroll <= 0:
         return _refused("invalid_bankroll")
+    # A negative fraction produced a NEGATIVE notional refused as
+    # "below_exchange_minimum", which is the wrong diagnosis in the refusal logs
+    # decision (c) is meant to be mined from. GATE 5 caught the negative amount,
+    # so it was fail-closed and mislabelled rather than dangerous.
+    if not math.isfinite(float(kelly_fraction)) or kelly_fraction <= 0:
+        return _refused("invalid_kelly_fraction")
 
     price = side_price_for(direction, float(yes_price))
     true_prob = float(sim_probability) if str(direction).upper() == "YES" \
@@ -217,11 +263,22 @@ def size_position(
     fraction = kelly_fraction * full_kelly
     kelly_debit = fraction * bankroll
 
+    # Size against the ceiling the executor actually ENFORCES FIRST. GATE 5
+    # checks trading_config.max_position_usdc (live value 10) before the hard
+    # ABSOLUTE_MAX_POSITION_USDC (25), so sizing against 25 could propose a $12
+    # position, show that number to a human, and have GATE 5 refuse it after
+    # approval. Same class as the approval-path guard: never put a figure in
+    # front of someone that the system will not honour.
+    ceiling = max_position_usdc
+    ceiling_name = "max_position_usdc"
+    if absolute_max_usdc is not None and absolute_max_usdc < ceiling:
+        ceiling, ceiling_name = absolute_max_usdc, "absolute_max_position_usdc"
+
     cap = kelly_debit
     clamped_by = None
-    if cap > max_position_usdc:
-        cap = max_position_usdc
-        clamped_by = "max_position_usdc"
+    if cap > ceiling:
+        cap = ceiling
+        clamped_by = ceiling_name
 
     # Size on the DEBIT: the wallet pays notional + fee, so solve for the
     # notional whose debit equals the cap.
@@ -242,6 +299,11 @@ def size_position(
         clamped_by=clamped_by,
     )
 
+    # STRICTLY less than. Exactly the minimum is ADMITTED, matching GATE 8's
+    # comparison; the two must agree or a trade the scanner sizes is refused at
+    # execution for a reason the scanner did not anticipate. Mutants moving this
+    # boundary either way, including admitting 1% under, survived the suite
+    # until it was pinned on both sides.
     if shares < required:
         # NEVER round up to reach the minimum. Rounding up would abandon the
         # only property Kelly provides, which is that the stake is proportional

--- a/tests/test_analyst.py
+++ b/tests/test_analyst.py
@@ -355,16 +355,32 @@ class TestScannerAppliesReduce(unittest.TestCase):
         self.assertFalse(summary.analyst_skip)
         self.assertEqual(summary.analyst_recommendation.recommendation, "reduce")
 
-    def test_reduce_floors_at_three_dollars(self):
+    def test_reduce_never_increases_the_position(self):
+        """This test used to be test_reduce_floors_at_three_dollars, and it
+        asserted the defect.
+
+        The old code was max(AMOUNT_MIN_USDC, before / 2) with a $3 floor, so a
+        $3.00 position "reduced" to $3.00 and a $1.23 Kelly position "reduced"
+        to $3.00: a 2.4x INCREASE, on the exact path where the Analyst has just
+        expressed doubt. The floor was invisible while the old sizing ramp never
+        went below $3, and became a live safety inversion the moment Kelly did.
+
+        REDUCE must reduce. Asserted across the range rather than at one value,
+        because the old assertion passed at exactly one point.
+        """
         patch_history(self, [])
-        client = StubClient(text=json.dumps({
-            "recommendation": "reduce", "confidence": 0.4,
-            "reasoning": "Marginal.", "flags": ["marginal_edge"],
-        }))
-        summary = make_summary(make_candidate(amount_usdc=3.0))
-        scanner = PolymarketScanner(analyst=TradeAnalyst(client=client))
-        run(scanner.apply_analyst(summary))
-        self.assertEqual(summary.best_trade.amount_usdc, 3.0)
+        for before in (0.25, 1.23, 3.0, 10.0):
+            with self.subTest(before=before):
+                client = StubClient(text=json.dumps({
+                    "recommendation": "reduce", "confidence": 0.4,
+                    "reasoning": "Marginal.", "flags": ["marginal_edge"],
+                }))
+                summary = make_summary(make_candidate(amount_usdc=before))
+                scanner = PolymarketScanner(analyst=TradeAnalyst(client=client))
+                run(scanner.apply_analyst(summary))
+                after = summary.best_trade.amount_usdc
+                self.assertLess(after, before, "REDUCE must never increase")
+                self.assertAlmostEqual(after, before / 2, places=6)
 
 
 # 8. pass sets analyst_skip

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -121,6 +121,28 @@ SUCCESS_STDOUT = json.dumps({
 })
 
 
+class _FakeGamma:
+    """Minimal httpx-shaped client for driving _fetch_market_limits directly."""
+
+    def __init__(self, payload, status=200, raises=None):
+        self._payload, self._status, self._raises = payload, status, raises
+        self.calls = []
+
+    async def get(self, url, params=None, timeout=None):
+        self.calls.append((url, params))
+        return _FakeResponse(self._payload, self._status, self._raises)
+
+
+class _FakeResponse:
+    def __init__(self, payload, status, raises):
+        self._payload, self.status_code, self._raises = payload, status, raises
+
+    def json(self):
+        if self._raises is not None:
+            raise self._raises
+        return self._payload
+
+
 class StubExecutor(TradeExecutor):
     """TradeExecutor with the subprocess and Telegram edges replaced."""
 
@@ -518,13 +540,111 @@ class GateTest(unittest.TestCase):
         self.assertEqual(result.gate_blocked, "below_exchange_minimum")
 
     def test_gate8_fails_closed_when_the_minimum_cannot_be_read(self):
-        """Never assumed to be the usual 5, and never assumed satisfied."""
+        """Never assumed to be the usual 5, and never assumed satisfied.
+
+        The candidate CARRIES a permissive min_order_size, because that is the
+        only case in which a fallback is possible and therefore the only case
+        that tests fail-closed. The previous version of this test used a
+        candidate with min_order_size=None, so a mutant falling back to the
+        candidate's copy whenever the live read failed survived the whole
+        suite: it kept the live fetch, kept live-wins, and broke only this half.
+        """
         ex = StubExecutor(market_limits=None)
         with DBStub():
-            result = run(ex.execute(make_approval(amount_usdc=9.0)))
+            result = run(ex.execute(make_approval(
+                amount_usdc=9.0, market_probability=0.40, min_order_size=1.0
+            )))
         self.assertFalse(result.success)
         self.assertEqual(result.gate_blocked, "below_exchange_minimum")
         self.assertEqual(ex.argv_calls, [])
+
+    def test_gate8_never_falls_back_to_the_candidates_copy(self):
+        """Asserts the docstring's claim, which was asserted nowhere.
+
+        _fetch_market_limits says it "deliberately does NOT fall back to the
+        candidate's scan-time copy". With a candidate whose copy would easily
+        admit the order, an unreadable live value must still refuse.
+        """
+        for copy in (1.0, 0.001, 5.0):
+            with self.subTest(candidate_min=copy):
+                ex = StubExecutor(market_limits=None)
+                with DBStub():
+                    result = run(ex.execute(make_approval(
+                        amount_usdc=9.0, market_probability=0.40,
+                        min_order_size=copy,
+                    )))
+                self.assertFalse(result.success)
+                self.assertEqual(result.gate_blocked, "below_exchange_minimum")
+
+    def test_gate8_uses_the_live_minimum_exactly_not_the_stricter_of_the_two(self):
+        """Kills max(live, candidate): the gate must use the live value, not
+        merely something no weaker than it. A candidate copy STRICTER than live
+        must not tighten the gate either."""
+        ex = StubExecutor(market_limits=(5.0, 0.40))
+        with DBStub():
+            result = run(ex.execute(make_approval(
+                amount_usdc=4.0, market_probability=0.40, min_order_size=500.0
+            )))
+        self.assertTrue(result.success, "10 shares clears the LIVE minimum of 5")
+
+    # --- the boundary, pinned on both sides ------------------------------
+
+    def test_gate8_admits_exactly_the_minimum(self):
+        """5.000000 shares trades, matching sizing.py's comparison."""
+        ex = StubExecutor(market_limits=(5.0, 0.40))
+        with DBStub():
+            result = run(ex.execute(make_approval(
+                amount_usdc=2.0, market_probability=0.40
+            )))
+        self.assertTrue(result.success, "2.00 / 0.40 is exactly 5 shares")
+
+    def test_gate8_refuses_a_hair_under_the_minimum(self):
+        """Kills `<=`, `- 1e-6` slack, and `* 0.99`. Nothing sat at the
+        boundary before, and the boundary is the entire question."""
+        for amount, shares in ((1.999996, 4.99999), (1.98, 4.95), (1.9, 4.75)):
+            with self.subTest(shares=shares):
+                ex = StubExecutor(market_limits=(5.0, 0.40))
+                with DBStub():
+                    result = run(ex.execute(make_approval(
+                        amount_usdc=amount, market_probability=0.40
+                    )))
+                self.assertFalse(result.success, f"{shares} shares must refuse")
+                self.assertEqual(result.gate_blocked, "below_exchange_minimum")
+
+    def test_gate8_converts_at_the_price_of_the_side_being_bought(self):
+        """A NO candidate priced 0.85 YES is bought at 0.15.
+
+        sizing.py complements the price for NO; the gate did not, so it divided
+        a NO notional by the YES price and refused sizeable NO candidates.
+        Unreachable today because best_trade is always YES, which is exactly
+        what the NO branch in sizing.py exists to stop anyone relying on.
+        """
+        ex = StubExecutor(market_limits=(5.0, 0.85))
+        with DBStub():
+            # `edge` is left POSITIVE deliberately. A real NO candidate carries
+            # a negative edge and GATE 4 refuses it long before GATE 8, which is
+            # the sense in which this is unreachable today. Keeping edge
+            # positive isolates GATE 8's price conversion, which is the property
+            # under test; the alternative is asserting nothing about it at all.
+            result = run(ex.execute(make_approval(
+                direction="NO", amount_usdc=1.0, market_probability=0.85,
+                edge=0.30, sim_probability=0.20,
+            )))
+        self.assertTrue(result.success, "1.00 / 0.15 is 6.67 shares, over the minimum")
+
+    def test_gate8_refuses_a_NO_candidate_that_is_genuinely_too_small(self):
+        """The other side of the same conversion: at the NO price of 0.15,
+        $0.50 is 3.3 shares and must refuse. Without the complement it would be
+        0.59 shares and refuse for the wrong reason, so this pins the arithmetic
+        rather than only the verdict."""
+        ex = StubExecutor(market_limits=(5.0, 0.85))
+        with DBStub():
+            result = run(ex.execute(make_approval(
+                direction="NO", amount_usdc=0.50, market_probability=0.85,
+                edge=0.30, sim_probability=0.20,
+            )))
+        self.assertFalse(result.success)
+        self.assertEqual(result.gate_blocked, "below_exchange_minimum")
 
     def test_gate8_fails_closed_with_no_usable_price(self):
         ex = StubExecutor(market_limits=(5.0, None))
@@ -541,6 +661,76 @@ class GateTest(unittest.TestCase):
         self.assert_blocked(
             "below_exchange_minimum", sizing_refusal="below_exchange_minimum"
         )
+
+    def test_gate8_refuses_when_gamma_returns_a_DIFFERENT_market(self):
+        """Fail-open by wrong target.
+
+        Gamma ignores unrecognised query params and returns its default page, so
+        a renamed or misspelled condition_ids filter yields a STRANGER's
+        orderMinSize and a stranger's price, both of which the gate would use.
+        Driven through the real _fetch_market_limits with a stubbed client.
+        """
+        ex = TradeExecutor(client=_FakeGamma([{
+            "conditionId": "0x" + "cd" * 32,          # not what was asked for
+            "orderMinSize": 1, "outcomePrices": '["0.02", "0.98"]',
+        }]), token="t", chat_id="c")
+        self.assertIsNone(run(ex._fetch_market_limits(VALID_CONDITION_ID)))
+
+    def test_fetch_accepts_the_market_it_asked_for(self):
+        ex = TradeExecutor(client=_FakeGamma([{
+            "conditionId": VALID_CONDITION_ID,
+            "orderMinSize": 5, "outcomePrices": '["0.42", "0.58"]',
+        }]), token="t", chat_id="c")
+        self.assertEqual(
+            run(ex._fetch_market_limits(VALID_CONDITION_ID)), (5.0, 0.42)
+        )
+
+    def test_fetch_is_case_insensitive_on_the_identifier(self):
+        ex = TradeExecutor(client=_FakeGamma([{
+            "conditionId": VALID_CONDITION_ID.upper().replace("0X", "0x"),
+            "orderMinSize": 5, "outcomePrices": '["0.42", "0.58"]',
+        }]), token="t", chat_id="c")
+        self.assertIsNotNone(run(ex._fetch_market_limits(VALID_CONDITION_ID)))
+
+    def test_fetch_returns_none_on_every_malformed_shape(self):
+        """The only new network call on the money path, and every gate test
+        stubs it. These drive the real function."""
+        cases = {
+            "http error": _FakeGamma(None, status=503),
+            "non-JSON": _FakeGamma(None, raises=ValueError("no json")),
+            "empty list": _FakeGamma([]),
+            "not a dict": _FakeGamma(["a string"]),
+            "no orderMinSize": _FakeGamma([{"conditionId": VALID_CONDITION_ID}]),
+            "orderMinSize null": _FakeGamma([
+                {"conditionId": VALID_CONDITION_ID, "orderMinSize": None}]),
+            "orderMinSize zero": _FakeGamma([
+                {"conditionId": VALID_CONDITION_ID, "orderMinSize": 0}]),
+            "orderMinSize garbage": _FakeGamma([
+                {"conditionId": VALID_CONDITION_ID, "orderMinSize": "many"}]),
+            "no conditionId": _FakeGamma([{"orderMinSize": 5}]),
+        }
+        for label, client in cases.items():
+            with self.subTest(case=label):
+                ex = TradeExecutor(client=client, token="t", chat_id="c")
+                self.assertIsNone(run(ex._fetch_market_limits(VALID_CONDITION_ID)))
+
+    def test_fetch_survives_a_malformed_price_without_losing_the_minimum(self):
+        """A bad outcomePrices must not discard a good orderMinSize, and must
+        not raise. outcomePrices as an OBJECT used to raise KeyError, escaping
+        to the blanket handler and reporting gate_error instead of
+        below_exchange_minimum: the wrong diagnosis in the refusal logs."""
+        for bad in ('{"yes": 0.4}', "[]", "not json", None, 12345):
+            with self.subTest(outcome_prices=bad):
+                ex = TradeExecutor(client=_FakeGamma([{
+                    "conditionId": VALID_CONDITION_ID,
+                    "orderMinSize": 5, "outcomePrices": bad,
+                }]), token="t", chat_id="c")
+                self.assertEqual(run(ex._fetch_market_limits(VALID_CONDITION_ID)),
+                                 (5.0, None))
+
+    def test_fetch_returns_none_for_a_missing_condition_id(self):
+        ex = TradeExecutor(client=_FakeGamma([]), token="t", chat_id="c")
+        self.assertIsNone(run(ex._fetch_market_limits(None)))
 
     def test_unapproved_status_refused(self):
         for status in (ApprovalStatus.skipped, ApprovalStatus.timeout,
@@ -842,6 +1032,43 @@ class RealFillRecordingTest(unittest.TestCase):
             make_candidate(amount_usdc=10.0), payload
         )
         self.assertAlmostEqual(usdc, 10.0, msg="must fall back to the notional")
+
+    def test_tolerance_has_an_ABSOLUTE_floor_at_small_sizes(self):
+        """The ratio alone was worth fractions of a cent at Kelly sizes.
+
+        A false trip records the NOTIONAL, excluding the fee: cost basis
+        understated, pnl overstated, GATE 3's daily-loss brake under-triggered.
+        That is the unsafe direction, so the floor covers a plausible
+        two-price fill rather than being tight.
+        """
+        # $2 notional at price 0.30: real fee 4.9%, so 2.098. A second maker
+        # fill 2c away moves it by ~0.009, which a 1% ratio (0.02) barely
+        # covers and the absolute floor (0.03) comfortably does.
+        ceiling = executor_mod.TradeExecutor._max_believable_cash_out(2.0, 0.30)
+        self.assertGreater(ceiling, 2.098 + 0.009)
+        self.assertAlmostEqual(ceiling, 2.0 * 1.049 + 0.03, places=6)
+
+    def test_the_floor_dominates_at_the_smallest_positions(self):
+        small = executor_mod.TradeExecutor._max_believable_cash_out(0.25, 0.30)
+        ratio_only = 0.25 * 1.049 + 0.01 * 0.25
+        self.assertGreater(small, ratio_only,
+                           "a 1% ratio on $0.25 is a quarter of a cent")
+
+    def test_the_ratio_takes_over_at_larger_positions(self):
+        big = executor_mod.TradeExecutor._max_believable_cash_out(10.0, 0.30)
+        self.assertAlmostEqual(big, 10.0 * 1.049 + 0.10, places=6)
+
+    def test_the_no_price_fallback_is_the_all_prices_worst_case(self):
+        """Not the old flat 1.5. That drop is a behaviour change and is pinned
+        here because a mutant restoring 1.5 survived the suite."""
+        fallback = executor_mod.TradeExecutor._max_believable_cash_out(10.0, None)
+        self.assertAlmostEqual(fallback, 10.0 * 1.08 + 0.03, places=6)
+        self.assertLess(fallback, 10.0 * 1.5)
+
+    def test_fee_tolerance_constants_are_what_the_reasoning_assumes(self):
+        """Pins both, since a mutant widening the ratio 40x survived."""
+        self.assertEqual(executor_mod.FEE_TOLERANCE_RATIO, 0.01)
+        self.assertEqual(executor_mod.FEE_TOLERANCE_ABS, 0.03)
 
     def test_real_fee_ratio_does_not_trip_the_upper_bound(self):
         """The real f4be9ee8 numbers: 10.501189 vs 10.00 notional is 1.05012x,

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -124,7 +124,8 @@ SUCCESS_STDOUT = json.dumps({
 class StubExecutor(TradeExecutor):
     """TradeExecutor with the subprocess and Telegram edges replaced."""
 
-    def __init__(self, *, stdout=SUCCESS_STDOUT, returncode=0, raises=None, **kw):
+    def __init__(self, *, stdout=SUCCESS_STDOUT, returncode=0, raises=None,
+                 market_limits=(5.0, None), **kw):
         kw.setdefault("token", "test-token")
         kw.setdefault("chat_id", "1375806243")
         super().__init__(**kw)
@@ -133,6 +134,16 @@ class StubExecutor(TradeExecutor):
         self.raises = raises
         self.argv_calls: list[list[str]] = []
         self.notifications: list[str] = []
+        # GATE 8 reads orderMinSize live from Gamma. Stubbed here so the rest of
+        # the suite does not make network calls; the default (5 shares, use the
+        # candidate's price) matches every market sampled. GATE 8's own tests
+        # override it, including with None to exercise the fail-closed path.
+        self.market_limits = market_limits
+        self.market_limit_calls: list[str] = []
+
+    async def _fetch_market_limits(self, condition_id):
+        self.market_limit_calls.append(condition_id)
+        return self.market_limits
 
     async def _run_script(self, argv):
         self.argv_calls.append(argv)
@@ -455,6 +466,82 @@ class GateTest(unittest.TestCase):
                     "horizon_below_minimum", end_date=bad, horizon_days=21.0
                 )
 
+    # --- GATE 8, the exchange's share minimum -----------------------------
+    #
+    # Polymarket rejects orders under a per-market minimum expressed in SHARES.
+    # These drive it through the executor rather than through sizing.py, because
+    # the property under test is that the EXECUTOR reads the minimum live and
+    # fails closed, not that the arithmetic is right. tests/test_sizing.py owns
+    # the arithmetic.
+
+    def test_gate8_refuses_an_order_below_the_share_minimum(self):
+        """$0.25 at price 0.40 is 0.625 shares. The exchange would reject it
+        after approval and after the money path commits."""
+        self.assert_blocked(
+            "below_exchange_minimum", amount_usdc=0.25, market_probability=0.40
+        )
+
+    def test_gate8_admits_an_order_that_clears_it(self):
+        ex = StubExecutor(market_limits=(5.0, 0.40))
+        with DBStub():
+            result = run(ex.execute(make_approval(
+                amount_usdc=4.0, market_probability=0.40
+            )))
+        self.assertTrue(result.success, "10 shares clears a 5-share minimum")
+
+    def test_gate8_reads_the_LIVE_minimum_not_the_candidates_copy(self):
+        """THE property. Same shape as GATE 7 reading the clock.
+
+        The candidate carries a permissive scan-time minimum. The live market
+        says something much stricter. A gate that trusted the candidate would
+        admit this; the gate must believe the exchange.
+        """
+        ex = StubExecutor(market_limits=(50.0, 0.40))
+        with DBStub():
+            result = run(ex.execute(make_approval(
+                amount_usdc=4.0, market_probability=0.40, min_order_size=1.0
+            )))
+        self.assertFalse(result.success)
+        self.assertEqual(result.gate_blocked, "below_exchange_minimum")
+        self.assertEqual(ex.argv_calls, [])
+        self.assertEqual(ex.market_limit_calls, [VALID_CONDITION_ID],
+                         "the gate must actually go and look")
+
+    def test_gate8_uses_the_live_price_over_the_scan_price(self):
+        """10 shares at the scan price, 2.5 at the live one. Refuse."""
+        ex = StubExecutor(market_limits=(5.0, 0.80))
+        with DBStub():
+            result = run(ex.execute(make_approval(
+                amount_usdc=2.0, market_probability=0.20
+            )))
+        self.assertFalse(result.success)
+        self.assertEqual(result.gate_blocked, "below_exchange_minimum")
+
+    def test_gate8_fails_closed_when_the_minimum_cannot_be_read(self):
+        """Never assumed to be the usual 5, and never assumed satisfied."""
+        ex = StubExecutor(market_limits=None)
+        with DBStub():
+            result = run(ex.execute(make_approval(amount_usdc=9.0)))
+        self.assertFalse(result.success)
+        self.assertEqual(result.gate_blocked, "below_exchange_minimum")
+        self.assertEqual(ex.argv_calls, [])
+
+    def test_gate8_fails_closed_with_no_usable_price(self):
+        ex = StubExecutor(market_limits=(5.0, None))
+        with DBStub():
+            result = run(ex.execute(make_approval(
+                amount_usdc=9.0, market_probability=0
+            )))
+        self.assertFalse(result.success)
+        self.assertEqual(result.gate_blocked, "below_exchange_minimum")
+
+    def test_gate8_refuses_a_candidate_the_scanner_never_sized(self):
+        """Defence in depth: a sizing refusal must not be executable even if
+        something upstream proposed it anyway."""
+        self.assert_blocked(
+            "below_exchange_minimum", sizing_refusal="below_exchange_minimum"
+        )
+
     def test_unapproved_status_refused(self):
         for status in (ApprovalStatus.skipped, ApprovalStatus.timeout,
                        ApprovalStatus.analyst_skip, ApprovalStatus.pending):
@@ -567,7 +654,12 @@ class EntryPriceNullTest(unittest.TestCase):
 
     def test_no_price_anywhere_records_null_not_zero(self):
         stdout = json.dumps({"success": True, "response": {"orderID": "0xo"}})
-        ex = StubExecutor(stdout=stdout)
+        # GATE 8 needs SOME price to convert the notional into shares, and
+        # market_probability=0 removes the candidate's. The live Gamma price
+        # supplies it, which is the real arrangement: the gate reads the market,
+        # the RECORDING path here still has no fill price to work from. Without
+        # this the gate refuses first and this test stops covering _derive_entry.
+        ex = StubExecutor(stdout=stdout, market_limits=(5.0, 0.40))
         with DBStub() as db:
             # market_probability=0 removes the fallback too.
             result = run(ex.execute(make_approval(market_probability=0)))
@@ -724,16 +816,38 @@ class RealFillRecordingTest(unittest.TestCase):
         self.assertAlmostEqual(usdc, 10.0)
 
     def test_cash_out_just_inside_the_upper_bound_is_accepted(self):
-        payload = self.real_payload(cash_out=14.99)  # 1.499x < 1.5x
+        """The bound is PRICE-AWARE now, so "just inside" is much tighter.
+
+        This used to accept 14.99 against a 10.00 notional, because the flat
+        1.5x ceiling was loose by more than 70x at high prices. The real fee
+        ratio is 1 + 0.07*(1-price), so at the payload's 0.284 the ceiling is
+        1 + 0.0501 + 0.01 tolerance = 1.0601, and 10.60 is the most that can be
+        believed.
+        """
+        payload = self.real_payload(cash_out=10.59)
         _, _, usdc = TradeExecutor._derive_entry(
             make_candidate(amount_usdc=10.0), payload
         )
-        self.assertAlmostEqual(usdc, 14.99)
+        self.assertAlmostEqual(usdc, 10.59)
+
+    def test_the_old_flat_ceiling_would_have_believed_a_50_percent_fee(self):
+        """What the tightening actually bought.
+
+        14.99 against a 10.00 notional is a 49.9% fee. The old flat 1.5x
+        accepted it and wrote it straight into pnl, which feeds Gate 3's
+        daily-loss brake. At this price the real fee is 5.01%.
+        """
+        payload = self.real_payload(cash_out=14.99)
+        _, _, usdc = TradeExecutor._derive_entry(
+            make_candidate(amount_usdc=10.0), payload
+        )
+        self.assertAlmostEqual(usdc, 10.0, msg="must fall back to the notional")
 
     def test_real_fee_ratio_does_not_trip_the_upper_bound(self):
-        """The real f4be9ee8 numbers: 10.501189 vs 10.00 notional is 1.05x,
-        comfortably inside the 1.5x ceiling. The bound must never reject a
-        genuine fee."""
+        """The real f4be9ee8 numbers: 10.501189 vs 10.00 notional is 1.05012x,
+        against a computed ceiling of 1.0601 at price 0.284. The bound must
+        never reject a genuine fee, and the tightened one still does not: the
+        margin is 0.0100, which is the tolerance and nothing else."""
         _, _, usdc = TradeExecutor._derive_entry(
             make_candidate(amount_usdc=10.0), self.real_payload()
         )

--- a/tests/test_scanner_horizon.py
+++ b/tests/test_scanner_horizon.py
@@ -47,6 +47,9 @@ from src.trade_engine.models import (  # noqa: E402
     ScannerCandidate,
     ScannerRunSummary,
 )
+import src.trade_engine.scanner as scanner_mod  # noqa: E402
+from src.trade_engine.executor import ABSOLUTE_MAX_POSITION_USDC  # noqa: E402
+from src.trade_engine.sizing import size_position  # noqa: E402
 from src.trade_engine.scanner import (  # noqa: E402
     DEFAULT_HORIZON_DAYS,
     HORIZON_MAX_DAYS,
@@ -345,6 +348,114 @@ class ReduceNeverIncreasesTest(unittest.TestCase):
         self.assertIsNone(summary.best_trade.sizing_refusal)
 
 
+class SizingWireThroughTest(unittest.TestCase):
+    """Every value that crosses the module boundary onto the money path.
+
+    THE FINDING THIS CLASS EXISTS FOR. sizing.py had 31 tests and
+    _to_candidate, its only caller and the code that actually puts a number on
+    amount_usdc, had none. Six mutants in that one function survived the entire
+    suite, including amount_usdc=sizing.debit, which is VERBATIM the defect this
+    change was written to fix.
+
+    An arithmetic module tested as a pure function proves the arithmetic. It
+    proves nothing about the values the caller feeds it or the field it writes
+    the answer into. Both halves need asserting, separately.
+    """
+
+    ROW = {
+        "market_id": "3257355", "condition_id": "0x" + "ab" * 32,
+        "slug": "s", "question": "Will Bitcoin reach $60,000 in September?",
+        "asset": "btc", "yes_price": 0.20, "volume": 279582.74,
+        "horizon_days": 20.333, "end_date": "2026-09-30T04:00:00Z",
+        "min_order_size": 5.0,
+    }
+
+    def capture(self, row=None, edge=0.40, probability=0.60, ceiling=10.0):
+        """Call _to_candidate with size_position spied, keeping real behaviour."""
+        captured = {}
+        real = scanner_mod.size_position
+
+        def spy(**kwargs):
+            captured.update(kwargs)
+            return real(**kwargs)
+
+        scanner_mod.size_position = spy
+        try:
+            candidate = PolymarketScanner._to_candidate(
+                dict(row or self.ROW), edge, probability, ceiling
+            )
+        finally:
+            scanner_mod.size_position = real
+        return captured, candidate
+
+    # --- the caller passes what it claims to pass ------------------------
+
+    def test_it_passes_the_configured_bankroll(self):
+        captured, _ = self.capture()
+        self.assertEqual(captured["bankroll"], config.bankroll_usdc)
+        self.assertEqual(captured["bankroll"], 25.0)
+
+    def test_it_passes_the_configured_kelly_fraction(self):
+        captured, _ = self.capture()
+        self.assertEqual(captured["kelly_fraction"], config.kelly_fraction)
+        self.assertEqual(captured["kelly_fraction"], 0.10)
+
+    def test_it_passes_the_configured_price_floor(self):
+        captured, _ = self.capture()
+        self.assertEqual(captured["price_floor"], config.sizing_price_floor)
+        self.assertEqual(captured["price_floor"], 0.10)
+
+    def test_it_passes_the_enforced_ceiling_and_the_hard_one(self):
+        captured, _ = self.capture(ceiling=10.0)
+        self.assertEqual(captured["max_position_usdc"], 10.0)
+        self.assertEqual(captured["absolute_max_usdc"], ABSOLUTE_MAX_POSITION_USDC)
+
+    def test_it_passes_the_markets_own_minimum_and_price(self):
+        captured, _ = self.capture()
+        self.assertEqual(captured["min_order_size"], 5.0)
+        self.assertEqual(captured["yes_price"], 0.20)
+        self.assertEqual(captured["sim_probability"], 0.60)
+
+    def test_it_passes_the_direction_it_derived(self):
+        for edge, expected in ((0.40, "YES"), (-0.40, "NO")):
+            with self.subTest(edge=edge):
+                captured, _ = self.capture(edge=edge)
+                self.assertEqual(captured["direction"], expected)
+
+    # --- the answer lands in the right field -----------------------------
+
+    def test_amount_usdc_is_the_NOTIONAL_not_the_debit(self):
+        """The mutant that survived, and it is this change's own headline bug.
+
+        The wallet pays notional plus fee. Writing the debit into amount_usdc
+        sends the fee-inclusive figure to the relay as the amount to SPEND, so
+        every trade overspends its cap by the fee: exactly what this change was
+        written to stop.
+        """
+        captured, candidate = self.capture()
+        expected = size_position(**captured)
+        self.assertTrue(expected.tradeable, "pick a sizeable case or this is vacuous")
+        self.assertGreater(expected.debit, expected.notional, "the fee must be non-zero")
+        self.assertEqual(candidate.amount_usdc, expected.notional)
+        self.assertNotEqual(candidate.amount_usdc, round(expected.debit, 6))
+
+    def test_the_sizing_refusal_is_recorded_on_the_candidate(self):
+        """select_best_trade filters on this field. Nothing asserted it is ever
+        set, so the K12 defence could be disabled upstream with its own test
+        still green."""
+        row = dict(self.ROW, yes_price=0.05)  # under the sizing price floor
+        _, candidate = self.capture(row=row)
+        self.assertEqual(candidate.sizing_refusal, "price_below_sizing_floor")
+
+    def test_a_sizeable_candidate_records_no_refusal(self):
+        _, candidate = self.capture()
+        self.assertIsNone(candidate.sizing_refusal)
+
+    def test_the_market_minimum_reaches_the_candidate(self):
+        _, candidate = self.capture()
+        self.assertEqual(candidate.min_order_size, 5.0)
+
+
 class SelectSkipsUnsizeableTest(unittest.TestCase):
     """best_trade must never be a candidate that cannot be sized.
 
@@ -405,6 +516,119 @@ class _StubAnalyst:
 
     async def analyse(self, candidate):
         return self._recommendation
+
+
+class ApprovalGuardTest(unittest.TestCase):
+    """An unsizeable best_trade must not reach a human.
+
+    K12's sibling, one function later, in the same change. select_best_trade
+    filters unsizeable candidates, but the Analyst's REDUCE can make a
+    candidate unsizeable AFTER that filter has run, and only this guard stops
+    it. Removing the guard survived the whole suite: the failure direction is
+    "shows a human a button that cannot fire", which reads as harmless and so
+    went untested.
+    """
+
+    def summary_with_refusal(self, refusal):
+        candidate = ScannerCandidate(
+            market_id="1", condition_id="0x" + "ab" * 32, question="q",
+            asset="btc", direction="YES", edge=0.20, sim_probability=0.60,
+            market_probability=0.40, volume=50000.0, horizon_days=5.0,
+            market_url="", amount_usdc=1.5, min_order_size=5.0,
+            sizing_refusal=refusal,
+        )
+        summary = ScannerRunSummary(
+            run_at=datetime.now(timezone.utc), markets_fetched=1,
+            candidates_analysed=1, simulations_run=1, sim_errors=0,
+        )
+        summary.best_trade = candidate
+        summary.analyst_recommendation = AnalystRecommendation(
+            recommendation="proceed", confidence=0.8, reasoning="ok", flags=[],
+        )
+        return summary
+
+    def test_no_approval_is_requested_for_an_unsizeable_trade(self):
+        summary = self.summary_with_refusal("below_exchange_minimum")
+        gate = _RecordingGate()
+        scanner = PolymarketScanner(approval_gate=gate)
+        run(scanner.apply_approval(summary))
+        self.assertEqual(gate.requests, [], "no button for an unplaceable trade")
+        self.assertIsNone(summary.approval_result)
+
+    def test_a_sizeable_trade_still_reaches_the_gate(self):
+        """Or the guard would be indistinguishable from the gate being broken."""
+        summary = self.summary_with_refusal(None)
+        gate = _RecordingGate()
+        scanner = PolymarketScanner(approval_gate=gate)
+        run(scanner.apply_approval(summary))
+        self.assertEqual(len(gate.requests), 1)
+
+
+class _RecordingGate:
+    def __init__(self):
+        self.requests = []
+
+    async def send_approval_request(self, candidate, recommendation):
+        self.requests.append(candidate)
+        return object()
+
+    async def wait_for_decision(self, pending):
+        from src.trade_engine.models import ApprovalResult, ApprovalStatus
+        return ApprovalResult(
+            approval_id="a", status=ApprovalStatus.timeout,
+            candidate=self.requests[-1],
+            recommendation=AnalystRecommendation(
+                recommendation="proceed", confidence=0.8, reasoning="r", flags=[]),
+            decided_at=datetime.now(timezone.utc), decision_source="timeout",
+        )
+
+
+class SizingConfigClampTest(unittest.TestCase):
+    """The sizing dials may only move in the conservative direction.
+
+    DEFAULT_BANKROLL_USDC's docstring says raising it is a capital decision and
+    "not a config edit". That was false while this was a bare env read:
+    BANKROLL_USDC=200 was exactly a config edit, unclamped and unlogged. Two
+    paragraphs of prose were the only guard on the number the whole sizing
+    model rests on.
+    """
+
+    def with_env(self, **env):
+        saved = {k: os.environ.get(k) for k in env}
+        try:
+            for k, v in env.items():
+                os.environ[k] = v
+            return Config()
+        finally:
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+    def test_bankroll_cannot_be_raised_by_env(self):
+        """The $180 that would make Kelly and the exchange compatible is a
+        DEPOSIT, not a config edit. The code now agrees with the comment."""
+        for attempt in ("200", "180", "25.01", "1e9"):
+            with self.subTest(value=attempt):
+                self.assertEqual(self.with_env(BANKROLL_USDC=attempt).bankroll_usdc, 25.0)
+
+    def test_bankroll_can_be_lowered(self):
+        self.assertEqual(self.with_env(BANKROLL_USDC="10").bankroll_usdc, 10.0)
+
+    def test_kelly_fraction_cannot_be_raised_by_env(self):
+        for attempt in ("1.0", "0.5", "5.0"):
+            with self.subTest(value=attempt):
+                self.assertEqual(
+                    self.with_env(KELLY_FRACTION=attempt).kelly_fraction, 0.10
+                )
+
+    def test_kelly_fraction_can_be_lowered(self):
+        self.assertEqual(self.with_env(KELLY_FRACTION="0.05").kelly_fraction, 0.05)
+
+    def test_the_price_floor_can_only_be_RAISED(self):
+        self.assertEqual(self.with_env(SIZING_PRICE_FLOOR="0.0").sizing_price_floor, 0.10)
+        self.assertEqual(self.with_env(SIZING_PRICE_FLOOR="0.25").sizing_price_floor, 0.25)
 
 
 class CandidateModelTest(unittest.TestCase):

--- a/tests/test_scanner_horizon.py
+++ b/tests/test_scanner_horizon.py
@@ -345,6 +345,60 @@ class ReduceNeverIncreasesTest(unittest.TestCase):
         self.assertIsNone(summary.best_trade.sizing_refusal)
 
 
+class SelectSkipsUnsizeableTest(unittest.TestCase):
+    """best_trade must never be a candidate that cannot be sized.
+
+    A mutant removing this filter survived the entire suite: nothing asserted
+    that an unsizeable candidate stays out of best_trade, only that sizing
+    refuses. GATE 8 would catch it at execution, but by then a human has been
+    asked to approve a trade the exchange will reject.
+    """
+
+    def candidate(self, market_id, edge, refusal=None):
+        return ScannerCandidate(
+            market_id=market_id, condition_id="0x" + "cd" * 32, question="q",
+            asset="btc", direction="YES", edge=edge, sim_probability=0.60,
+            market_probability=0.40, volume=50000.0, horizon_days=5.0,
+            market_url="", amount_usdc=2.0, min_order_size=5.0,
+            sizing_refusal=refusal,
+        )
+
+    def summary(self, *candidates):
+        s = ScannerRunSummary(
+            run_at=datetime.now(timezone.utc), markets_fetched=1,
+            candidates_analysed=len(candidates), simulations_run=len(candidates),
+            sim_errors=0,
+        )
+        s.high_edge = list(candidates)
+        return s
+
+    def test_the_widest_edge_is_skipped_when_it_cannot_be_sized(self):
+        """The unsizeable one has the BIGGEST edge, so a filter that is absent
+        picks it. That is what makes this test able to fail."""
+        summary = self.summary(
+            self.candidate("big", 0.40, refusal="below_exchange_minimum"),
+            self.candidate("small", 0.12),
+        )
+        best = PolymarketScanner().select_best_trade(summary)
+        self.assertIsNotNone(best)
+        self.assertEqual(best.market_id, "small")
+
+    def test_none_sizeable_means_no_trade(self):
+        summary = self.summary(
+            self.candidate("a", 0.40, refusal="below_exchange_minimum"),
+            self.candidate("b", 0.30, refusal="price_below_sizing_floor"),
+        )
+        self.assertIsNone(PolymarketScanner().select_best_trade(summary))
+
+    def test_unsizeable_candidates_are_still_REPORTED(self):
+        """They stay in the bucket. The refusal is the measurement."""
+        summary = self.summary(
+            self.candidate("a", 0.40, refusal="below_exchange_minimum"),
+        )
+        PolymarketScanner().select_best_trade(summary)
+        self.assertEqual(len(summary.high_edge), 1)
+
+
 class _StubAnalyst:
     def __init__(self, recommendation):
         self._recommendation = recommendation

--- a/tests/test_scanner_horizon.py
+++ b/tests/test_scanner_horizon.py
@@ -42,7 +42,11 @@ from src.trade_engine.config import (  # noqa: E402
     config,
 )
 from src.trade_engine.horizon import horizon_days  # noqa: E402
-from src.trade_engine.models import ScannerCandidate  # noqa: E402
+from src.trade_engine.models import (  # noqa: E402
+    AnalystRecommendation,
+    ScannerCandidate,
+    ScannerRunSummary,
+)
 from src.trade_engine.scanner import (  # noqa: E402
     DEFAULT_HORIZON_DAYS,
     HORIZON_MAX_DAYS,
@@ -273,6 +277,80 @@ class CandidateCarriesEndDateTest(unittest.TestCase):
         self.assertIsNotNone(
             horizon_days(candidate.end_date, datetime.now(timezone.utc))
         )
+
+
+class ReduceNeverIncreasesTest(unittest.TestCase):
+    """The Analyst's REDUCE must reduce.
+
+    It was max(AMOUNT_MIN_USDC, before / 2) with a $3 floor. On a $1.23 Kelly
+    position that returns $3.00: a 2.4x INCREASE, on the exact path where the
+    Analyst has just said it is less confident. A safety inversion, invisible
+    while the old ramp never sized below $3, and live the moment Kelly does.
+    """
+
+    def summary_with(self, amount, price=0.40, minimum=5.0):
+        candidate = ScannerCandidate(
+            market_id="1", condition_id="0x" + "ab" * 32, question="q",
+            asset="btc", direction="YES", edge=0.20, sim_probability=0.60,
+            market_probability=price, volume=50000.0, horizon_days=5.0,
+            market_url="", amount_usdc=amount, min_order_size=minimum,
+        )
+        summary = ScannerRunSummary(
+            run_at=datetime.now(timezone.utc), markets_fetched=1,
+            candidates_analysed=1, simulations_run=1, sim_errors=0,
+        )
+        summary.best_trade = candidate
+        summary.analyst_recommendation = AnalystRecommendation(
+            recommendation="reduce", confidence=0.4, reasoning="thin", flags=[],
+        )
+        return summary
+
+    def reduce_to(self, amount, **kw):
+        summary = self.summary_with(amount, **kw)
+        scanner = PolymarketScanner(analyst=_StubAnalyst(summary.analyst_recommendation))
+        run(scanner.apply_analyst(summary))
+        return summary.best_trade.amount_usdc
+
+    def test_reduce_never_increases_at_any_size(self):
+        """The property, across the whole range including sub-$3 Kelly sizes."""
+        for before in (0.25, 0.5, 1.23, 2.99, 3.0, 5.0, 10.0):
+            with self.subTest(before=before):
+                after = self.reduce_to(before)
+                self.assertLess(after, before, "REDUCE must reduce")
+                self.assertAlmostEqual(after, before / 2, places=6)
+
+    def test_the_old_floor_would_have_tripled_a_kelly_position(self):
+        """Pins the specific defect rather than only the general property."""
+        self.assertLess(self.reduce_to(1.23), 1.23)
+        self.assertAlmostEqual(self.reduce_to(1.23), 0.615, places=6)
+
+    def test_reducing_under_the_exchange_minimum_marks_it_unsizeable(self):
+        """Halving can make a position unplaceable. That is a refusal, not a
+        smaller trade, and nobody should be asked to approve it."""
+        # $3.00 at price 0.40 is 7.5 shares, comfortably over. Halved it is
+        # $1.50, or 3.75 shares, which the exchange would reject.
+        summary = self.summary_with(3.0, price=0.40, minimum=5.0)
+        scanner = PolymarketScanner(analyst=_StubAnalyst(summary.analyst_recommendation))
+        run(scanner.apply_analyst(summary))
+        self.assertEqual(summary.best_trade.amount_usdc, 1.5)
+        self.assertEqual(summary.best_trade.sizing_refusal, "below_exchange_minimum")
+
+    def test_a_reduction_that_still_clears_the_minimum_is_not_marked(self):
+        """Exactly at the minimum is admitted, matching GATE 8's comparison.
+        $4.00 at 0.40 halves to $2.00, which is exactly 5 shares."""
+        summary = self.summary_with(4.0, price=0.40, minimum=5.0)
+        scanner = PolymarketScanner(analyst=_StubAnalyst(summary.analyst_recommendation))
+        run(scanner.apply_analyst(summary))
+        self.assertEqual(summary.best_trade.amount_usdc, 2.0)
+        self.assertIsNone(summary.best_trade.sizing_refusal)
+
+
+class _StubAnalyst:
+    def __init__(self, recommendation):
+        self._recommendation = recommendation
+
+    async def analyse(self, candidate):
+        return self._recommendation
 
 
 class CandidateModelTest(unittest.TestCase):

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -1,0 +1,298 @@
+"""Tests for fractional-Kelly position sizing (src/trade_engine/sizing.py).
+
+sizing.py imports nothing but the stdlib, so these need no env, no config, no
+network and no numpy. That is deliberate and is the same reason horizon.py and
+simulation.py were split out: the arithmetic that decides how much money leaves
+the wallet has to be testable on its own.
+
+The historical positions here are the four from
+docs/trade-engine-horizon-rebaseline.md, at their re-baselined probabilities.
+
+Run:
+    python3 -m unittest tests.test_sizing
+"""
+
+import math
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.trade_engine.sizing import (  # noqa: E402
+    FEE_RATE,
+    fee_ratio,
+    side_price_for,
+    size_position,
+)
+
+# The shipped configuration.
+LIVE = dict(bankroll=25.0, kelly_fraction=0.10, max_position_usdc=25.0,
+            price_floor=0.10)
+MIN_SHARES = 5.0
+
+# position, simulated p, market YES price
+HISTORICAL = [
+    ("cee4eacd XRP", 0.9863, 0.925),
+    ("71f8a608 BTC", 0.5459, 0.415),
+    ("f4be9ee8 ETH", 0.6149, 0.279),
+    ("b3cecdef SOL", 0.7062, 0.396),
+]
+
+
+def size(p, price, direction="YES", minimum=MIN_SHARES, **over):
+    kw = dict(LIVE)
+    kw.update(over)
+    return size_position(
+        sim_probability=p, yes_price=price, direction=direction,
+        min_order_size=minimum, **kw,
+    )
+
+
+class KellyArithmeticTest(unittest.TestCase):
+    """The formula, against a closed form computed independently here."""
+
+    def test_fraction_matches_the_closed_form(self):
+        for p, price in ((0.60, 0.40), (0.30, 0.20), (0.99, 0.90), (0.52, 0.50)):
+            with self.subTest(p=p, price=price):
+                s = size(p, price)
+                expected = LIVE["kelly_fraction"] * (p - price) / (1 - price)
+                self.assertAlmostEqual(s.kelly_fraction, expected, places=12)
+
+    def test_zero_edge_is_a_refusal_not_a_zero_bet(self):
+        s = size(0.40, 0.40)
+        self.assertFalse(s.tradeable)
+        self.assertEqual(s.refusal, "no_positive_edge")
+
+    def test_certainty_gives_the_whole_kelly_fraction(self):
+        """At p=1 the full-Kelly fraction is 1, so the stake is exactly
+        KELLY_FRACTION of bankroll: $2.50. This is the ceiling on any position
+        at this bankroll, and it is what makes the exchange minimum binding."""
+        s = size(1.0, 0.50)
+        self.assertAlmostEqual(s.kelly_debit, 2.50, places=9)
+
+    def test_edge_scales_the_stake_monotonically(self):
+        previous = 0.0
+        for p in (0.45, 0.50, 0.60, 0.80, 0.99):
+            s = size(p, 0.40)
+            self.assertGreater(s.notional, previous)
+            previous = s.notional
+
+
+class FeeAwareTest(unittest.TestCase):
+    """The cap is the DEBIT, not the notional."""
+
+    def test_fee_ratio_matches_the_verified_receipt(self):
+        """10.501189 debited against 10.00 notional at price 0.284."""
+        self.assertAlmostEqual(1 + fee_ratio(0.284), 10.501189 / 10.0, places=4)
+
+    def test_debit_equals_the_cap_and_notional_is_below_it(self):
+        s = size(1.0, 0.50)  # kelly_debit is the binding cap here
+        self.assertAlmostEqual(s.debit, s.kelly_debit, places=9)
+        self.assertLess(s.notional, s.debit, "the fee is charged on top")
+
+    def test_sizing_the_notional_to_the_cap_would_overspend(self):
+        """What the old code did, stated as a number.
+
+        Sizing the notional to the cap makes the wallet pay cap * (1 + fee),
+        which at price 0.10 is 6.3% more than intended, every single trade.
+        """
+        s = size(1.0, 0.10)
+        naive_debit = s.kelly_debit * (1 + fee_ratio(0.10))
+        self.assertGreater(naive_debit - s.kelly_debit, 0.15)
+        self.assertAlmostEqual(s.debit, s.kelly_debit, places=9)
+
+    def test_shares_are_derived_from_the_notional_actually_sent(self):
+        """Not from an unrounded intermediate.
+
+        The relay is sent the ROUNDED notional, and the exchange divides that by
+        price to get the order size. Deriving shares from anything else means
+        the count checked against the minimum is not the count the exchange
+        computes, which at the boundary is the difference between a clean
+        refusal and a rejected order.
+        """
+        for p_true, price in ((0.90, 0.20), (0.35, 0.10), (0.60, 0.40)):
+            with self.subTest(price=price):
+                s = size(p_true, price)
+                self.assertEqual(s.notional, round(s.notional, 6))
+                self.assertAlmostEqual(s.shares, s.notional / price, places=12)
+                self.assertEqual(
+                    s.debit, round(s.notional * (1 + fee_ratio(price)), 6),
+                    "debit must follow the rounded notional, not an intermediate",
+                )
+
+
+class CeilingTest(unittest.TestCase):
+    """Kelly only ever sizes DOWN. The ceiling sits above it."""
+
+    def test_ceiling_binds_and_is_recorded(self):
+        s = size(1.0, 0.50, bankroll=10_000.0)
+        self.assertEqual(s.clamped_by, "max_position_usdc")
+        self.assertAlmostEqual(s.debit, LIVE["max_position_usdc"], places=9)
+
+    def test_ceiling_does_not_bind_at_the_live_bankroll(self):
+        """At $25 and a tenth of Kelly the largest possible stake is $2.50, so
+        the ceiling can never bind. It still has to exist: bankroll is config."""
+        for p, price in ((1.0, 0.10), (1.0, 0.50), (0.99, 0.30)):
+            with self.subTest(p=p, price=price):
+                self.assertIsNone(size(p, price).clamped_by)
+
+    def test_the_ceiling_never_raises_a_small_kelly(self):
+        s = size(0.50, 0.415)
+        self.assertLess(s.debit, LIVE["max_position_usdc"])
+        self.assertIsNone(s.clamped_by)
+
+
+class ExchangeMinimumTest(unittest.TestCase):
+    """The finding that reshaped this change."""
+
+    def test_every_historical_position_is_refused(self):
+        """Correct sizing puts all four under the 5-share floor.
+
+        Not a regression. These are the trades the old ramp sized at $10 each.
+        """
+        for name, p, price in HISTORICAL:
+            with self.subTest(position=name):
+                s = size(p, price)
+                self.assertFalse(s.tradeable)
+                self.assertEqual(s.refusal, "below_exchange_minimum")
+                self.assertLess(s.shares, MIN_SHARES)
+
+    def test_refusal_still_carries_the_arithmetic(self):
+        """A refusal is a measurement. Item (c) needs these numbers."""
+        s = size(0.6149, 0.279)
+        self.assertFalse(s.tradeable)
+        for field in ("price=", "edge=", "shares=", "required_shares=",
+                      "min_notional=", "kelly_notional="):
+            self.assertIn(field, s.log_fields())
+        self.assertGreater(s.notional, 0, "the computed size is still reported")
+
+    def test_it_never_rounds_up_to_reach_the_minimum(self):
+        """The one thing that must not happen.
+
+        A stake raised to clear an exchange floor is a stake chosen by the
+        exchange, not by the edge, and it is larger than Kelly says is safe.
+        """
+        s = size(0.6149, 0.279)
+        self.assertLess(s.shares, s.required_shares)
+        self.assertLess(s.notional, s.min_notional)
+
+    def test_above_price_one_half_it_is_impossible_at_any_edge(self):
+        """The correction to the original audit.
+
+        edge can never exceed (1 - price), so requiring edge >= 2*price*(1-price)
+        requires price <= 0.5. Deep favourites are the region that is
+        arithmetically impossible, NOT the region that survives. Checked at
+        p = 1, which is the best case there is.
+        """
+        for price in (0.50, 0.60, 0.75, 0.90, 0.964, 0.99):
+            with self.subTest(price=price):
+                s = size(1.0, price)
+                self.assertFalse(
+                    s.tradeable,
+                    f"price {price} cleared the minimum at certainty: {s.log_fields()}",
+                )
+
+    def test_below_price_one_half_a_large_enough_edge_does_clear(self):
+        """The band that survives is real, just narrow."""
+        for price, p in ((0.10, 0.35), (0.20, 0.60), (0.30, 0.80), (0.40, 0.95)):
+            with self.subTest(price=price, p=p):
+                s = size(p, price)
+                self.assertTrue(s.tradeable, s.log_fields())
+                self.assertGreaterEqual(s.shares, MIN_SHARES)
+
+    def test_the_seven_point_edge_floor_can_never_be_placed(self):
+        """At the minimum qualifying edge nothing is placeable anywhere in the
+        sizeable price range."""
+        for price in (0.10, 0.20, 0.30, 0.40, 0.45):
+            with self.subTest(price=price):
+                self.assertFalse(size(price + 0.07, price).tradeable)
+
+    def test_the_minimum_is_read_not_assumed(self):
+        """A market with a different orderMinSize sizes against ITS value."""
+        generous = size(0.35, 0.10, minimum=1.0)
+        strict = size(0.35, 0.10, minimum=50.0)
+        self.assertTrue(generous.tradeable)
+        self.assertFalse(strict.tradeable)
+        self.assertEqual(strict.required_shares, 50.0)
+
+
+class FailClosedTest(unittest.TestCase):
+    def test_unknown_minimum_is_refused_never_assumed_to_be_five(self):
+        for bad in (None, 0, -1, float("nan"), float("inf")):
+            with self.subTest(minimum=bad):
+                s = size(0.35, 0.10, minimum=bad)
+                self.assertFalse(s.tradeable)
+                self.assertEqual(s.refusal, "unknown_min_order_size")
+
+    def test_a_market_that_would_otherwise_trade_is_still_refused(self):
+        """The fail-closed path must not be reachable only for bad trades."""
+        self.assertTrue(size(0.35, 0.10, minimum=5.0).tradeable)
+        self.assertFalse(size(0.35, 0.10, minimum=None).tradeable)
+
+    def test_invalid_prices_are_refused(self):
+        for price in (0.0, 1.0, -0.5, 1.5):
+            with self.subTest(price=price):
+                self.assertEqual(size(0.5, price).refusal, "invalid_price")
+
+    def test_non_finite_inputs_are_refused(self):
+        for p in (float("nan"), float("inf")):
+            with self.subTest(p=p):
+                self.assertEqual(size(p, 0.40).refusal, "invalid_input")
+
+    def test_non_positive_bankroll_is_refused(self):
+        for bank in (0.0, -25.0):
+            with self.subTest(bankroll=bank):
+                self.assertEqual(size(0.9, 0.20, bankroll=bank).refusal,
+                                 "invalid_bankroll")
+
+
+class PriceFloorTest(unittest.TestCase):
+    """A proposal filter, not a clamp on price in the formula."""
+
+    def test_below_the_floor_is_refused(self):
+        s = size(0.50, 0.05)
+        self.assertFalse(s.tradeable)
+        self.assertEqual(s.refusal, "price_below_sizing_floor")
+
+    def test_the_floor_is_not_applied_as_a_clamp(self):
+        """If price were clamped to 0.10 rather than filtered, a 0.05 market
+        would return a SIZE. It must return a refusal instead."""
+        self.assertEqual(size(0.50, 0.05).notional, 0.0)
+
+    def test_at_and_above_the_floor_it_sizes(self):
+        self.assertNotEqual(size(0.50, 0.10).refusal, "price_below_sizing_floor")
+
+    def test_the_floor_is_separate_from_inclusion(self):
+        """YES_PRICE_MIN is 0.01 and governs which markets are scanned. This
+        floor is 0.10 and governs which can be sized. A market between them is
+        scanned and reported, and refused only for sizing."""
+        s = size(0.50, 0.05)
+        self.assertEqual(s.refusal, "price_below_sizing_floor")
+        self.assertGreater(s.edge, 0, "it still has a real edge, it is reported")
+
+
+class NoSideTest(unittest.TestCase):
+    """Sizing the NO side, which the old abs(edge) hack got wrong."""
+
+    def test_side_price_is_complemented(self):
+        self.assertAlmostEqual(side_price_for("NO", 0.30), 0.70)
+        self.assertAlmostEqual(side_price_for("YES", 0.30), 0.30)
+
+    def test_no_side_uses_complemented_probability_and_price(self):
+        """Buying NO at 0.70 believing 0.80 is the same Kelly problem as
+        buying YES at 0.70 believing 0.80."""
+        no = size(0.20, 0.30, direction="NO")     # p(NO)=0.80, price(NO)=0.70
+        yes = size(0.80, 0.70, direction="YES")
+        self.assertAlmostEqual(no.kelly_fraction, yes.kelly_fraction, places=12)
+        self.assertAlmostEqual(no.notional, yes.notional, places=9)
+
+    def test_no_side_with_no_edge_is_refused(self):
+        self.assertEqual(size(0.80, 0.30, direction="NO").refusal, "no_positive_edge")
+
+    def test_fee_uses_the_side_actually_bought(self):
+        self.assertAlmostEqual(fee_ratio(0.70), FEE_RATE * 0.30, places=12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -163,9 +163,24 @@ class ExchangeMinimumTest(unittest.TestCase):
         s = size(0.6149, 0.279)
         self.assertFalse(s.tradeable)
         for field in ("price=", "edge=", "shares=", "required_shares=",
-                      "min_notional=", "kelly_notional="):
+                      "min_notional=", "sized_notional=", "kelly_debit=",
+                      "clamped_by="):
             self.assertIn(field, s.log_fields())
         self.assertGreater(s.notional, 0, "the computed size is still reported")
+
+    def test_the_log_does_not_call_the_sized_notional_a_kelly_notional(self):
+        """The label used to name the wrong quantity.
+
+        kelly_debit is the PRE-clamp ask; the sized notional is what survives
+        any clamp. They differ whenever clamped_by is set, and a log that calls
+        one by the other's name misreports exactly the case worth reading.
+        """
+        s = size(1.0, 0.50, bankroll=10_000.0)
+        self.assertEqual(s.clamped_by, "max_position_usdc")
+        self.assertNotIn("kelly_notional=", s.log_fields())
+        self.assertIn(f"kelly_debit={s.kelly_debit:.4f}", s.log_fields())
+        self.assertIn("clamped_by=max_position_usdc", s.log_fields())
+        self.assertNotAlmostEqual(s.kelly_debit, s.notional, places=2)
 
     def test_it_never_rounds_up_to_reach_the_minimum(self):
         """The one thing that must not happen.
@@ -215,6 +230,132 @@ class ExchangeMinimumTest(unittest.TestCase):
         self.assertTrue(generous.tradeable)
         self.assertFalse(strict.tradeable)
         self.assertEqual(strict.required_shares, 50.0)
+
+
+class BoundaryTest(unittest.TestCase):
+    """The comparison against the exchange minimum, pinned on BOTH sides.
+
+    Mutants moving it either way survived the suite: `<=` instead of `<`, and
+    admitting 1% under. Nothing sat at the boundary, and the boundary is the
+    entire question this code exists to answer.
+    """
+
+    def shares_for(self, notional, price):
+        return notional / price
+
+    def test_exactly_the_minimum_is_admitted(self):
+        """5.000000 shares trades. GATE 8 uses the same comparison."""
+        price, minimum = 0.20, 5.0
+        # Choose p so the sized notional lands exactly on 5 shares.
+        target_notional = minimum * price
+        lo, hi = price, 1.0
+        for _ in range(200):
+            mid = (lo + hi) / 2
+            if size(mid, price).notional >= target_notional:
+                hi = mid
+            else:
+                lo = mid
+        s = size(hi, price)
+        self.assertGreaterEqual(s.shares, minimum)
+        self.assertTrue(s.tradeable, s.log_fields())
+
+    def test_a_hair_under_the_minimum_is_refused(self):
+        """Kills `shares <= required` and any epsilon slack."""
+        price, minimum = 0.20, 5.0
+        lo, hi = price, 1.0
+        for _ in range(200):
+            mid = (lo + hi) / 2
+            if size(mid, price).shares >= minimum:
+                hi = mid
+            else:
+                lo = mid
+        just_under = size(lo, price)
+        self.assertLess(just_under.shares, minimum)
+        self.assertFalse(just_under.tradeable, just_under.log_fields())
+        self.assertGreater(just_under.shares, minimum * 0.9999,
+                           "must be a HAIR under, or it proves nothing")
+
+    def test_one_percent_under_is_refused(self):
+        """Kills `shares < required * 0.99`, which survived the whole suite."""
+        for fraction in (0.99, 0.995, 0.999):
+            with self.subTest(fraction=fraction):
+                price, minimum = 0.20, 5.0
+                notional = minimum * fraction * price
+                lo, hi = price, 1.0
+                for _ in range(200):
+                    mid = (lo + hi) / 2
+                    if size(mid, price).notional >= notional:
+                        hi = mid
+                    else:
+                        lo = mid
+                s = size(hi, price)
+                if s.shares < minimum:
+                    self.assertFalse(s.tradeable, s.log_fields())
+
+
+class ProbabilityRangeTest(unittest.TestCase):
+    """The headline result depends on p <= 1, so p is range-checked.
+
+    Measured before this existed: p = 1.05 at price 0.98 returned a TRADEABLE
+    $8.74 notional, inside the region this module calls impossible. The old
+    linear ramp clamped every input to $10; Kelly is linear in the edge, so the
+    same unit slip now runs to the ceiling.
+    """
+
+    def test_a_probability_above_one_is_refused(self):
+        for p in (1.0000001, 1.04, 1.05, 70.0):
+            with self.subTest(p=p):
+                s = size(p, 0.40)
+                self.assertFalse(s.tradeable)
+                self.assertEqual(s.refusal, "invalid_probability")
+
+    def test_it_cannot_reopen_the_impossible_region(self):
+        """The specific measured case."""
+        s = size(1.05, 0.98)
+        self.assertFalse(s.tradeable)
+        self.assertEqual(s.notional, 0.0)
+
+    def test_a_negative_probability_is_refused(self):
+        self.assertEqual(size(-0.1, 0.40).refusal, "invalid_probability")
+
+    def test_the_valid_endpoints_are_still_accepted(self):
+        for p in (0.0, 1.0):
+            with self.subTest(p=p):
+                self.assertNotEqual(size(p, 0.40).refusal, "invalid_probability")
+
+    def test_a_bad_kelly_fraction_is_named_correctly(self):
+        """It used to produce a NEGATIVE notional refused as
+        below_exchange_minimum, mislabelling a bad input as a small trade in
+        the very logs decision (c) is mined from."""
+        for fraction in (-0.10, 0.0, float("nan")):
+            with self.subTest(fraction=fraction):
+                s = size(0.60, 0.40, kelly_fraction=fraction)
+                self.assertEqual(s.refusal, "invalid_kelly_fraction")
+                self.assertGreaterEqual(s.notional, 0.0)
+
+
+class EnforcedCeilingTest(unittest.TestCase):
+    """Size against the ceiling the executor enforces FIRST."""
+
+    def test_the_configured_ceiling_binds_before_the_hard_one(self):
+        s = size(1.0, 0.50, bankroll=10_000.0,
+                 max_position_usdc=10.0, absolute_max_usdc=25.0)
+        self.assertAlmostEqual(s.debit, 10.0, places=9)
+        self.assertEqual(s.clamped_by, "max_position_usdc")
+
+    def test_the_hard_ceiling_binds_when_it_is_the_lower(self):
+        s = size(1.0, 0.50, bankroll=10_000.0,
+                 max_position_usdc=100.0, absolute_max_usdc=25.0)
+        self.assertAlmostEqual(s.debit, 25.0, places=9)
+        self.assertEqual(s.clamped_by, "absolute_max_position_usdc")
+
+    def test_it_never_proposes_above_what_gate_5_enforces(self):
+        """A $12 proposal against a $10 configured cap would be refused after
+        approval, putting a figure in front of a human the system will not
+        honour."""
+        s = size(1.0, 0.30, bankroll=10_000.0,
+                 max_position_usdc=10.0, absolute_max_usdc=25.0)
+        self.assertLessEqual(s.debit, 10.0)
 
 
 class FailClosedTest(unittest.TestCase):


### PR DESCRIPTION
Items 7 and 2. **Trading stays DISABLED and this does not re-enable it.**

## The headline, which is not what was scoped

The scope expected an ~8x size reduction to $0.25-$1.25. The sizes are right.
**None of them can be placed.**

Polymarket enforces a per-market minimum order size in **SHARES**
(`orderMinSize`, 5 on every market sampled), server-side:

```
order 0x... is invalid. Size (1.08) lower than the minimum: 5
```

Clearing it requires `edge >= 2 * price * (1 - price)`. Edge can never exceed
`1 - price`, so that requires `price <= 0.5`. **Above price 0.5 the minimum is
unreachable at any edge, including certainty**: at p=1 the stake collapses to
`KELLY_FRACTION * bankroll` = $2.50 whatever the price, giving `2.5 / price`
shares, which crosses 5 at price 0.48.

All four historical positions are refused:

| position | p | price | edge | Kelly notional | shares | vs 5 required |
|---|---|---|---|---|---|---|
| cee4eacd XRP | 0.986 | 0.925 | 0.061 | $2.03 | 2.20 | refused |
| 71f8a608 BTC | 0.546 | 0.415 | 0.131 | $0.54 | 1.29 | refused |
| f4be9ee8 ETH | 0.615 | 0.279 | 0.336 | $1.11 | 3.97 | refused |
| b3cecdef SOL | 0.706 | 0.396 | 0.310 | $1.23 | 3.11 | refused |

**This corrects my own audit.** I reported the surviving region as deep
favourites (`price >= 0.964`). That was wrong, and backwards: deep favourites
are the one region that is arithmetically **impossible**. What survives is
`price in [0.10, ~0.48]` with a very large edge, needing a simulated
probability of 0.29 at price 0.10, 0.54 at 0.20, 0.74 at 0.30 and 0.90 at 0.40.
At the 7-point edge floor nothing is placeable anywhere.

**Near-total suppression is the intended outcome.** The model was 7x wrong six
weeks ago. A system that sizes correctly and therefore almost never trades is
behaving properly. Per decision (c), every refusal is logged with price, edge,
required shares, available shares and the computed Kelly notional, so the
suppression rate becomes data for a capital decision rather than a guess. What
that measures, and the analytic condition cannot, is **what fraction of actually
proposed candidates land in the placeable band** — that is market flow.

## bankroll_usdc = 25 is a measurement, not a dial

From $29.24 of real spendable collateral. The ~$180 that would make Kelly and
the exchange compatible at mid prices is a **deposit of about $155: a capital
decision, not a config edit.** Editing the constant to reach it would size
against money that does not exist, which is what turns Kelly from conservative
into dangerous. The config comment says this at length, because it is the
tempting "fix".

## What the sizing does

`f = 0.10 * (p - price) / (1 - price)` against bankroll 25, capped so the
**DEBIT** hits the cap, not the notional. The fee is `0.07 * (1 - price)` of
notional, so `notional = cap / (1 + 0.07 * (1 - price))`.

### The fee model's evidence base

Included because it was not here before, and its absence caused a review to
conclude the model was "verified at exactly one price" and call its
price-dependence "extrapolation from a single point". That was a fair reading of
this PR body and wrong about the evidence, which is a self-sufficiency failure
of the same kind #118 was corrected for: evidence that exists but is unreachable
from the artefact.

The fit is over **eight settlement receipts, buys and sells, prices from 1.5c to
90c, maximum residual 4e-6** — recorded in the build log entry of 2026-09-05,
"Polymarket's fee, solved". The per-receipt decode lives in that entry's
analysis; the summary is reproduced here rather than reconstructed, because I
did not re-derive the individual rows for this PR and will not present a table I
did not compute.

Spot-check against one of them, the 2026-08-20 fill: 10.501189 debited against
10.00 notional at price 0.284 is a ratio of 1.05012, predicted
`1 + 0.07 * 0.716 = 1.05012`. Four decimal places.

That entry also carries a caveat this PR honours: *"treat 0.07 as a monitored
hypothesis with a residual check, not a constant: it is an empirical fit to one
wallet in one market family, not documentation."* The cash-out ceiling is that
residual check, which is why a persistent breach is logged as "the fee schedule
changed" rather than as one bad decode.

Kelly only ever sizes DOWN. `max_position_usdc` stays a hard ceiling above it
and records when it binds (never, at this bankroll: the max possible stake is
$2.50).

## Also in this change

**GATE 8** refuses orders under the market's `orderMinSize`, read **live from
Gamma at execution** rather than trusted from the candidate or hardcoded to 5.
Hardcoding a remote per-market value is the manual-allowlist pattern this
codebase has been caught by four times. Unavailable **fails closed**. Without
the gate a $0.25 order passes every other check, gets human approval, commits
the money path, and is rejected by the exchange after all of that.

**The Analyst's REDUCE was a safety inversion.** `max(AMOUNT_MIN_USDC, before/2)`
with a $3 floor returned **$3.00 on a $1.23 Kelly position — a 2.4x increase**,
on the exact path where the Analyst has just expressed doubt. Masked only
because the old ramp never sized below $3. Now `min(before, before/2)`, and a
reduction landing under the exchange minimum marks the candidate unsizeable
rather than putting a one-tap Execute button on an unplaceable trade.

**`MAX_CASH_OUT_NOTIONAL_FACTOR` is per-trade**, `1 + 0.07*(1-price)` plus
tolerance, replacing a flat 1.5 that was loose by more than 70x at high prices
and made a fee-schedule change detectable only on the cheapest markets. The old
bound accepted a **49.9% fee** against a 10.00 notional; a test pins that it no
longer does.

**The NO side is sized correctly** by complementing both price and probability,
replacing an `abs(edge)` hack the old code apologised for in its own docstring.
Unreachable from the scanner today; correct rather than dead so nothing has to
remember that.

`AMOUNT_MIN_USDC`, `AMOUNT_MAX_USDC`, `AMOUNT_EDGE_FLOOR` and
`AMOUNT_EDGE_CEILING` deleted rather than left dead. `trading.md` updated: it
claimed six gates and a fixed $10 position, and would have had Charlie
explaining neither the refusals nor why nothing trades.


---

# Review round 3: the arithmetic was tested, the wiring was not

Fifteen findings, all fixed. **Eighteen mutants that survived the previous suite
now die.**

## The finding worth carrying, and it is bigger than this PR

`sizing.py` had 31 tests. `_to_candidate` — its only caller, and the code that
actually puts a number on `amount_usdc` — had **none**. Six mutants in that one
function survived the entire suite:

| mutant | was |
|---|---|
| `bankroll=250.0` (10x the measured bankroll) | SURVIVED |
| `kelly_fraction=1.0` (full Kelly) | SURVIVED |
| `price_floor=0.0` | SURVIVED |
| **`amount_usdc=sizing.debit`** | SURVIVED |
| `sizing_refusal=None` | SURVIVED |
| `max_position_usdc=1e9` | SURVIVED |

The fourth is **verbatim the defect this PR exists to fix**: sizing the notional
to the cap so the wallet overspends by the fee. Green suite.

> An arithmetic module tested as a pure function proves the arithmetic. It
> proves nothing about the values the caller feeds it, or the field it writes
> the answer into.

Fixed as a class, not six instances: every value crossing the module boundary
onto the money path now has a wire-through test asserting the caller passes what
it claims to pass. `sizing_refusal=None` mattered twice — `select_best_trade`
filters on a field nothing asserted was ever set, so K12's defence could have
been disabled upstream with K12's own test still green.

**This is the third consecutive PR in this series where the cold review found
the tests, not the code.**

## D2-D5, the blockers

**D2.** GATE 8's fail-closed test used a candidate with `min_order_size=None` —
the one case where a fallback is impossible — so a mutant falling back to the
candidate's scan-time copy *only when the live read failed* survived. It kept
the live fetch and kept live-wins, breaking only the fail-closed half. Now
tested with a candidate that HAS a copy, and the docstring's "deliberately does
NOT fall back" is asserted rather than merely stated.

**D3.** The exchange-minimum comparison is pinned on both sides, in `sizing.py`
AND `executor.py`. Mutants moving it either way survived, including admitting
1% under — the exact failure GATE 8 exists to prevent.

**D4.** `_fetch_market_limits` now verifies the market it got back is the market
it asked for. Gamma ignores unrecognised query params and returns its default
page, so a renamed `condition_ids` filter returned **a stranger's**
`orderMinSize` and price, both used: fail-open by wrong target. It is the only
new network call on the money path and every test stubbed it; it now has direct
tests over ten payload shapes. `outcomePrices` as an object raised `KeyError`
past the except clause and reported `gate_error` instead of
`below_exchange_minimum` — the wrong diagnosis in the logs (c) exists to mine.

**D5.** `sim_probability` is range-validated at both ends of the chain. The
headline result rests on `edge <= 1 - price`, which rests on `p <= 1`, and
nothing enforced it: **p = 1.05 at price 0.98 returned a TRADEABLE $8.74
notional, inside the region this PR calls impossible.** The old ramp clamped any
input to $10; Kelly is linear in the edge, so the same unit slip now runs to the
ceiling.

## The two owner decisions

**D8.** Sizing uses `min(trading_config.max_position_usdc,
ABSOLUTE_MAX_POSITION_USDC)`, read once per run, because GATE 5 enforces the
configured value first. Sizing against the hard 25 could propose $12 and have
GATE 5 refuse it after approval. `clamped_by` names which of the two bound.

**D10.** `FEE_TOLERANCE` gains an **absolute floor of $0.03** alongside the 1%
ratio. Reasoning rather than a guess: at Kelly sizes the ratio is worth half a
cent to two and a half, while the error it must absorb does not shrink with
position size. A two-price fill 2c apart on a $2 order moves the fee by about
`0.07 * 0.02 * 6.5 = $0.009`, which a 1% ratio on $0.25 ($0.0025) does not
cover. A false trip records the notional, **excluding the fee** — understating
cost basis, overstating pnl, under-triggering GATE 3's loss brake. That is the
unsafe direction, so the floor covers a plausible multi-fill with headroom.
$0.03 is ~1.2% of a $2.50 position and 12% of a $0.25 one, deliberately generous
at the small end. It is not slack in the fee model: at 4e-6 residual, model
error is irrelevant here.

## The three wrong numbers

They matter most because `trading.md` ships them to Charlie.

- Required edge at price 0.279 is **0.4226**, not 0.395.
- `x(1-x) <= 0.035` has **two** roots and both are now stated. The upper
  (0.963681) is explained as infeasible rather than dropped: it solves the
  inequality while violating `edge <= 1 - price`, and it is the region the
  original audit wrongly called the survivor. Dropping it left the arithmetic
  that produced the original error in the file, just truncated.
- The cut is **0.482521**, stated once, with the fee-aware model it comes from
  named. `trading.md` said "above 0.5" — the fee-free answer, which reports the
  0.4826-0.4999 band as tradeable where the code refuses it.

## Also fixed

D6 (approval-path guard asserted — K12's sibling), D7 (GATE 8 converts at the
side price; unreachable today only because GATE 4 refuses a negative edge
first), D9 (`bankroll_usdc`, `kelly_fraction` and `sizing_price_floor` clamped
like `min_horizon_tradeable_days`, env may only move them conservatively, a
rejected override is logged not silently dropped, and the detached comment is
back above its own line), D14 (`invalid_kelly_fraction` instead of a negative
notional mislabelled), D15 (`log_fields` reports `sized_notional`, `kelly_debit`
and `clamped_by`).

## Three silently-unrunnable test files, not one

`test_analyst.py`, `test_manual_position.py` and `test_relay_settlement.py` all
import a third-party package at module scope and are invisible on a stock local
box. `test_relay_settlement.py` covers the settlement path this PR's cash-out
ceiling feeds. Filed as **#130**; the constraint recorded there is that any fix
must fail LOUDLY, since a clean skip is worse than the current import error.

## Verification: 30 mutants, all killed

Property-pinning, not assertion-adding. Run on a **committed** tree with
`__pycache__` purged and a dirty-tree refusal on both sides.

| id | mutant | killed by |
|---|---|---|
| K1 | size the NOTIONAL to the cap, ignoring the fee | `test_sizing` |
| K2 | full Kelly instead of fractional | `test_sizing` |
| K3 | ROUND UP to reach the exchange minimum | `test_sizing` |
| K4 | assume the usual 5 when `orderMinSize` is unknown | `test_sizing` |
| K5 | CLAMP price to the floor instead of filtering on it | `test_sizing` |
| K6 | let the ceiling raise a small Kelly, not only lower it | `test_sizing` |
| K7 | GATE 8 trusts the candidate's minimum, not the live one | `test_executor` |
| K8 | GATE 8 fails OPEN when the minimum cannot be read | `test_executor` |
| K9 | GATE 8 prefers the scan price over the live one | `test_executor` |
| K10 | restore the $3 floor in the Analyst's REDUCE | `test_scanner_horizon` |
| K11 | restore the flat 1.5x cash-out ceiling | `test_executor` |
| K12 | `select_best_trade` proposes an unsizeable candidate | `test_scanner_horizon` |

**K7 is the property mutant**, same shape as GATE 7's clock: keep the gate
entirely and change only where freshness comes from. **K12 initially SURVIVED** —
nothing asserted that an unsizeable candidate stays out of `best_trade`, only
that sizing refuses it. Now covered, with the unsizeable candidate carrying the
widest edge so an absent filter selects it.

One correctness fix found by writing the tests: `shares` was derived from an
unrounded notional while the relay receives the rounded one, so the count
checked against the minimum was not the count the exchange computes. At the
boundary that is the difference between a clean refusal and a rejected order.

Suite: 31 new in `test_sizing`, 7 GATE 8 cases, 6 reduce/select cases. All
green, plus every pre-existing suite.

## Review status

**DRAFT**, pending a fresh cold review. Trading stays disabled and does not
re-enable on merge.
