### PR TITLE
docs: record the Manus decommission as it actually ended

### DIFF
--- a/FLOW_OS_STATE.md
+++ b/FLOW_OS_STATE.md
@@ -260,25 +260,25 @@ $97/month Starter Plan, but this app touches no billing or entitlement.
   deploys, customer-facing copy about pricing, and CRM writes.
   Revisit once CI and preview deploys exist.
 - **Known issues / owed:**
-  1. Gmail app password "n8n dashboard email" still active in the
-     Google account; the system it served is gone (see the n8n Health
-     Dashboard entry in LOCATIONS.md). Revocation is Tyson's, owed.
-  2. Privacy disclosure gap: Meta receives challenge signup data via
+  1. Privacy disclosure gap: Meta receives challenge signup data via
      the GHL-side fb-retarget tag, and needs to appear in the privacy
      policy alongside the open Clarity consent item. Meta tracking
      itself stays per Tyson.
-  3. No headless browser tier: validation matrix at repo
+  2. No headless browser tier: validation matrix at repo
      docs/validation-matrix.md, browser tier manual; Playwright is the
      recorded fix. (CI itself exists since 2026-09-08: required `test`
      check plus branch protection, and Railway auto-deploys main, so
      "no CI / manual railway up" is no longer true and is retired from
      this item.)
-  4. Landing page corrections proposed, not shipped (customGPT bullet,
+  3. Landing page corrections proposed, not shipped (customGPT bullet,
      canonical tag): ~/Projects/flow-coach-ai-audit/SLICE5-LANDING-PROPOSALS.md
-  5. Dependency advisories: 0 as of 2026-09-08 (from 76 at the
+  4. Dependency advisories: 0 as of 2026-09-08 (from 76 at the
      2026-08-19 audit; cleared in repo PR #17, deployed at baa7908).
      Two pnpm overrides (`express>qs`, `mysql2`) carry the reasoning
      for the next person and are droppable when upstream catches up.
+  (The Gmail app password item that briefly stood here was found
+  already absent from the Google account on 2026-09-08; see the n8n
+  Health Dashboard entry in LOCATIONS.md. Nothing is owed.)
 - **History:** built on Manus 2026-03-17, existed undocumented in every
   canonical doc until the 2026-08-19 audit; decoupled and cut over
   across Phase 2 slices 1-4 (five adversarial review rounds on the

--- a/FLOW_OS_STATE.md
+++ b/FLOW_OS_STATE.md
@@ -276,9 +276,10 @@ $97/month Starter Plan, but this app touches no billing or entitlement.
      2026-08-19 audit; cleared in repo PR #17, deployed at baa7908).
      Two pnpm overrides (`express>qs`, `mysql2`) carry the reasoning
      for the next person and are droppable when upstream catches up.
-  (The Gmail app password item that briefly stood here was found
-  already absent from the Google account on 2026-09-08; see the n8n
-  Health Dashboard entry in LOCATIONS.md. Nothing is owed.)
+  (The Gmail app password item that briefly stood here was already
+  handled: Tyson revoked it around the time decommissioning was first
+  discussed, unrecorded at the time; confirmed absent 2026-09-08. See
+  the n8n Health Dashboard entry in LOCATIONS.md. Nothing is owed.)
 - **History:** built on Manus 2026-03-17, existed undocumented in every
   canonical doc until the 2026-08-19 audit; decoupled and cut over
   across Phase 2 slices 1-4 (five adversarial review rounds on the

--- a/FLOW_OS_STATE.md
+++ b/FLOW_OS_STATE.md
@@ -239,8 +239,12 @@ $97/month Starter Plan, but this app touches no billing or entitlement.
 
 - **Status:** LIVE on Railway at `flowcoach.flowos.tech` since the
   2026-08-21 DNS cutover. Fully Manus-free (verified zero vendor
-  artefacts on the live page, bundles, and headers). Manus deployment
-  retained purely as DNS rollback until decommission.
+  artefacts on the live page, bundles, and headers). Manus decommission
+  completed 2026-09-08: webhooks rotated and proven (old URLs dead, new
+  ones delivering through the live app), the "manus API" n8n key
+  revoked, and the Manus deployment itself ceased to exist vendor-side
+  (platform reboot deleted all user data) rather than being retired.
+  No rollback path exists or is needed.
 - **Owner:** Tyson.
 - **Distribution:** the access link goes out in the first challenge
   email and sits in the challenge channel in the community hub. Volume
@@ -256,26 +260,34 @@ $97/month Starter Plan, but this app touches no billing or entitlement.
   deploys, customer-facing copy about pricing, and CRM writes.
   Revisit once CI and preview deploys exist.
 - **Known issues / owed:**
-  1. Decommission checklist (blocks retiring Manus): regenerate both
-     GHL webhook triggers, update Railway env, re-verify delivery
-     GHL-side; revoke the "manus API" key; then retire the Manus
-     project. Regeneration deferred to decommission deliberately so the
-     DNS rollback path keeps working webhooks.
+  1. Gmail app password "n8n dashboard email" still active in the
+     Google account; the system it served is gone (see the n8n Health
+     Dashboard entry in LOCATIONS.md). Revocation is Tyson's, owed.
   2. Privacy disclosure gap: Meta receives challenge signup data via
      the GHL-side fb-retarget tag, and needs to appear in the privacy
      policy alongside the open Clarity consent item. Meta tracking
      itself stays per Tyson.
-  3. No CI / no headless browser tier: deploys are manual railway up;
-     validation matrix at repo docs/validation-matrix.md, browser tier
-     manual. Playwright is the recorded fix.
+  3. No headless browser tier: validation matrix at repo
+     docs/validation-matrix.md, browser tier manual; Playwright is the
+     recorded fix. (CI itself exists since 2026-09-08: required `test`
+     check plus branch protection, and Railway auto-deploys main, so
+     "no CI / manual railway up" is no longer true and is retired from
+     this item.)
   4. Landing page corrections proposed, not shipped (customGPT bullet,
      canonical tag): ~/Projects/flow-coach-ai-audit/SLICE5-LANDING-PROPOSALS.md
-  5. Residual dependency advisories: 43 (7 low / 30 moderate / 6 high)
-     as of 2026-08-21, concentrated in transitive UI deps.
+  5. Dependency advisories: 0 as of 2026-09-08 (from 76 at the
+     2026-08-19 audit; cleared in repo PR #17, deployed at baa7908).
+     Two pnpm overrides (`express>qs`, `mysql2`) carry the reasoning
+     for the next person and are droppable when upstream catches up.
 - **History:** built on Manus 2026-03-17, existed undocumented in every
   canonical doc until the 2026-08-19 audit; decoupled and cut over
   across Phase 2 slices 1-4 (five adversarial review rounds on the
-  security slices). Full trail in QCLAW_BUILD_LOG.md.
+  security slices). Manus decommissioned 2026-09-08, closing audit
+  finding P1-1 (leaked webhook capability URLs) by rotation with the
+  old URLs proven dead; the vendor deleted the deployment in a platform
+  reboot the same day, destroying without notice the rollback path that
+  had been deliberately preserved for three weeks. Full trail in
+  QCLAW_BUILD_LOG.md.
 
 ### Flow States Collective
 

--- a/LOCATIONS.md
+++ b/LOCATIONS.md
@@ -122,7 +122,7 @@ files and are still mutable via the dashboard. Reconciliation TBD.
   - **Key duplication is intentional, not drift.** `POLYMARKET_PRIVATE_KEY` and `POLYMARKET_FUNDER_ADDRESS` remain in qclaw's `.env` because `src/trade_engine/config.py` hard-requires them in `REQUIRED_KEYS` and `src/trading/get_balance.py` uses them. Removing the qclaw copy is deferred to Slice 6. **Rotating the Polymarket key therefore means rotating both hosts**, and qclaw alone is not enough.
   - Not decommission-pending: this host is load-bearing for as long as trading runs from a geoblocked region. It appears in no CI config and in no repo sweep, which is how it stayed undocumented until the 2026-08-19 audit.
 
-- n8n Health Dashboard (email alerter): **GONE, 2026-09-08.** Ran in a Manus GCP workspace; the workspace ceased to exist vendor-side in the Manus platform reboot the same day its decommission was executed. Its n8n API key "manus API" (`MYYZFn3DjtKQ43i4`) was revoked 2026-09-08 (verified: row deleted, the four other keys intact, qclaw's key live-tested after). The Gmail app password "n8n dashboard email" (created 2026-03-16) is still owed a revocation, Tyson-side, in the Google account. Code record survives at `github.com/tysonven/n8n-health-dashboard` (private). Replaced by the heartbeat-based Telegram alerter (Slice 3h). Standing rule from this incident stays: platform-hosted builder workspaces (Manus and similar) get a LOCATIONS.md entry at creation, not at first commit; estate recon cannot enumerate them later.
+- n8n Health Dashboard (email alerter): **GONE, 2026-09-08.** Ran in a Manus GCP workspace; the workspace ceased to exist vendor-side in the Manus platform reboot the same day its decommission was executed. Its n8n API key "manus API" (`MYYZFn3DjtKQ43i4`) was revoked 2026-09-08 (verified: row deleted, the four other keys intact, qclaw's key live-tested after). The Gmail app password "n8n dashboard email" (created 2026-03-16) was FOUND ABSENT 2026-09-08: the Google account lists no app passwords at all. When or by what it went is unknown (Google deletes app passwords silently on certain account events, such as a password change), so this is recorded as found absent, not revoked. Code record survives at `github.com/tysonven/n8n-health-dashboard` (private). Replaced by the heartbeat-based Telegram alerter (Slice 3h). Standing rule from this incident stays: platform-hosted builder workspaces (Manus and similar) get a LOCATIONS.md entry at creation, not at first commit; estate recon cannot enumerate them later.
 ## CI and deploy gating (all six repos)
 
 State as of 2026-09-08. Before the CI/CD rollout, 670 tests existed across five
@@ -544,8 +544,9 @@ without an entry here is the failure mode this log exists to catch.
   rollback note (the Manus deployment it pointed at ceased to exist
   vendor-side in a platform reboot the same day), rewrote the n8n Health
   Dashboard entry as gone, and removed the revoked `manus API` row from the
-  n8n key table. The Gmail app password revocation is recorded in the
-  dashboard entry as still owed.
+  n8n key table. The Gmail app password planned for revocation was found
+  already absent from the Google account (timing and cause unknown), and is
+  recorded that way in the dashboard entry rather than as revoked.
 - **2026-08-20** Documented **Call Intel** (`tysonven/call-intel`) under
   standalone applications. It had never appeared in this file at all. Vercel
   serverless, and the one standalone app that does **not** have its own

--- a/LOCATIONS.md
+++ b/LOCATIONS.md
@@ -122,7 +122,7 @@ files and are still mutable via the dashboard. Reconciliation TBD.
   - **Key duplication is intentional, not drift.** `POLYMARKET_PRIVATE_KEY` and `POLYMARKET_FUNDER_ADDRESS` remain in qclaw's `.env` because `src/trade_engine/config.py` hard-requires them in `REQUIRED_KEYS` and `src/trading/get_balance.py` uses them. Removing the qclaw copy is deferred to Slice 6. **Rotating the Polymarket key therefore means rotating both hosts**, and qclaw alone is not enough.
   - Not decommission-pending: this host is load-bearing for as long as trading runs from a geoblocked region. It appears in no CI config and in no repo sweep, which is how it stayed undocumented until the 2026-08-19 audit.
 
-- n8n Health Dashboard (email alerter): **GONE, 2026-09-08.** Ran in a Manus GCP workspace; the workspace ceased to exist vendor-side in the Manus platform reboot the same day its decommission was executed. Its n8n API key "manus API" (`MYYZFn3DjtKQ43i4`) was revoked 2026-09-08 (verified: row deleted, the four other keys intact, qclaw's key live-tested after). The Gmail app password "n8n dashboard email" (created 2026-03-16) was FOUND ABSENT 2026-09-08: the Google account lists no app passwords at all. When or by what it went is unknown (Google deletes app passwords silently on certain account events, such as a password change), so this is recorded as found absent, not revoked. Code record survives at `github.com/tysonven/n8n-health-dashboard` (private). Replaced by the heartbeat-based Telegram alerter (Slice 3h). Standing rule from this incident stays: platform-hosted builder workspaces (Manus and similar) get a LOCATIONS.md entry at creation, not at first commit; estate recon cannot enumerate them later.
+- n8n Health Dashboard (email alerter): **GONE, 2026-09-08.** Ran in a Manus GCP workspace; the workspace ceased to exist vendor-side in the Manus platform reboot the same day its decommission was executed. Its n8n API key "manus API" (`MYYZFn3DjtKQ43i4`) was revoked 2026-09-08 (verified: row deleted, the four other keys intact, qclaw's key live-tested after). The Gmail app password "n8n dashboard email" (created 2026-03-16) was revoked by Tyson around the time decommissioning was first being discussed (late August 2026; exact date not recorded), confirmed absent from the Google account 2026-09-08. The revocation went unrecorded at the time, so this entry carried the password as live for roughly two weeks after it was destroyed; see the build log for the rule that fell out. Code record survives at `github.com/tysonven/n8n-health-dashboard` (private). Replaced by the heartbeat-based Telegram alerter (Slice 3h). Standing rule from this incident stays: platform-hosted builder workspaces (Manus and similar) get a LOCATIONS.md entry at creation, not at first commit; estate recon cannot enumerate them later.
 ## CI and deploy gating (all six repos)
 
 State as of 2026-09-08. Before the CI/CD rollout, 670 tests existed across five
@@ -544,9 +544,9 @@ without an entry here is the failure mode this log exists to catch.
   rollback note (the Manus deployment it pointed at ceased to exist
   vendor-side in a platform reboot the same day), rewrote the n8n Health
   Dashboard entry as gone, and removed the revoked `manus API` row from the
-  n8n key table. The Gmail app password planned for revocation was found
-  already absent from the Google account (timing and cause unknown), and is
-  recorded that way in the dashboard entry rather than as revoked.
+  n8n key table. The Gmail app password planned for revocation turned out to
+  have been revoked by Tyson weeks earlier without the act being recorded;
+  the dashboard entry now says so, dated approximately.
 - **2026-08-20** Documented **Call Intel** (`tysonven/call-intel`) under
   standalone applications. It had never appeared in this file at all. Vercel
   serverless, and the one standalone app that does **not** have its own

--- a/LOCATIONS.md
+++ b/LOCATIONS.md
@@ -122,7 +122,7 @@ files and are still mutable via the dashboard. Reconciliation TBD.
   - **Key duplication is intentional, not drift.** `POLYMARKET_PRIVATE_KEY` and `POLYMARKET_FUNDER_ADDRESS` remain in qclaw's `.env` because `src/trade_engine/config.py` hard-requires them in `REQUIRED_KEYS` and `src/trading/get_balance.py` uses them. Removing the qclaw copy is deferred to Slice 6. **Rotating the Polymarket key therefore means rotating both hosts**, and qclaw alone is not enough.
   - Not decommission-pending: this host is load-bearing for as long as trading runs from a geoblocked region. It appears in no CI config and in no repo sweep, which is how it stayed undocumented until the 2026-08-19 audit.
 
-- n8n Health Dashboard (email alerter): runs in a Manus GCP workspace (external platform, unaudited runtime); code exported 2026-08-18 to `github.com/tysonven/n8n-health-dashboard` (private). Sends "n8n Alert" emails via Gmail app password "n8n dashboard email" (created 2026-03-16, Manus-side env only); polls the n8n REST API every 5 min with the dedicated unscoped key "manus API" (`MYYZFn3DjtKQ43i4`). **DECOMMISSION-PENDING**: revoke the app password and the API key only after the heartbeat-based Telegram alerter is live and proven. Standing rule from this incident: platform-hosted builder workspaces (Manus and similar) get a LOCATIONS.md entry at creation, not at first commit; estate recon cannot enumerate them later.
+- n8n Health Dashboard (email alerter): **GONE, 2026-09-08.** Ran in a Manus GCP workspace; the workspace ceased to exist vendor-side in the Manus platform reboot the same day its decommission was executed. Its n8n API key "manus API" (`MYYZFn3DjtKQ43i4`) was revoked 2026-09-08 (verified: row deleted, the four other keys intact, qclaw's key live-tested after). The Gmail app password "n8n dashboard email" (created 2026-03-16) is still owed a revocation, Tyson-side, in the Google account. Code record survives at `github.com/tysonven/n8n-health-dashboard` (private). Replaced by the heartbeat-based Telegram alerter (Slice 3h). Standing rule from this incident stays: platform-hosted builder workspaces (Manus and similar) get a LOCATIONS.md entry at creation, not at first commit; estate recon cannot enumerate them later.
 ## CI and deploy gating (all six repos)
 
 State as of 2026-09-08. Before the CI/CD rollout, 670 tests existed across five
@@ -383,8 +383,10 @@ a database is on the qclaw droplet just because the product is Flow OS.
     rebuild, not just a variable edit
   - GHL: posts to two Flow OS sub-account (2NszMTudEJyVXCzQjNTo)
     workflow webhooks (lead + day progress). Touches NO n8n workflow
-  - Rollback: restore the Cloudflare CNAME for `flowcoach` to
-    `cname.manus.space` (Manus deployment retained until decommission)
+  - Rollback: none, and none possible. The Manus deployment held as the DNS
+    rollback target ceased to exist vendor-side on 2026-09-08 (platform
+    reboot, all user data deleted). Webhook URLs rotated and the old ones
+    proven dead the same day; see the build log entry.
 
 ## Secrets and credentials
 
@@ -502,7 +504,6 @@ n8n Postgres `user_api_keys` on `157.230.216.158`
 
 | Key | Purpose |
 |---|---|
-| `manus API` | Unscoped key polled every 5 min by the Manus-hosted n8n Health Dashboard. **DECOMMISSION-PENDING**: revoke once the heartbeat Telegram alerter is proven. Created 2026-03-16. |
 | `MCP Server API Key` | [needs Tyson input]. Created 2026-01-02. |
 | `n8n mcp` | [needs Tyson input]. Created 2025-07-15, the oldest key in the store. |
 | `n8n query key v2` | [needs Tyson input]. Created 2026-04-20. |
@@ -539,6 +540,12 @@ When migrating any location (e.g. file-based log → Supabase table):
 Append-only record of what changed in this file and why. A location that moved
 without an entry here is the failure mode this log exists to catch.
 
+- **2026-09-08** Manus decommission executed: removed the flow-coach-ai DNS
+  rollback note (the Manus deployment it pointed at ceased to exist
+  vendor-side in a platform reboot the same day), rewrote the n8n Health
+  Dashboard entry as gone, and removed the revoked `manus API` row from the
+  n8n key table. The Gmail app password revocation is recorded in the
+  dashboard entry as still owed.
 - **2026-08-20** Documented **Call Intel** (`tysonven/call-intel`) under
   standalone applications. It had never appeared in this file at all. Vercel
   serverless, and the one standalone app that does **not** have its own

--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -26265,3 +26265,84 @@ somewhere is not reviewing.
 Fixed by putting the evidence base in the PR body, including the caveat the
 original entry attached to it: treat 0.07 as a monitored hypothesis with a
 residual check, not a constant.
+## 2026-09-08: Manus decommission, P1-1 closed by proof, and the vendor closed step 3 for us
+
+The 2026-08-19 audit's P1-1: both GHL webhook capability URLs sat in
+flow-coach-ai's git history from commits 117b161 and 709a263 until 3d791eb,
+authored on and by Manus, giving anyone with repo history read access
+unauthenticated write access to the Flow OS contact store. Rotation was
+deferred to decommission deliberately, so the DNS rollback path kept working
+webhooks. That reasoning expired when the rollback window closed, and this
+entry records the closure actually happening rather than being declared.
+
+**The rotation, proven from both sides.** Both triggers regenerated in the
+GHL builder, new URLs pasted into Railway only (fingerprints
+33f8460b to dbb2288f lead, f92d03a7 to 3153e64c day-progress). Positive
+control ran through the LIVE app path, not a simulation of it:
+leads.register on flowcoach.flowos.tech created the GHL contact 12 seconds
+later, and chat.trackDay put tag flow-coach-day-1 plus four custom fields
+(day, event, day_label "Day 1 - Find the Leaks", source) on that contact, a
+concrete diff. Negative control: the exact app payloads POSTed to both OLD
+URLs with a dedicated marker identity, then the CRM swept settled minutes
+later. Zero contacts. All test contacts and the test lead row deleted after;
+the store ended the day byte-identical in count to where it started.
+
+**THE RULE, because the observation is not enough: a 200 from a GHL
+capability URL proves nothing. Re-verification of a rotation must check the
+response body and the CRM, not the status code.** The old URLs did not go
+non-2xx after regeneration, and the criterion "old URLs must return non-2xx"
+was simply wrong. A dead trigger URL answers:
+
+```
+200 {"status":"Success: test request received"}
+```
+
+while a live one answers:
+
+```
+200 {"status":"Success: request sent to trigger execution server","id":"..."}
+```
+
+Same status code, opposite meanings, distinguished only by body and by
+whether a contact exists afterwards. Anyone re-verifying this rotation, or
+performing the next one, who checks only the status code will conclude the
+leaked URLs still work when they do not, or that a rotation succeeded when
+it did not. Same family as the vacuity variants this log keeps collecting:
+a green signal that does not assert the thing it appears to assert, this
+time issued by a third party's API rather than our own tests. A related
+trap in the same session: GHL contact search lags creation by a minute or
+two, so a zero-match immediately after a POST proves nothing either;
+absence claims must be asserted settled.
+
+**The rotation-day leak, recorded because P1-1 is exactly this class.** The
+first regenerated lead URL was pasted into a Claude chat by mistake. Not
+git, but a third place a third party holds, which is precisely what P1-1 is
+about. Handled correctly: both triggers regenerated a second time, burning
+the pasted URL the same way the git-history ones were burned, and the final
+URLs went into Railway without transiting the chat. Capability URLs are
+unredactable once they leave your hands; the only fix is to make the leaked
+value worthless.
+
+**The key revocation, fingerprinted first.** The n8n key labelled
+"manus API" (id MYYZFn3DjtKQ43i4, created 2026-03-16) was deleted from
+user_api_keys with a RETURNING clause proving it was that row and only that
+row, but only after sha256 fingerprints proved it was NOT the key qclaw
+runs on (that is "quantum claw api v2", a different fingerprint), and after
+reading the exported dashboard code to confirm a revoked key produces
+silence, not false alert emails (runAlertCheck throws on the first 401
+before any email logic). qclaw's key was live-tested 200 after the delete.
+
+**Step 3 closed itself, dishonorably.** The plan said "retire the Manus
+project". There was nothing left to retire: Manus rebooted its platform,
+deleted user data, and now presents a restore-by-upload screen. Recorded
+honestly as "asset ceased to exist vendor-side" rather than as a completed
+retirement. The rollback path deliberately preserved for three weeks was
+destroyed by the vendor without notice, which is its own argument that
+migrating off the platform was the right call, and a second argument for
+the standing rule that platform-hosted workspaces get documented at
+creation: an estate you cannot enumerate is also an estate that can vanish
+without you noticing.
+
+Still owed: the Gmail app password "n8n dashboard email" revocation
+(Tyson-side, Google account); tracked in FLOW_OS_STATE.md and the
+LOCATIONS.md dashboard entry.

--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -26265,6 +26265,7 @@ somewhere is not reviewing.
 Fixed by putting the evidence base in the PR body, including the caveat the
 original entry attached to it: treat 0.07 as a monitored hypothesis with a
 residual check, not a constant.
+
 ## 2026-09-08: Manus decommission, P1-1 closed by proof, and the vendor closed step 3 for us
 
 The 2026-08-19 audit's P1-1: both GHL webhook capability URLs sat in
@@ -26346,17 +26347,25 @@ without you noticing.
 **The last credential was already gone, and the record did not know.** The
 plan's final item, revoking the Gmail app password "n8n dashboard email"
 (created 2026-03-16), ended with Google's app-passwords page showing no app
-passwords at all. When or by what it went is unknown; Google deletes app
-passwords silently on certain account events, such as a password change, so
-absence of a deliberate revocation act is unsurprising. It is recorded as
-FOUND ABSENT, not revoked, because claiming a revocation nobody performed
-would be inventing an event. The instructive part: LOCATIONS.md carried
-"created 2026-03-16, Manus-side env only" as a live credential for however
-long the password has actually been gone. That is a record standing in for
-a state, the same family this log has been collecting all week, this time
-in our own canonical docs rather than in a check. Docs that describe
-credentials are checks that never re-run; the generated-inventory rule from
-2026-08-20 exists for exactly this reason, and this entry extends it: a
-credential entry that cannot be re-verified against the issuer is a claim
-with no expiry, and should be dated as an observation, never stated as a
-standing fact.
+passwords at all. Tyson had revoked it himself around the time
+decommissioning was first being discussed (after the 2026-08-19 exit plan
+raised it; the exact date was not recorded), and the action never reached
+the docs. So LOCATIONS.md carried the password as a live credential for
+roughly two weeks after its owner destroyed it, and the decommission
+checklist kept owing a revocation that had already been performed. A record
+standing in for a state, the same family this log has been collecting all
+week, this time in our own canonical docs rather than in a check.
+
+The correction itself then demonstrated the family twice. The first fix
+recorded the password as "found absent, cause unknown, Google deletes these
+silently on some account events": a plausible mechanism reasoned from the
+absence, stating a mystery where there had been a deliberate action, wrong
+in exactly the way the entry it was correcting was wrong. Two rules come
+out, one per failure. For actions: an out-of-band credential change that is
+not written down at the time it is made will be discovered as a
+contradiction later, so record the act when performed, even one line. For
+observations: docs that describe credentials are checks that never re-run;
+a credential entry that cannot be re-verified against the issuer is a claim
+with no expiry, so date it as an observation, never state it as a standing
+fact, and when the cause of a state is not known, say "not recorded" rather
+than reaching for the most available explanation.

--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -26343,6 +26343,20 @@ the standing rule that platform-hosted workspaces get documented at
 creation: an estate you cannot enumerate is also an estate that can vanish
 without you noticing.
 
-Still owed: the Gmail app password "n8n dashboard email" revocation
-(Tyson-side, Google account); tracked in FLOW_OS_STATE.md and the
-LOCATIONS.md dashboard entry.
+**The last credential was already gone, and the record did not know.** The
+plan's final item, revoking the Gmail app password "n8n dashboard email"
+(created 2026-03-16), ended with Google's app-passwords page showing no app
+passwords at all. When or by what it went is unknown; Google deletes app
+passwords silently on certain account events, such as a password change, so
+absence of a deliberate revocation act is unsurprising. It is recorded as
+FOUND ABSENT, not revoked, because claiming a revocation nobody performed
+would be inventing an event. The instructive part: LOCATIONS.md carried
+"created 2026-03-16, Manus-side env only" as a live credential for however
+long the password has actually been gone. That is a record standing in for
+a state, the same family this log has been collecting all week, this time
+in our own canonical docs rather than in a check. Docs that describe
+credentials are checks that never re-run; the generated-inventory rule from
+2026-08-20 exists for exactly this reason, and this entry extends it: a
+credential entry that cannot be re-verified against the issuer is a claim
+with no expiry, and should be dated as an observation, never stated as a
+standing fact.


### PR DESCRIPTION
Step 4 of the decommission checklist. Everything here records what was executed and proven earlier today, plus the ending nobody planned.

**LOCATIONS.md**: the flow-coach-ai rollback note is gone (the deployment it pointed at no longer exists vendor-side); the n8n Health Dashboard entry is rewritten as GONE with the key-revocation evidence and the still-owed Gmail app password; the revoked `manus API` row is removed from the n8n key table; maintenance log entry added.

**FLOW_OS_STATE.md**: status and history record the decommission completing 2026-09-08 with P1-1 closed, and step 3 recorded honestly as 'asset ceased to exist vendor-side' (Manus platform reboot deleted user data) rather than as a retirement. Also retires two stale entries this week made false: 'no CI / manual railway up' (CI plus branch protection exist since 2026-09-08, Railway auto-deploys main; the browser-tier gap stays) and '43 advisories' (0 as of 2026-09-08 via repo PR #17, deployed at baa7908).

**QCLAW_BUILD_LOG.md**: the full entry. The load-bearing part is the corrected verification rule, stated as a rule per Tyson: **a 200 from a GHL capability URL proves nothing; re-verification must check the response body and the CRM, not the status code.** Dead and live triggers both answer 200, distinguished only by body ('test request received' vs 'request sent to trigger execution server' plus id) and by contact presence. The entry also records the rotation-day chat-paste of an interim URL (burned by a second regeneration), the contact-search-lag trap, the fingerprint discipline on the key revocation, and the vendor destroying the three-week-preserved rollback path without notice.

Docs only. Not merged by me.