### PR TITLE
feat(sizing): fractional Kelly pricing kernel, fee-aware, pure

### DIFF
--- a/src/trade_engine/sizing.py
+++ b/src/trade_engine/sizing.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Fractional-Kelly position sizing, fee-aware, and the exchange minimum.
+
+Pure. No network, no config import, no logging. Everything is passed in, so the
+arithmetic can be tested directly and so the scanner and executor GATE 8 can run
+the SAME function against different inputs, the way horizon.py serves the
+scanner and GATE 7.
+
+WHAT REPLACED WHAT
+------------------
+Until 2026-09-08 size was a linear ramp on edge: $3 at a 7-point edge rising to
+$10 at 15 points, floored at $3. It had no relationship to bankroll, to the
+probability estimate's confidence, or to what the trade could lose. It also
+sized the NOTIONAL while the wallet is debited notional PLUS fee, so every
+position quietly overspent its own ceiling.
+
+THE THREE THINGS THIS GETS RIGHT
+--------------------------------
+1. Kelly, fractionally. For a binary contract bought at `side_price` with true
+   probability `true_prob`, the full-Kelly fraction of bankroll is
+   (true_prob - side_price) / (1 - side_price). KELLY_FRACTION scales it down.
+   Kelly ONLY sizes down from the configured maximum; it can never size up.
+
+2. The fee. fee = 0.07 * price * (1 - price) * shares, equivalently
+   fee / notional = 0.07 * (1 - price). Verified against the 2026-08-20 receipt:
+   10.501189 debited against 10.00 notional at price 0.284 is a ratio of
+   1.05012, against a predicted 1 + 0.07 * 0.716 = 1.05012. So sizing to a cap
+   means notional = cap / (1 + 0.07 * (1 - price)), and the CAP IS THE DEBIT.
+
+3. The exchange minimum, which is in SHARES and is the reason most trades will
+   now be refused rather than resized. See the module note below.
+
+WHY ALMOST NOTHING WILL TRADE, AND WHY THAT IS CORRECT
+------------------------------------------------------
+Polymarket enforces a per-market minimum order size in SHARES (`orderMinSize`,
+5 on every market sampled 2026-09-08), server-side:
+
+    order 0x... is invalid. Size (1.08) lower than the minimum: 5
+
+Ignoring the fee term, clearing that minimum requires
+
+    shares = KELLY_FRACTION * bankroll * edge / (price * (1 - price)) >= 5
+    i.e.    edge >= 2 * price * (1 - price)        at KELLY_FRACTION * bankroll = 2.5
+
+Two consequences, and the second is the one that surprises.
+
+FIRST. At the 7-point edge floor the condition needs price * (1 - price) <= 0.035.
+That inequality has TWO roots, and both are stated here deliberately, because an
+earlier version of this derivation reported only one of them and the other is
+where an error lived:
+
+    price <= 0.036319    excluded by the 0.10 sizing price floor
+    price >= 0.963681    excluded for a DIFFERENT reason, see below
+
+The upper root is not a feasible region. At price 0.963681 the largest edge that
+can exist is 1 - price = 0.036319, so an edge of 0.07 is unreachable there: the
+root solves the inequality while violating the constraint edge <= 1 - price. An
+earlier audit reported that root as the surviving region. It is the opposite.
+Nothing sized at the minimum qualifying edge can be placed at any price.
+
+SECOND. Edge can never exceed (1 - price), since that is the whole payoff.
+Requiring edge >= 2 * price * (1 - price) therefore requires 2 * price <= 1, so
+ABOVE PRICE 0.5 THE MINIMUM IS UNREACHABLE AT ANY EDGE, INCLUDING CERTAINTY.
+Deep favourites are the region that is arithmetically impossible, not the region
+that survives.
+
+The exact cut is 0.482521, not 0.5. 0.5 is the FEE-FREE answer; including the
+fee the condition is
+
+    2 * price * (1 + 0.07 * (1 - price)) <= 1
+    0.14 * price^2 - 2.14 * price + 1 >= 0
+    price <= 0.482521
+
+Both numbers are correct for their own model and they are not interchangeable.
+The code is fee-aware, so 0.482521 is the one that describes it, and it is the
+only one quoted elsewhere.
+
+What survives is a narrow band: price in [0.10, 0.482521] with a very large
+edge. The minimum simulated probability that clears 5 shares, from this
+implementation:
+
+    price   0.10   0.15   0.20   0.25   0.30   0.35   0.40   0.45   0.4825
+    p_min   0.291  0.420  0.538  0.645  0.741  0.826  0.900  0.964  1.000
+
+For comparison, the largest edge in the four historical positions was 0.336 at
+price 0.279, which needed 0.4226. (An earlier version of this docstring said
+0.395. That number is wrong and is reproducible by no formula here; it appears
+to be a transcription of min_notional = 5 * 0.279 = 1.395.)
+
+That is arithmetic, not a tuning error. At a $25 bankroll the exchange's share
+granularity is coarser than the entire Kelly budget. NEVER "fix" this by raising
+bankroll_usdc: that number came from $29.24 of MEASURED spendable collateral,
+and raising it to the ~$180 that would make Kelly and the exchange compatible at
+mid prices would size against money that does not exist, which is exactly what
+turns Kelly from conservative into dangerous. Making that work is a CAPITAL
+decision, a deposit of about $155, not a config edit.
+
+A system that sizes correctly and therefore almost never trades is behaving
+properly. The model was 7x wrong six weeks ago. Suppression is the discipline
+working, and every refusal is logged with its numbers so the suppression rate
+becomes data for the capital decision rather than a guess.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import NamedTuple, Optional
+
+# Polymarket's taker fee coefficient. fee = FEE_RATE * p * (1-p) * shares.
+# One fee mechanism, not two (build log 2026-09-05). Verified to 4dp against a
+# real settlement receipt; see the module docstring.
+FEE_RATE = 0.07
+
+
+class PositionSizing(NamedTuple):
+    """A sizing decision, with everything needed to log why.
+
+    `tradeable` is the only field callers should branch on. The rest exists so a
+    refusal can be recorded with its arithmetic rather than as a bare reason
+    string: the whole point of (c) is to measure how often, and at what prices,
+    correct sizing lands under the exchange floor.
+    """
+
+    tradeable: bool
+    refusal: Optional[str]
+    notional: float           # what the relay is told to spend (amount_usdc)
+    debit: float              # what actually leaves the wallet, notional + fee
+    shares: float             # notional / side_price
+    required_shares: float    # the exchange's orderMinSize for this market
+    side_price: float         # price of the side being bought
+    edge: float               # true_prob - side_price, for the side being bought
+    kelly_fraction: float     # fraction of bankroll after KELLY_FRACTION scaling
+    kelly_debit: float        # debit Kelly asked for, before any clamp
+    clamped_by: Optional[str] # set when the hard ceiling bound the size down
+    min_notional: float       # required_shares * side_price
+    min_debit: float          # the same, including fee
+
+    def log_fields(self) -> str:
+        """One line carrying every number a later capital decision needs."""
+        # sized_notional, not "kelly_notional": this is the figure AFTER any
+        # clamp, and the pre-clamp Kelly ask is kelly_debit. The two differ
+        # whenever clamped_by is set, and the old label named the wrong one.
+        return (
+            f"price={self.side_price:.4f} edge={self.edge:+.4f} "
+            f"kelly_f={self.kelly_fraction:.5f} kelly_debit={self.kelly_debit:.4f} "
+            f"sized_notional={self.notional:.4f} debit={self.debit:.4f} "
+            f"shares={self.shares:.4f} required_shares={self.required_shares:.4f} "
+            f"min_notional={self.min_notional:.4f} min_debit={self.min_debit:.4f} "
+            f"clamped_by={self.clamped_by or 'none'}"
+        )
+
+
+def _refused(reason: str, **kw) -> PositionSizing:
+    base = dict(
+        tradeable=False, refusal=reason, notional=0.0, debit=0.0, shares=0.0,
+        required_shares=0.0, side_price=0.0, edge=0.0, kelly_fraction=0.0,
+        kelly_debit=0.0, clamped_by=None, min_notional=0.0, min_debit=0.0,
+    )
+    base.update(kw)
+    return PositionSizing(**base)
+
+
+def fee_ratio(side_price: float) -> float:
+    """fee / notional for a market bought at `side_price`.
+
+    Depends only on price, which is why MAX_CASH_OUT_NOTIONAL_FACTOR can be
+    computed per trade instead of held at a flat worst-case constant.
+    """
+    return FEE_RATE * (1.0 - side_price)
+
+
+def side_price_for(direction: str, yes_price: float) -> float:
+    """Price of the side actually being bought.
+
+    The old sizing used abs(edge) and apologised for it in a docstring. Buying
+    NO at (1 - yes_price) with true probability (1 - p) is the same Kelly
+    problem with both terms complemented, so sizing it correctly costs one line
+    and removes the hack. best_trade only ever comes from the high-edge bucket
+    today, so the NO branch is unreachable from the scanner; it is correct
+    rather than dead because nothing should have to remember that.
+    """
+    return yes_price if str(direction).upper() == "YES" else 1.0 - yes_price
+
+
+def size_position(
+    *,
+    sim_probability: float,
+    yes_price: float,
+    direction: str,
+    min_order_size: Optional[float],
+    bankroll: float,
+    kelly_fraction: float,
+    max_position_usdc: float,
+    price_floor: float,
+    absolute_max_usdc: Optional[float] = None,
+) -> PositionSizing:
+    """Size one trade, or refuse it with a reason.
+
+    `min_order_size` is the market's own `orderMinSize`, read live rather than
+    hardcoded: it is a remote value and baking in a copy is the manual-allowlist
+    pattern this codebase has been bitten by repeatedly. None means it could not
+    be read, and that FAILS CLOSED.
+
+    `max_position_usdc` bounds the DEBIT, not the notional. It sits ABOVE Kelly
+    and only ever binds downward; when it binds, `clamped_by` records it.
+    """
+    # Inputs first, so a refusal never carries arithmetic derived from garbage.
+    for name, value in (("sim_probability", sim_probability), ("yes_price", yes_price)):
+        if value is None or not isinstance(value, (int, float)) or isinstance(value, bool) \
+                or not math.isfinite(float(value)):
+            return _refused("invalid_input")
+    if not 0.0 < float(yes_price) < 1.0:
+        return _refused("invalid_price")
+    # A PROBABILITY, so range-checked and not merely finite. The whole
+    # "impossible above price 0.5" result rests on edge <= 1 - price, which
+    # rests on p <= 1; nothing upstream enforced it and the Monte Carlo worker
+    # is a remote HTTP service with no asserted response schema. Measured before
+    # this check existed: p = 1.05 at price 0.98 returned a TRADEABLE $8.74
+    # notional, inside the region this module calls arithmetically impossible.
+    # The old linear ramp clamped every input to $10 no matter what; Kelly is
+    # linear in the edge, so the same unit slip now runs to the ceiling.
+    if not 0.0 <= float(sim_probability) <= 1.0:
+        return _refused("invalid_probability")
+    if min_order_size is None or not math.isfinite(float(min_order_size)) \
+            or float(min_order_size) <= 0:
+        # Fail closed. An unknown exchange minimum is refused, never assumed to
+        # be 5, and never assumed to be satisfied.
+        return _refused("unknown_min_order_size")
+    if not math.isfinite(float(bankroll)) or bankroll <= 0:
+        return _refused("invalid_bankroll")
+    # A negative fraction produced a NEGATIVE notional refused as
+    # "below_exchange_minimum", which is the wrong diagnosis in the refusal logs
+    # decision (c) is meant to be mined from. GATE 5 caught the negative amount,
+    # so it was fail-closed and mislabelled rather than dangerous.
+    if not math.isfinite(float(kelly_fraction)) or kelly_fraction <= 0:
+        return _refused("invalid_kelly_fraction")
+
+    price = side_price_for(direction, float(yes_price))
+    true_prob = float(sim_probability) if str(direction).upper() == "YES" \
+        else 1.0 - float(sim_probability)
+    edge = true_prob - price
+    required = float(min_order_size)
+    min_notional = required * price
+    min_debit = min_notional * (1.0 + fee_ratio(price))
+
+    common = dict(
+        side_price=price, edge=edge, required_shares=required,
+        min_notional=min_notional, min_debit=min_debit,
+    )
+
+    # The sizing price floor is a PROPOSAL filter and is deliberately separate
+    # from YES_PRICE_MIN, which governs inclusion. Sub-floor markets are still
+    # scanned, simulated and reported; they are just never sized or proposed,
+    # which keeps the question answerable from data later.
+    if price < price_floor:
+        return _refused("price_below_sizing_floor", **common)
+
+    if edge <= 0:
+        # Kelly says do not bet. Not an error; the no-edge bucket lands here.
+        return _refused("no_positive_edge", **common)
+
+    full_kelly = edge / (1.0 - price)
+    fraction = kelly_fraction * full_kelly
+    kelly_debit = fraction * bankroll
+
+    # Size against the ceiling the executor actually ENFORCES FIRST. GATE 5
+    # checks trading_config.max_position_usdc (live value 10) before the hard
+    # ABSOLUTE_MAX_POSITION_USDC (25), so sizing against 25 could propose a $12
+    # position, show that number to a human, and have GATE 5 refuse it after
+    # approval. Same class as the approval-path guard: never put a figure in
+    # front of someone that the system will not honour.
+    ceiling = max_position_usdc
+    ceiling_name = "max_position_usdc"
+    if absolute_max_usdc is not None and absolute_max_usdc < ceiling:
+        ceiling, ceiling_name = absolute_max_usdc, "absolute_max_position_usdc"
+
+    cap = kelly_debit
+    clamped_by = None
+    if cap > ceiling:
+        cap = ceiling
+        clamped_by = ceiling_name
+
+    # Size on the DEBIT: the wallet pays notional + fee, so solve for the
+    # notional whose debit equals the cap.
+    #
+    # Round FIRST, then derive shares and debit from the rounded figure. The
+    # rounded notional is what is actually sent to the relay, so it is what the
+    # exchange divides by price to get the order size; deriving shares from the
+    # unrounded value would mean the share count checked against the minimum is
+    # not the share count the exchange computes. At the boundary that is the
+    # difference between a refusal and a rejected order.
+    notional = round(cap / (1.0 + fee_ratio(price)), 6)
+    shares = notional / price
+    debit = notional * (1.0 + fee_ratio(price))
+
+    sized = dict(
+        common, notional=notional, debit=round(debit, 6),
+        shares=shares, kelly_fraction=fraction, kelly_debit=kelly_debit,
+        clamped_by=clamped_by,
+    )
+
+    # STRICTLY less than. Exactly the minimum is ADMITTED, matching GATE 8's
+    # comparison; the two must agree or a trade the scanner sizes is refused at
+    # execution for a reason the scanner did not anticipate. Mutants moving this
+    # boundary either way, including admitting 1% under, survived the suite
+    # until it was pinned on both sides.
+    if shares < required:
+        # NEVER round up to reach the minimum. Rounding up would abandon the
+        # only property Kelly provides, which is that the stake is proportional
+        # to the edge; a stake raised to clear an exchange floor is a stake
+        # chosen by the exchange.
+        return PositionSizing(tradeable=False, refusal="below_exchange_minimum", **sized)
+
+    return PositionSizing(tradeable=True, refusal=None, **sized)

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -1,0 +1,439 @@
+"""Tests for fractional-Kelly position sizing (src/trade_engine/sizing.py).
+
+sizing.py imports nothing but the stdlib, so these need no env, no config, no
+network and no numpy. That is deliberate and is the same reason horizon.py and
+simulation.py were split out: the arithmetic that decides how much money leaves
+the wallet has to be testable on its own.
+
+The historical positions here are the four from
+docs/trade-engine-horizon-rebaseline.md, at their re-baselined probabilities.
+
+Run:
+    python3 -m unittest tests.test_sizing
+"""
+
+import math
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.trade_engine.sizing import (  # noqa: E402
+    FEE_RATE,
+    fee_ratio,
+    side_price_for,
+    size_position,
+)
+
+# The shipped configuration.
+LIVE = dict(bankroll=25.0, kelly_fraction=0.10, max_position_usdc=25.0,
+            price_floor=0.10)
+MIN_SHARES = 5.0
+
+# position, simulated p, market YES price
+HISTORICAL = [
+    ("cee4eacd XRP", 0.9863, 0.925),
+    ("71f8a608 BTC", 0.5459, 0.415),
+    ("f4be9ee8 ETH", 0.6149, 0.279),
+    ("b3cecdef SOL", 0.7062, 0.396),
+]
+
+
+def size(p, price, direction="YES", minimum=MIN_SHARES, **over):
+    kw = dict(LIVE)
+    kw.update(over)
+    return size_position(
+        sim_probability=p, yes_price=price, direction=direction,
+        min_order_size=minimum, **kw,
+    )
+
+
+class KellyArithmeticTest(unittest.TestCase):
+    """The formula, against a closed form computed independently here."""
+
+    def test_fraction_matches_the_closed_form(self):
+        for p, price in ((0.60, 0.40), (0.30, 0.20), (0.99, 0.90), (0.52, 0.50)):
+            with self.subTest(p=p, price=price):
+                s = size(p, price)
+                expected = LIVE["kelly_fraction"] * (p - price) / (1 - price)
+                self.assertAlmostEqual(s.kelly_fraction, expected, places=12)
+
+    def test_zero_edge_is_a_refusal_not_a_zero_bet(self):
+        s = size(0.40, 0.40)
+        self.assertFalse(s.tradeable)
+        self.assertEqual(s.refusal, "no_positive_edge")
+
+    def test_certainty_gives_the_whole_kelly_fraction(self):
+        """At p=1 the full-Kelly fraction is 1, so the stake is exactly
+        KELLY_FRACTION of bankroll: $2.50. This is the ceiling on any position
+        at this bankroll, and it is what makes the exchange minimum binding."""
+        s = size(1.0, 0.50)
+        self.assertAlmostEqual(s.kelly_debit, 2.50, places=9)
+
+    def test_edge_scales_the_stake_monotonically(self):
+        previous = 0.0
+        for p in (0.45, 0.50, 0.60, 0.80, 0.99):
+            s = size(p, 0.40)
+            self.assertGreater(s.notional, previous)
+            previous = s.notional
+
+
+class FeeAwareTest(unittest.TestCase):
+    """The cap is the DEBIT, not the notional."""
+
+    def test_fee_ratio_matches_the_verified_receipt(self):
+        """10.501189 debited against 10.00 notional at price 0.284."""
+        self.assertAlmostEqual(1 + fee_ratio(0.284), 10.501189 / 10.0, places=4)
+
+    def test_debit_equals_the_cap_and_notional_is_below_it(self):
+        s = size(1.0, 0.50)  # kelly_debit is the binding cap here
+        self.assertAlmostEqual(s.debit, s.kelly_debit, places=9)
+        self.assertLess(s.notional, s.debit, "the fee is charged on top")
+
+    def test_sizing_the_notional_to_the_cap_would_overspend(self):
+        """What the old code did, stated as a number.
+
+        Sizing the notional to the cap makes the wallet pay cap * (1 + fee),
+        which at price 0.10 is 6.3% more than intended, every single trade.
+        """
+        s = size(1.0, 0.10)
+        naive_debit = s.kelly_debit * (1 + fee_ratio(0.10))
+        self.assertGreater(naive_debit - s.kelly_debit, 0.15)
+        self.assertAlmostEqual(s.debit, s.kelly_debit, places=9)
+
+    def test_shares_are_derived_from_the_notional_actually_sent(self):
+        """Not from an unrounded intermediate.
+
+        The relay is sent the ROUNDED notional, and the exchange divides that by
+        price to get the order size. Deriving shares from anything else means
+        the count checked against the minimum is not the count the exchange
+        computes, which at the boundary is the difference between a clean
+        refusal and a rejected order.
+        """
+        for p_true, price in ((0.90, 0.20), (0.35, 0.10), (0.60, 0.40)):
+            with self.subTest(price=price):
+                s = size(p_true, price)
+                self.assertEqual(s.notional, round(s.notional, 6))
+                self.assertAlmostEqual(s.shares, s.notional / price, places=12)
+                self.assertEqual(
+                    s.debit, round(s.notional * (1 + fee_ratio(price)), 6),
+                    "debit must follow the rounded notional, not an intermediate",
+                )
+
+
+class CeilingTest(unittest.TestCase):
+    """Kelly only ever sizes DOWN. The ceiling sits above it."""
+
+    def test_ceiling_binds_and_is_recorded(self):
+        s = size(1.0, 0.50, bankroll=10_000.0)
+        self.assertEqual(s.clamped_by, "max_position_usdc")
+        self.assertAlmostEqual(s.debit, LIVE["max_position_usdc"], places=9)
+
+    def test_ceiling_does_not_bind_at_the_live_bankroll(self):
+        """At $25 and a tenth of Kelly the largest possible stake is $2.50, so
+        the ceiling can never bind. It still has to exist: bankroll is config."""
+        for p, price in ((1.0, 0.10), (1.0, 0.50), (0.99, 0.30)):
+            with self.subTest(p=p, price=price):
+                self.assertIsNone(size(p, price).clamped_by)
+
+    def test_the_ceiling_never_raises_a_small_kelly(self):
+        s = size(0.50, 0.415)
+        self.assertLess(s.debit, LIVE["max_position_usdc"])
+        self.assertIsNone(s.clamped_by)
+
+
+class ExchangeMinimumTest(unittest.TestCase):
+    """The finding that reshaped this change."""
+
+    def test_every_historical_position_is_refused(self):
+        """Correct sizing puts all four under the 5-share floor.
+
+        Not a regression. These are the trades the old ramp sized at $10 each.
+        """
+        for name, p, price in HISTORICAL:
+            with self.subTest(position=name):
+                s = size(p, price)
+                self.assertFalse(s.tradeable)
+                self.assertEqual(s.refusal, "below_exchange_minimum")
+                self.assertLess(s.shares, MIN_SHARES)
+
+    def test_refusal_still_carries_the_arithmetic(self):
+        """A refusal is a measurement. Item (c) needs these numbers."""
+        s = size(0.6149, 0.279)
+        self.assertFalse(s.tradeable)
+        for field in ("price=", "edge=", "shares=", "required_shares=",
+                      "min_notional=", "sized_notional=", "kelly_debit=",
+                      "clamped_by="):
+            self.assertIn(field, s.log_fields())
+        self.assertGreater(s.notional, 0, "the computed size is still reported")
+
+    def test_the_log_does_not_call_the_sized_notional_a_kelly_notional(self):
+        """The label used to name the wrong quantity.
+
+        kelly_debit is the PRE-clamp ask; the sized notional is what survives
+        any clamp. They differ whenever clamped_by is set, and a log that calls
+        one by the other's name misreports exactly the case worth reading.
+        """
+        s = size(1.0, 0.50, bankroll=10_000.0)
+        self.assertEqual(s.clamped_by, "max_position_usdc")
+        self.assertNotIn("kelly_notional=", s.log_fields())
+        self.assertIn(f"kelly_debit={s.kelly_debit:.4f}", s.log_fields())
+        self.assertIn("clamped_by=max_position_usdc", s.log_fields())
+        self.assertNotAlmostEqual(s.kelly_debit, s.notional, places=2)
+
+    def test_it_never_rounds_up_to_reach_the_minimum(self):
+        """The one thing that must not happen.
+
+        A stake raised to clear an exchange floor is a stake chosen by the
+        exchange, not by the edge, and it is larger than Kelly says is safe.
+        """
+        s = size(0.6149, 0.279)
+        self.assertLess(s.shares, s.required_shares)
+        self.assertLess(s.notional, s.min_notional)
+
+    def test_above_price_one_half_it_is_impossible_at_any_edge(self):
+        """The correction to the original audit.
+
+        edge can never exceed (1 - price), so requiring edge >= 2*price*(1-price)
+        requires price <= 0.5. Deep favourites are the region that is
+        arithmetically impossible, NOT the region that survives. Checked at
+        p = 1, which is the best case there is.
+        """
+        for price in (0.50, 0.60, 0.75, 0.90, 0.964, 0.99):
+            with self.subTest(price=price):
+                s = size(1.0, price)
+                self.assertFalse(
+                    s.tradeable,
+                    f"price {price} cleared the minimum at certainty: {s.log_fields()}",
+                )
+
+    def test_below_price_one_half_a_large_enough_edge_does_clear(self):
+        """The band that survives is real, just narrow."""
+        for price, p in ((0.10, 0.35), (0.20, 0.60), (0.30, 0.80), (0.40, 0.95)):
+            with self.subTest(price=price, p=p):
+                s = size(p, price)
+                self.assertTrue(s.tradeable, s.log_fields())
+                self.assertGreaterEqual(s.shares, MIN_SHARES)
+
+    def test_the_seven_point_edge_floor_can_never_be_placed(self):
+        """At the minimum qualifying edge nothing is placeable anywhere in the
+        sizeable price range."""
+        for price in (0.10, 0.20, 0.30, 0.40, 0.45):
+            with self.subTest(price=price):
+                self.assertFalse(size(price + 0.07, price).tradeable)
+
+    def test_the_minimum_is_read_not_assumed(self):
+        """A market with a different orderMinSize sizes against ITS value."""
+        generous = size(0.35, 0.10, minimum=1.0)
+        strict = size(0.35, 0.10, minimum=50.0)
+        self.assertTrue(generous.tradeable)
+        self.assertFalse(strict.tradeable)
+        self.assertEqual(strict.required_shares, 50.0)
+
+
+class BoundaryTest(unittest.TestCase):
+    """The comparison against the exchange minimum, pinned on BOTH sides.
+
+    Mutants moving it either way survived the suite: `<=` instead of `<`, and
+    admitting 1% under. Nothing sat at the boundary, and the boundary is the
+    entire question this code exists to answer.
+    """
+
+    def shares_for(self, notional, price):
+        return notional / price
+
+    def test_exactly_the_minimum_is_admitted(self):
+        """5.000000 shares trades. GATE 8 uses the same comparison."""
+        price, minimum = 0.20, 5.0
+        # Choose p so the sized notional lands exactly on 5 shares.
+        target_notional = minimum * price
+        lo, hi = price, 1.0
+        for _ in range(200):
+            mid = (lo + hi) / 2
+            if size(mid, price).notional >= target_notional:
+                hi = mid
+            else:
+                lo = mid
+        s = size(hi, price)
+        self.assertGreaterEqual(s.shares, minimum)
+        self.assertTrue(s.tradeable, s.log_fields())
+
+    def test_a_hair_under_the_minimum_is_refused(self):
+        """Kills `shares <= required` and any epsilon slack."""
+        price, minimum = 0.20, 5.0
+        lo, hi = price, 1.0
+        for _ in range(200):
+            mid = (lo + hi) / 2
+            if size(mid, price).shares >= minimum:
+                hi = mid
+            else:
+                lo = mid
+        just_under = size(lo, price)
+        self.assertLess(just_under.shares, minimum)
+        self.assertFalse(just_under.tradeable, just_under.log_fields())
+        self.assertGreater(just_under.shares, minimum * 0.9999,
+                           "must be a HAIR under, or it proves nothing")
+
+    def test_one_percent_under_is_refused(self):
+        """Kills `shares < required * 0.99`, which survived the whole suite."""
+        for fraction in (0.99, 0.995, 0.999):
+            with self.subTest(fraction=fraction):
+                price, minimum = 0.20, 5.0
+                notional = minimum * fraction * price
+                lo, hi = price, 1.0
+                for _ in range(200):
+                    mid = (lo + hi) / 2
+                    if size(mid, price).notional >= notional:
+                        hi = mid
+                    else:
+                        lo = mid
+                s = size(hi, price)
+                if s.shares < minimum:
+                    self.assertFalse(s.tradeable, s.log_fields())
+
+
+class ProbabilityRangeTest(unittest.TestCase):
+    """The headline result depends on p <= 1, so p is range-checked.
+
+    Measured before this existed: p = 1.05 at price 0.98 returned a TRADEABLE
+    $8.74 notional, inside the region this module calls impossible. The old
+    linear ramp clamped every input to $10; Kelly is linear in the edge, so the
+    same unit slip now runs to the ceiling.
+    """
+
+    def test_a_probability_above_one_is_refused(self):
+        for p in (1.0000001, 1.04, 1.05, 70.0):
+            with self.subTest(p=p):
+                s = size(p, 0.40)
+                self.assertFalse(s.tradeable)
+                self.assertEqual(s.refusal, "invalid_probability")
+
+    def test_it_cannot_reopen_the_impossible_region(self):
+        """The specific measured case."""
+        s = size(1.05, 0.98)
+        self.assertFalse(s.tradeable)
+        self.assertEqual(s.notional, 0.0)
+
+    def test_a_negative_probability_is_refused(self):
+        self.assertEqual(size(-0.1, 0.40).refusal, "invalid_probability")
+
+    def test_the_valid_endpoints_are_still_accepted(self):
+        for p in (0.0, 1.0):
+            with self.subTest(p=p):
+                self.assertNotEqual(size(p, 0.40).refusal, "invalid_probability")
+
+    def test_a_bad_kelly_fraction_is_named_correctly(self):
+        """It used to produce a NEGATIVE notional refused as
+        below_exchange_minimum, mislabelling a bad input as a small trade in
+        the very logs decision (c) is mined from."""
+        for fraction in (-0.10, 0.0, float("nan")):
+            with self.subTest(fraction=fraction):
+                s = size(0.60, 0.40, kelly_fraction=fraction)
+                self.assertEqual(s.refusal, "invalid_kelly_fraction")
+                self.assertGreaterEqual(s.notional, 0.0)
+
+
+class EnforcedCeilingTest(unittest.TestCase):
+    """Size against the ceiling the executor enforces FIRST."""
+
+    def test_the_configured_ceiling_binds_before_the_hard_one(self):
+        s = size(1.0, 0.50, bankroll=10_000.0,
+                 max_position_usdc=10.0, absolute_max_usdc=25.0)
+        self.assertAlmostEqual(s.debit, 10.0, places=9)
+        self.assertEqual(s.clamped_by, "max_position_usdc")
+
+    def test_the_hard_ceiling_binds_when_it_is_the_lower(self):
+        s = size(1.0, 0.50, bankroll=10_000.0,
+                 max_position_usdc=100.0, absolute_max_usdc=25.0)
+        self.assertAlmostEqual(s.debit, 25.0, places=9)
+        self.assertEqual(s.clamped_by, "absolute_max_position_usdc")
+
+    def test_it_never_proposes_above_what_gate_5_enforces(self):
+        """A $12 proposal against a $10 configured cap would be refused after
+        approval, putting a figure in front of a human the system will not
+        honour."""
+        s = size(1.0, 0.30, bankroll=10_000.0,
+                 max_position_usdc=10.0, absolute_max_usdc=25.0)
+        self.assertLessEqual(s.debit, 10.0)
+
+
+class FailClosedTest(unittest.TestCase):
+    def test_unknown_minimum_is_refused_never_assumed_to_be_five(self):
+        for bad in (None, 0, -1, float("nan"), float("inf")):
+            with self.subTest(minimum=bad):
+                s = size(0.35, 0.10, minimum=bad)
+                self.assertFalse(s.tradeable)
+                self.assertEqual(s.refusal, "unknown_min_order_size")
+
+    def test_a_market_that_would_otherwise_trade_is_still_refused(self):
+        """The fail-closed path must not be reachable only for bad trades."""
+        self.assertTrue(size(0.35, 0.10, minimum=5.0).tradeable)
+        self.assertFalse(size(0.35, 0.10, minimum=None).tradeable)
+
+    def test_invalid_prices_are_refused(self):
+        for price in (0.0, 1.0, -0.5, 1.5):
+            with self.subTest(price=price):
+                self.assertEqual(size(0.5, price).refusal, "invalid_price")
+
+    def test_non_finite_inputs_are_refused(self):
+        for p in (float("nan"), float("inf")):
+            with self.subTest(p=p):
+                self.assertEqual(size(p, 0.40).refusal, "invalid_input")
+
+    def test_non_positive_bankroll_is_refused(self):
+        for bank in (0.0, -25.0):
+            with self.subTest(bankroll=bank):
+                self.assertEqual(size(0.9, 0.20, bankroll=bank).refusal,
+                                 "invalid_bankroll")
+
+
+class PriceFloorTest(unittest.TestCase):
+    """A proposal filter, not a clamp on price in the formula."""
+
+    def test_below_the_floor_is_refused(self):
+        s = size(0.50, 0.05)
+        self.assertFalse(s.tradeable)
+        self.assertEqual(s.refusal, "price_below_sizing_floor")
+
+    def test_the_floor_is_not_applied_as_a_clamp(self):
+        """If price were clamped to 0.10 rather than filtered, a 0.05 market
+        would return a SIZE. It must return a refusal instead."""
+        self.assertEqual(size(0.50, 0.05).notional, 0.0)
+
+    def test_at_and_above_the_floor_it_sizes(self):
+        self.assertNotEqual(size(0.50, 0.10).refusal, "price_below_sizing_floor")
+
+    def test_the_floor_is_separate_from_inclusion(self):
+        """YES_PRICE_MIN is 0.01 and governs which markets are scanned. This
+        floor is 0.10 and governs which can be sized. A market between them is
+        scanned and reported, and refused only for sizing."""
+        s = size(0.50, 0.05)
+        self.assertEqual(s.refusal, "price_below_sizing_floor")
+        self.assertGreater(s.edge, 0, "it still has a real edge, it is reported")
+
+
+class NoSideTest(unittest.TestCase):
+    """Sizing the NO side, which the old abs(edge) hack got wrong."""
+
+    def test_side_price_is_complemented(self):
+        self.assertAlmostEqual(side_price_for("NO", 0.30), 0.70)
+        self.assertAlmostEqual(side_price_for("YES", 0.30), 0.30)
+
+    def test_no_side_uses_complemented_probability_and_price(self):
+        """Buying NO at 0.70 believing 0.80 is the same Kelly problem as
+        buying YES at 0.70 believing 0.80."""
+        no = size(0.20, 0.30, direction="NO")     # p(NO)=0.80, price(NO)=0.70
+        yes = size(0.80, 0.70, direction="YES")
+        self.assertAlmostEqual(no.kelly_fraction, yes.kelly_fraction, places=12)
+        self.assertAlmostEqual(no.notional, yes.notional, places=9)
+
+    def test_no_side_with_no_edge_is_refused(self):
+        self.assertEqual(size(0.80, 0.30, direction="NO").refusal, "no_positive_edge")
+
+    def test_fee_uses_the_side_actually_bought(self):
+        self.assertAlmostEqual(fee_ratio(0.70), FEE_RATE * 0.30, places=12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -79,6 +79,93 @@ class KellyArithmeticTest(unittest.TestCase):
             previous = s.notional
 
 
+class ParametersAreUsedNotAssumedTest(unittest.TestCase):
+    """Every parameter must TRACK its argument, not equal a hardcoded default.
+
+    Two parameters could be discarded entirely and replaced with the shipped
+    constant, and the suite stayed green:
+
+        fraction = 0.10 * full_kelly      # kelly_fraction ignored
+        if price < 0.10:                  # price_floor ignored
+
+    Invisible because 0.10 IS the live value on both, so every assertion
+    comparing against it passes either way. Same shape as a wire-through test
+    whose expected value is a literal that also appears at the call site: it
+    proves the constant, not that the argument is used.
+
+    The mutants that DO die are the ones substituting an obviously wrong value.
+    Those are the easy ones. The survivor is the one that looks right.
+
+    Every test here passes a value that is NOT the default and asserts the
+    output moves with it.
+    """
+
+    def test_kelly_fraction_is_used(self):
+        """Halving the fraction must halve the stake."""
+        base = size(0.80, 0.20, kelly_fraction=0.10)
+        half = size(0.80, 0.20, kelly_fraction=0.05)
+        quarter = size(0.80, 0.20, kelly_fraction=0.025)
+        self.assertAlmostEqual(half.kelly_debit, base.kelly_debit / 2, places=9)
+        self.assertAlmostEqual(quarter.kelly_debit, base.kelly_debit / 4, places=9)
+        self.assertAlmostEqual(half.notional, base.notional / 2, places=6)
+
+    def test_kelly_fraction_tracks_across_valid_values(self):
+        for fraction in (0.02, 0.05, 0.10, 0.25, 1.0):
+            with self.subTest(kelly_fraction=fraction):
+                s = size(0.80, 0.20, kelly_fraction=fraction)
+                expected = fraction * (0.80 - 0.20) / (1 - 0.20)
+                self.assertAlmostEqual(s.kelly_fraction, expected, places=12)
+
+    def test_a_larger_fraction_produces_a_larger_stake(self):
+        previous = 0.0
+        for fraction in (0.02, 0.05, 0.10, 0.25):
+            stake = size(0.80, 0.20, kelly_fraction=fraction).notional
+            self.assertGreater(stake, previous)
+            previous = stake
+
+    def test_price_floor_is_used(self):
+        """A market at 0.15 is refused under a 0.20 floor and sized under 0.10.
+
+        Neither probe is the default, so a hardcoded 0.10 fails the first and a
+        hardcoded 0.20 fails the second.
+        """
+        under = size(0.60, 0.15, price_floor=0.20)
+        self.assertEqual(under.refusal, "price_below_sizing_floor")
+        over = size(0.60, 0.15, price_floor=0.10)
+        self.assertNotEqual(over.refusal, "price_below_sizing_floor")
+
+    def test_price_floor_tracks_across_valid_values(self):
+        price = 0.25
+        for floor, refused in ((0.05, False), (0.20, False),
+                               (0.30, True), (0.50, True)):
+            with self.subTest(price_floor=floor):
+                s = size(0.80, price, price_floor=floor)
+                self.assertEqual(
+                    s.refusal == "price_below_sizing_floor", refused,
+                    f"floor {floor} against price {price}",
+                )
+
+    def test_bankroll_is_used(self):
+        base = size(0.80, 0.20, bankroll=25.0)
+        half = size(0.80, 0.20, bankroll=12.5)
+        self.assertAlmostEqual(half.kelly_debit, base.kelly_debit / 2, places=9)
+
+    def test_min_order_size_is_used(self):
+        """Already covered by the exchange-minimum tests, asserted here as a
+        parameter so all four sit together and none can regress alone."""
+        for minimum in (1.0, 7.5, 50.0):
+            with self.subTest(min_order_size=minimum):
+                s = size(0.80, 0.20, minimum=minimum)
+                self.assertEqual(s.required_shares, minimum)
+                self.assertAlmostEqual(s.min_notional, minimum * 0.20, places=12)
+
+    def test_the_ceilings_are_used(self):
+        for ceiling in (1.0, 6.0, 13.5):
+            with self.subTest(max_position_usdc=ceiling):
+                s = size(1.0, 0.50, bankroll=10_000.0, max_position_usdc=ceiling)
+                self.assertAlmostEqual(s.debit, ceiling, places=9)
+
+
 class FeeAwareTest(unittest.TestCase):
     """The cap is the DEBIT, not the notional."""
 
@@ -158,15 +245,72 @@ class ExchangeMinimumTest(unittest.TestCase):
                 self.assertEqual(s.refusal, "below_exchange_minimum")
                 self.assertLess(s.shares, MIN_SHARES)
 
-    def test_refusal_still_carries_the_arithmetic(self):
-        """A refusal is a measurement. Item (c) needs these numbers."""
-        s = size(0.6149, 0.279)
-        self.assertFalse(s.tradeable)
-        for field in ("price=", "edge=", "shares=", "required_shares=",
-                      "min_notional=", "sized_notional=", "kelly_debit=",
-                      "clamped_by="):
-            self.assertIn(field, s.log_fields())
+    def test_refusal_carries_the_arithmetic_BY_VALUE(self):
+        """A refusal is a measurement. Item (c) needs these numbers.
+
+        Asserting the LABELS is not asserting the numbers. An earlier version
+        of this test checked `assertIn("price=", ...)` and friends, which are
+        substrings of the implementation's own f-string, so every value in the
+        line could be zeroed and the suite stayed green. The whole log could be
+        emptied to bare labels and nothing noticed.
+
+        That is the same defect as a wire-through test comparing against a
+        literal: it proves the format string, not the data. This log IS the
+        deliverable of the sizing decision, so every field is pinned to its
+        own value here.
+        """
+        # minimum=12.0 on one fixture, deliberately NOT the shipped 5. Both
+        # fixtures previously used 5, so `required_shares={5.0:.4f}` (the value
+        # hardcoded) matched them and survived. A fixture that agrees with the
+        # plausible hardcode cannot tell it from the real thing, which is the
+        # same reason the per-market minimum needs a non-default probe.
+        for s in (size(0.6149, 0.279, minimum=12.0),          # refused, unclamped
+                  size(1.0, 0.50, bankroll=10_000.0)):        # tradeable, clamped
+            with self.subTest(clamped=s.clamped_by):
+                self.assert_every_field_pinned(s)
+
+    def assert_every_field_pinned(self, s):
+        line = s.log_fields()
+        for label, value in (
+            ("price", f"{s.side_price:.4f}"),
+            ("edge", f"{s.edge:+.4f}"),
+            ("kelly_f", f"{s.kelly_fraction:.5f}"),
+            ("kelly_debit", f"{s.kelly_debit:.4f}"),
+            ("sized_notional", f"{s.notional:.4f}"),
+            ("debit", f"{s.debit:.4f}"),
+            ("shares", f"{s.shares:.4f}"),
+            ("required_shares", f"{s.required_shares:.4f}"),
+            ("min_notional", f"{s.min_notional:.4f}"),
+            ("min_debit", f"{s.min_debit:.4f}"),
+        ):
+            with self.subTest(field=label):
+                self.assertIn(f"{label}={value}", line)
         self.assertGreater(s.notional, 0, "the computed size is still reported")
+
+    def test_every_logged_number_is_distinct_so_a_swap_is_visible(self):
+        """Pinning values only helps if the values differ.
+
+        If two fields happen to be equal, printing one under the other's label
+        passes. This picks a case where price, edge, notional, debit, shares and
+        the two minima are all different, so any swap shows.
+        """
+        s = size(0.6149, 0.279, minimum=12.0)
+        # kelly_debit is EXCLUDED here: when nothing clamps it equals debit by
+        # construction, which is the "cap IS the debit" invariant rather than a
+        # coincidence. The clamped fixture in the test above is what
+        # distinguishes those two, and it is why the value pinning runs over
+        # both a clamped and an unclamped case.
+        values = [s.side_price, s.edge, s.kelly_fraction, s.notional, s.debit,
+                  s.shares, s.required_shares, s.min_notional, s.min_debit]
+        rounded = [round(v, 4) for v in values]
+        self.assertEqual(len(set(rounded)), len(rounded),
+                         f"fixture makes a swap invisible: {rounded}")
+
+        clamped = size(1.0, 0.50, bankroll=10_000.0)
+        self.assertNotAlmostEqual(
+            clamped.kelly_debit, clamped.debit, places=2,
+            msg="the clamped fixture must separate kelly_debit from debit",
+        )
 
     def test_the_log_does_not_call_the_sized_notional_a_kelly_notional(self):
         """The label used to name the wrong quantity.
@@ -177,10 +321,35 @@ class ExchangeMinimumTest(unittest.TestCase):
         """
         s = size(1.0, 0.50, bankroll=10_000.0)
         self.assertEqual(s.clamped_by, "max_position_usdc")
-        self.assertNotIn("kelly_notional=", s.log_fields())
-        self.assertIn(f"kelly_debit={s.kelly_debit:.4f}", s.log_fields())
-        self.assertIn("clamped_by=max_position_usdc", s.log_fields())
+        line = s.log_fields()
+        self.assertNotIn("kelly_notional=", line)
+        self.assertIn(f"kelly_debit={s.kelly_debit:.4f}", line)
+        self.assertIn("clamped_by=max_position_usdc", line)
+        # THE POINT: sized_notional must carry the notional, not the pre-clamp
+        # ask. This test was named for that defect and did not detect it,
+        # because it never asserted what sized_notional actually prints.
+        self.assertIn(f"sized_notional={s.notional:.4f}", line)
+        self.assertNotIn(f"sized_notional={s.kelly_debit:.4f}", line)
         self.assertNotAlmostEqual(s.kelly_debit, s.notional, places=2)
+        self.assertNotAlmostEqual(s.kelly_debit, s.notional, places=2)
+
+    def test_the_two_minima_are_exact(self):
+        """min_notional and min_debit are what the caller needs to know how far
+        short it fell. Pinned exactly: min_notional was only ever asserted from
+        BELOW (doubling it strengthened the assertion), and min_debit was never
+        asserted at any value, so dropping its fee term survived."""
+        for p, price, minimum in ((0.6149, 0.279, 5.0), (0.35, 0.10, 12.0)):
+            with self.subTest(price=price, minimum=minimum):
+                s = size(p, price, minimum=minimum)
+                self.assertAlmostEqual(s.min_notional, minimum * price, places=12)
+                self.assertAlmostEqual(
+                    s.min_debit, minimum * price * (1 + fee_ratio(price)),
+                    places=12,
+                )
+                self.assertGreater(
+                    s.min_debit, s.min_notional,
+                    "min_debit must include the fee, or it is min_notional",
+                )
 
     def test_it_never_rounds_up_to_reach_the_minimum(self):
         """The one thing that must not happen.
@@ -289,8 +458,12 @@ class BoundaryTest(unittest.TestCase):
                     else:
                         lo = mid
                 s = size(hi, price)
-                if s.shares < minimum:
-                    self.assertFalse(s.tradeable, s.log_fields())
+                # Unconditional. Wrapping the assertion in `if s.shares <
+                # minimum` made it pass vacuously for any mutant that lifted
+                # shares above the floor, which is the mutant class it exists
+                # to catch.
+                self.assertLess(s.shares, minimum, "probe landed above the floor")
+                self.assertFalse(s.tradeable, s.log_fields())
 
 
 class ProbabilityRangeTest(unittest.TestCase):


### PR DESCRIPTION
Split out of #127. **This is the arithmetic only, and nothing imports it**, so
merging changes no behaviour.

## Why split

Four cold review rounds on #127 produced five blockers, **each in a different
layer** — the tests, the wiring, GATE 8, the config, the docs. That is a signal
the PR carried too much surface for one review, not that the reviews were
excessive.

**No finding has ever landed against the arithmetic.** Four independent rounds
re-derived it and four confirmed it. Keeping it in the contested PR means
re-reviewing settled ground every round.

## What it is

`src/trade_engine/sizing.py` plus `tests/test_sizing.py`. 43 tests. Imports
`math` and `typing` and nothing else — no flask, no numpy, no network, no
config — so it runs anywhere, which is why the Monte Carlo kernel was split the
same way in #118.

Fractional Kelly, `f = 0.10 * (p - price) / (1 - price)` against bankroll 25,
sized so the **wallet debit** hits the cap rather than the notional
(`notional = cap / (1 + 0.07 * (1 - price))`). Refuses below the exchange's
per-market share minimum and **never rounds up to reach it**.

## The result that shapes everything downstream

Clearing a 5-share minimum needs `edge >= 2·price·(1-price)`, and `edge` can
never exceed `1-price`, so `2·price <= 1`. **Above price 0.482521 the minimum is
unreachable at any edge, including certainty.** Deep favourites are the region
that is arithmetically impossible, not the one that survives.

Independently re-derived by four review rounds: the cut at
**0.4825213851384235**, the p_min table (0.291 / 0.538 / 0.741 / 0.900 / 0.964),
the required edge of **0.4226** at price 0.279, and all four historical position
refusals (2.1975 / 1.2949 / 3.9740 / 3.1107 shares).

Two numbers are stated with the model each belongs to, because an earlier
version mixed them: **0.482521** is fee-aware and describes this code;
**0.5** is fee-free. And `p(1-p) <= 0.035` has two roots — 0.036319 and
0.963681 — and both are stated, with the upper explained as infeasible
(it solves the inequality while violating `edge <= 1-price`) rather than
dropped. That upper root is the region an earlier audit wrongly called the
survivor, so leaving it out would leave the arithmetic that produced the error
truncated in the file.

## Review scope

Small: is the arithmetic right, and is it genuinely unwired? A reviewer should
confirm `grep -r "trade_engine.sizing"` finds only `tests/test_sizing.py`.

Everything contested — the wiring, GATE 8, the cash-out ceiling, the config
clamps, `trading.md` — follows in a separate PR and is not in this diff.

**DRAFT** pending one short cold pass. Trading stays disabled.