### PR TITLE
docs: build log 2026-09-08, three consecutive reviews found the tests not the code

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -26053,3 +26053,104 @@ dispatch (run 34257851939) went green end to end, which also closed the last
 unproven link in the retention rollout, the Actions secret path. The failure
 direction throughout was the right one: loud, in setup, before the job could
 assert anything.
+
+## 2026-09-08: three consecutive reviews found the tests, not the code
+
+Third cold review in a row on the trade engine, and the third where the defect
+was in the test suite rather than in the implementation. That is now a pattern
+rather than three coincidences, and it has a shape worth naming.
+
+### The three
+
+**PR #118, round 2.** `test_gate7_admits_exactly_the_floor` asserted that a
+market at exactly the tradeable-horizon floor passes the executor gate. The
+implementation read a scan-time snapshot, so a market at the floor when proposed
+was below it when executed and the gate admitted it. The test asserted the
+defect.
+
+**PR #118, round 3.** The replacement sentinel moved the END DATE and never
+moved the CLOCK, so it could not distinguish "recomputed at execution" from
+"recomputed at import". A mutant capturing the clock once at module scope passed
+the full suite, 75/75.
+
+**PR #127, round 3.** `sizing.py` had 31 tests. `_to_candidate`, its only caller
+and the code that actually puts a number on `amount_usdc`, had none. Six mutants
+inside that one function survived the entire suite:
+
+```
+bankroll=250.0          10x the measured bankroll        SURVIVED
+kelly_fraction=1.0      full Kelly, not a tenth          SURVIVED
+price_floor=0.0         the sizing floor removed         SURVIVED
+amount_usdc=debit       the fee-inclusive figure sent    SURVIVED
+sizing_refusal=None     the refusal never recorded       SURVIVED
+max_position_usdc=1e9   the ceiling removed              SURVIVED
+```
+
+The fourth is the one to sit with. Writing the DEBIT into `amount_usdc` sends
+the fee-inclusive number to the relay as the amount to spend, so every trade
+overspends its cap by the fee. **That is verbatim the defect the PR was written
+to fix**, restatable as a one-line mutation of the fix itself, against a green
+suite.
+
+### The shape
+
+> An arithmetic module tested as a pure function proves the arithmetic. It
+> proves nothing about the values the caller feeds it, or the field it writes
+> the answer into.
+
+The pure function attracts the tests. It is easy to test, satisfying to test,
+and the tests read well: 31 of them, covering Kelly, the fee, the ceiling, the
+exchange minimum, both directions, every fail-closed path. None of that was
+wrong. All of it was about a function that cannot spend money.
+
+The boundary attracts none, and three things conspire to hide that:
+
+1. **Line coverage says it is covered.** `_to_candidate` WAS executed by two
+   existing tests. They asserted `end_date` and nothing else. A coverage report
+   shows the function green while every sizing value it passes is unasserted.
+2. **The wiring looks too simple to be wrong.** `bankroll=config.bankroll_usdc`
+   is not an algorithm. It is a line nobody re-reads, which is the same reason
+   the shares-rounding defect survived: an invariant that looks too obvious to
+   assert is exactly the one an implementation can quietly break.
+3. **The mutants were aimed at the interesting code.** Twelve mutants were
+   written for this change and every one targeted `sizing.py` or the gate logic.
+   Not one targeted the six-line call site. The harness inherited the same bias
+   as the tests.
+
+### The rule
+
+**Every value that crosses a module boundary onto the money path needs a
+wire-through test asserting the caller passes what it claims to pass.** Not that
+the callee handles it correctly, which is a separate test, but that the value
+arriving is the configured one.
+
+Mechanically, for this codebase: spy the callee, call the caller, assert the
+captured kwargs equal the config values, and separately assert the returned
+figure lands in the field the caller claims to write. That kills all six of the
+above and is about forty lines.
+
+The corresponding mutant class, to sit alongside the "capture the source of
+freshness once at import" mutant from the #118 entry:
+
+> For any caller that passes configured values into a computation, replace each
+> one with a plausible wrong constant. If the suite stays green, the wiring is
+> untested no matter how well the computation is.
+
+### A recurrence worth noting separately
+
+The same review concluded the fee model was "verified at exactly one price" and
+called its price-dependence "extrapolation from a single point". The model is
+fitted to eight receipts from 1.5c to 90c with a maximum residual of 4e-6, in
+the build log entry of 2026-09-05.
+
+The reviewer was reading the PR body, which cited one receipt. So the criticism
+was a correct reading of the artefact and wrong about the world, and the fault
+is the artefact's. This is exactly the self-sufficiency failure #118 was
+corrected for: evidence that exists but is unreachable from the thing under
+review. A cold reader cannot be expected to search the build log for the
+justification of a constant, and a reviewer who assumes the evidence exists
+somewhere is not reviewing.
+
+Fixed by putting the evidence base in the PR body, including the caveat the
+original entry attached to it: treat 0.07 as a monitored hypothesis with a
+residual check, not a constant.


### PR DESCRIPTION
Build log only. No code. Independent of #127. Stacks after #128 (different
section, no conflict).

Third cold review in a row on the trade engine, and the third where the defect
was in the **suite** rather than the implementation. That is a pattern now.

## The three

- **#118 round 2** — `test_gate7_admits_exactly_the_floor` asserted the defect
  it was written to catch.
- **#118 round 3** — the replacement sentinel moved the END DATE and never the
  CLOCK, so a mutant capturing the clock once at import passed 75/75.
- **#127 round 3** — `sizing.py` had 31 tests; `_to_candidate`, its only caller
  and the code that puts a number on `amount_usdc`, had none.

```
bankroll=250.0          10x the measured bankroll        SURVIVED
kelly_fraction=1.0      full Kelly, not a tenth          SURVIVED
price_floor=0.0         the sizing floor removed         SURVIVED
amount_usdc=debit       the fee-inclusive figure sent    SURVIVED
sizing_refusal=None     the refusal never recorded       SURVIVED
max_position_usdc=1e9   the ceiling removed              SURVIVED
```

The fourth is the one to sit with. It sends the fee-inclusive figure to the
relay as the amount to spend, so every trade overspends its cap by the fee.
**That is verbatim the defect the PR was written to fix**, restatable as a
one-line mutation of the fix itself, against a green suite.

## The shape

> An arithmetic module tested as a pure function proves the arithmetic. It
> proves nothing about the values the caller feeds it, or the field it writes
> the answer into.

The pure function attracts the tests: easy to test, satisfying to test, and none
of those 31 were wrong. All of them were about a function that cannot spend
money.

Three things hide the boundary:

1. **Line coverage says it is covered.** `_to_candidate` *was* executed, by two
   tests that asserted `end_date` and nothing else. Green function, unasserted
   values.
2. **The wiring looks too simple to be wrong.** `bankroll=config.bankroll_usdc`
   is not an algorithm; it is a line nobody re-reads. Same reason the
   shares-rounding defect survived.
3. **The mutants inherited the tests' bias.** Twelve were written for this
   change and every one targeted `sizing.py` or the gate logic. Not one targeted
   the six-line call site.

## The rule, and the matching mutant class

> Every value that crosses a module boundary onto the money path needs a
> wire-through test asserting the caller passes what it claims to pass.

Mechanically: spy the callee, call the caller, assert the captured kwargs equal
the config values, and separately assert the returned figure lands in the field
the caller claims to write. Kills all six. About forty lines.

> For any caller that passes configured values into a computation, replace each
> one with a plausible wrong constant. If the suite stays green, the wiring is
> untested no matter how well the computation is.

Sits alongside the "capture the source of freshness once at import" mutant from
the earlier entry.

## A recurrence, recorded separately

The same review concluded the fee model was "verified at exactly one price" and
called its price-dependence "extrapolation from a single point". It is fitted to
**eight receipts from 1.5c to 90c, maximum residual 4e-6** (build log
2026-09-05).

The reviewer was reading the PR body, which cited one receipt. **So the
criticism was a correct reading of the artefact and wrong about the world, and
the fault is the artefact's.** Exactly the self-sufficiency failure #118 was
corrected for: evidence that exists but is unreachable from the thing under
review. A cold reader cannot be expected to search the build log for the
justification of a constant, and a reviewer who assumes the evidence exists
somewhere is not reviewing.

Branched from `main` @ `4c129cc`.