### PR TITLE
docs: record the setup-node v5 package-manager-cache trap portfolio-wide

### DIFF
--- a/LOCATIONS.md
+++ b/LOCATIONS.md
@@ -194,6 +194,47 @@ one real error on its first run.
   the worker. It does NOT match production, and cannot: production is the
   Cloudflare Workers runtime, which is V8 rather than Node.
 
+### setup-node v5 arms itself from package.json
+
+`actions/setup-node@v5` defaults `package-manager-cache: true` (v4 had no such
+input). At that default it reads the `packageManager` field from package.json
+and RUNS that tool to resolve the cache store path, before any workflow step
+executes. GitHub runners preinstall npm and yarn but not pnpm, so in a repo
+whose field says `pnpm@...`, a setup-node step with neither a prior
+`pnpm/action-setup` step nor `package-manager-cache: false` kills the job in
+setup:
+
+```
+Unable to locate executable file: pnpm. Please verify either the file path
+exists or the file can be found within a directory specified by the PATH
+environment variable.
+```
+
+First hit: flow-coach-ai `retention-watch.yml`, first dispatch (run
+34256430562 on flow-coach-ai@9cc6b6c, 2026-09-08). Fix merged same day as
+flow-coach-ai@f598fda (`package-manager-cache: false`, since that job installs
+nothing on purpose).
+
+Why this is recorded here and not just in that repo: **the same YAML is green
+or dead depending on the target repo's package.json**, so a workflow shape
+proven green in one repo is not evidence it works in another. Exposure as
+measured 2026-09-08:
+
+| Repo | `packageManager` field | setup-node without pnpm/action-setup | State |
+|---|---|---|---|
+| flow-coach-ai | `pnpm@10.4.1` | retention-watch.yml | fixed (`package-manager-cache: false`) |
+| ghl-support-bot | `pnpm@10.4.1` | none (ci.yml runs pnpm/action-setup first) | immune by ordering |
+| QClaw | none | ci.yml (twice) | immune only while the field stays absent |
+| flowos-web | none | ci.yml | immune only while the field stays absent |
+| flowos-sms-delivery | none | ci.yml (twice), deploy-drift.yml | immune only while the field stays absent |
+| flowos-sms-gateway | none | no setup-node | not exposed |
+
+The standing rule that follows: adding a `packageManager: pnpm@...` field to a
+package.json retroactively arms every setup-node step in that repo's
+workflows. Whoever adds the field owns checking the workflows in the same
+commit; whoever writes a new workflow in a pnpm repo either puts
+`pnpm/action-setup` before setup-node or sets `package-manager-cache: false`.
+
 ### flowos-sms-delivery deploys differently, permanently
 
 This repo does not auto-deploy, and that is a settled decision rather than a

--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -25985,3 +25985,71 @@ appleboy/ssh-action          v1 unchanged (composite, no node runtime)
 Bumping only the two actions the warning named would have left `setup-python`
 and `pnpm/action-setup` warning. Bumping `upload-artifact` by one major would
 have fixed nothing at all while appearing to.
+
+## 2026-09-08: a workflow killed by a default it never opted into
+
+The first dispatched run of flow-coach-ai's new retention watcher (run
+34256430562, on flow-coach-ai@9cc6b6c) died before any step executed:
+
+```
+Unable to locate executable file: pnpm. Please verify either the file path
+exists or the file can be found within a directory specified by the PATH
+environment variable.
+```
+
+The workflow does not call pnpm anywhere, which is what makes the failure
+worth an entry. The dying step was `actions/setup-node@v5` itself. Its run
+log shows the config it resolved:
+
+```
+with:
+  node-version-file: .nvmrc
+  ...
+  package-manager-cache: true
+```
+
+`package-manager-cache: true` appears in no workflow file in any of the six
+repos. It is a default new in setup-node v5 (v4 had no such input). At that
+default, setup-node reads the `packageManager` field from the target repo's
+package.json and RUNS that tool to resolve its cache store path.
+flow-coach-ai's field says `pnpm@10.4.1`, GitHub runners preinstall npm and
+yarn but not pnpm, and the job was dead before its first step.
+
+Three properties compound here:
+
+**The workflow was authored green and failed on repo state.** ci.yml in the
+same repo uses the identical setup-node@v5 step and passes every run, because
+`pnpm/action-setup` happens to run before it. deploy-drift.yml in
+flowos-sms-delivery is the same shape as the watcher, no pnpm anywhere, and
+passes every run, because that package.json has no `packageManager` field for
+setup-node to read. Same YAML, three different outcomes, decided by files the
+YAML never mentions. A workflow shape proven green in one repo is not
+evidence it works in another, and this entry exists mostly to anchor that
+sentence.
+
+**The arming trigger is a package.json edit, not a workflow edit.** Adding
+`packageManager: pnpm@...` to QClaw, flowos-web, or flowos-sms-delivery today
+would break their setup-node workflows on the next run, without any workflow
+file changing and without CI on the arming commit necessarily noticing
+(scheduled workflows run later, on main). The full exposure table as measured
+2026-09-08 is in LOCATIONS.md under "setup-node v5 arms itself from
+package.json", with the standing rule: whoever adds the field owns checking
+the workflows in the same commit.
+
+**It is the delayed cost of an upgrade recorded as free.** The portfolio
+moved checkout and setup-node from v4 to v5 hours earlier, verified as
+"CI=0, node20-warnings=0" across all six repos. That verification was
+honest and this failure does not contradict it: every existing workflow kept
+passing. What the bump actually changed was the environment for workflows
+not yet written. The first new workflow authored to the v5 convention, in a
+pnpm repo, without the accidental protection of pnpm/action-setup, hit the
+new default within hours.
+
+Disposition: fixed in flow-coach-ai@f598fda with `package-manager-cache:
+false` and the reasoning in a comment at the line. Chosen over adding
+pnpm/action-setup because the watcher installs nothing by design, so there is
+nothing to cache and no reason to couple it to the app toolchain. The second
+dispatch (run 34257851939) went green end to end, which also closed the last
+unproven link in the retention rollout, the Actions secret path. The failure
+direction throughout was the right one: loud, in setup, before the job could
+assert anything.


### PR DESCRIPTION
Follow-up 2 from the retention rollout: the trap that killed flow-coach-ai's first retention-watch dispatch, recorded where the next workflow author will look rather than only in the repo that got hit.

**The trap:** setup-node v5 defaults `package-manager-cache: true` (no such input existed in v4). At that default it reads `packageManager` from the target repo's package.json and runs that tool to resolve the cache store, before any workflow step. Runners preinstall npm and yarn but not pnpm, so in a pnpm repo any setup-node step without a prior `pnpm/action-setup` (or an explicit `false`) dies in setup: `Unable to locate executable file: pnpm`.

**What this PR adds:**
- **LOCATIONS.md**, in the CI and deploy gating section: the mechanism, the verbatim error, the exposure table measured 2026-09-08 across all six repos (two pnpm-field repos, one hit and fixed, one immune by step ordering; three repos immune only while their package.json stays field-less; one not exposed), and the standing rule: adding a `packageManager: pnpm@...` field retroactively arms every setup-node step in that repo's workflows, so whoever adds the field owns checking the workflows in the same commit.
- **QCLAW_BUILD_LOG.md**: the incident (run 34256430562 on flow-coach-ai@9cc6b6c), the three-way asymmetry of one YAML shape across repos, why the arming trigger is a package.json edit rather than a workflow edit, and why the hours-earlier v4-to-v5 bump verified green across all six repos yet still produced this: the bump changed the environment for workflows not yet written, and the verification only covered workflows that existed.

Fix itself already merged as flow-coach-ai@f598fda (#16 there); second dispatch run 34257851939 green end to end. Docs only, no code paths touched.