### PR TITLE
fix(trade-engine): conditional close, consistent hold, and a read that names the subject

### DIFF
--- a/src/agents/skills/trading-api.md
+++ b/src/agents/skills/trading-api.md
@@ -25,6 +25,7 @@ POST /positions/manual - Log a manually-executed trade so it is tracked and the 
 POST /monitor/run - Run the Position Monitor sweep once, on demand
 GET /positions/alerts - Live threshold alerts needing attention; an alert is NOT a close, the position is still open
 GET /positions/{{position_id}}/alerts - Full alert history for one position, resolved ones included
+GET /positions/{{position_id}} - One position by id, ANY status, with its market question and unresolved alert count; 404 when the value is not a position id
 POST /positions/{{position_id}}/hold - Mark a position manually managed so alerts stop; body hold true or false
 POST /positions/manual-close - Log a position Tyson closed by hand; body position_id, exit_price, optional exit_usdc, exit_reason, note
 

--- a/src/trade_engine/database.py
+++ b/src/trade_engine/database.py
@@ -149,18 +149,71 @@ async def write_position(position: dict[str, Any]) -> dict[str, Any]:
     return rows[0]
 
 
+class PositionStateConflict(SupabaseError):
+    """A conditional PATCH matched no row.
+
+    Raised only when update_position is called with require_status: the
+    position either does not exist or is not in the status the caller
+    required. Kept distinct from SupabaseError so a route can answer 404/409
+    with a message about the position, instead of the 503 a transport
+    failure gets.
+    """
+
+
+async def get_position(position_id: str) -> Optional[TradePosition]:
+    """One position by id, ANY status. None when no row matches.
+
+    This is the read the approval prompt and the post-error re-read use to say
+    what an identifier actually points at. get_open_positions cannot serve
+    that: a closed position is exactly the case the caller needs to see.
+    The caller is responsible for rejecting values that are not UUIDs, since
+    PostgREST answers those with a 400 rather than an empty set.
+    """
+    rows = await _request(
+        "GET",
+        "/trading_positions",
+        params={"id": f"eq.{position_id}", "limit": 1},
+    )
+    if not rows:
+        return None
+    return TradePosition.model_validate(rows[0])
+
+
 async def update_position(
-    position_id: str, updates: dict[str, Any]
+    position_id: str,
+    updates: dict[str, Any],
+    *,
+    require_status: Optional[str] = None,
 ) -> dict[str, Any]:
-    """Patch one position by id and return the updated row."""
+    """Patch one position by id and return the updated row.
+
+    require_status makes the write CONDITIONAL: the filter becomes
+    id=eq.<id> AND status=eq.<require_status>, evaluated by Postgres inside the
+    one UPDATE statement. Two concurrent closes of the same open position then
+    cannot both succeed; the second matches zero rows and raises
+    PositionStateConflict. Without it, a read-then-write caller has a window in
+    which both writes land and the last one wins, which the 2026-09-10 audit
+    reproduced against this handler. The default (no condition) is kept for
+    the executor's own writes, which target rows it created moments earlier.
+    """
+    params: dict[str, Any] = {"id": f"eq.{position_id}"}
+    if require_status is not None:
+        params["status"] = f"eq.{require_status}"
     rows = await _request(
         "PATCH",
         "/trading_positions",
-        params={"id": f"eq.{position_id}"},
+        params=params,
         json_body=updates,
         write=True,
     )
     if not rows:
+        if require_status is not None:
+            raise PositionStateConflict(
+                "PATCH",
+                "/trading_positions",
+                200,
+                f"no row updated for id={position_id} with status={require_status}",
+            )
         raise SupabaseError(
             "PATCH",
             "/trading_positions",
@@ -428,8 +481,14 @@ async def set_manual_hold(position_id: str, hold: bool) -> dict[str, Any]:
 
     manual_hold suppresses alerting only. The monitor still prices the position
     every sweep so the dashboard and Analyst stay accurate.
+
+    Conditional on status=open, matching POST /positions/manual-close. Before
+    2026-09-10 this accepted any id that matched a row, so a closed position
+    returned 200 while the close endpoint 404'd the same id.
     """
-    return await update_position(position_id, {"manual_hold": bool(hold)})
+    return await update_position(
+        position_id, {"manual_hold": bool(hold)}, require_status="open"
+    )
 
 
 # Heartbeat identities. ONE per scheduled entry point, deliberately not one per

--- a/src/trade_engine/main.py
+++ b/src/trade_engine/main.py
@@ -21,6 +21,7 @@ sys.path.insert(
 
 import asyncio  # noqa: E402
 import logging  # noqa: E402
+import uuid  # noqa: E402
 from contextlib import asynccontextmanager  # noqa: E402
 from datetime import datetime, timezone  # noqa: E402
 from typing import Any, Optional  # noqa: E402
@@ -38,6 +39,7 @@ from src.trade_engine.config import config, configure_logging  # noqa: E402
 from src.trade_engine.database import (  # noqa: E402
     HEARTBEAT_MONITOR,
     HEARTBEAT_SCANNER,
+    PositionStateConflict,
     SupabaseError,
     close_client,
     count_all_positions,
@@ -45,7 +47,9 @@ from src.trade_engine.database import (  # noqa: E402
     get_alerts_for_position,
     get_daily_pnl,
     get_open_positions,
+    get_position,
     get_recent_simulations,
+    get_simulations_by_ids,
     get_trading_config,
     get_unresolved_alerts,
     record_success_heartbeat,
@@ -469,6 +473,90 @@ async def positions_alerts() -> JSONResponse:
     }))
 
 
+def _is_position_id(value: str) -> bool:
+    """True iff value has the shape of a trading_positions.id (a UUID).
+
+    Anything else cannot name a row, so routes answer 404 for it themselves
+    rather than forwarding it to PostgREST, which rejects a malformed uuid
+    filter with a 400 that would surface here as a 503 "could not write".
+    The 2026-08-27 composed id "solana-110-aug-2026" is the case.
+    """
+    try:
+        uuid.UUID(str(value))
+    except (ValueError, AttributeError, TypeError):
+        return False
+    return True
+
+
+@app.get("/positions/{position_id}")
+async def position_by_id(position_id: str) -> JSONResponse:
+    """One position by id, ANY status.
+
+    Serves two callers in QClaw that need to say what an identifier points
+    at: the approval prompt's subject line before Tyson is asked to approve a
+    write, and the re-read after a write whose outcome is unknown. Both need
+    "closed" and "nothing" as answers, which GET /positions (open only)
+    cannot give. The market question is joined from the linked simulation
+    because trading_positions does not carry it.
+
+    Secondary lookups (question, live alerts) are reported under `lookups`
+    when they fail rather than degraded to a plausible None/0 inside a 200,
+    so a caller can tell "no alerts" from "could not read alerts".
+
+    Declared AFTER /positions/alerts on purpose: FastAPI matches routes in
+    declaration order, and this pattern would otherwise capture "alerts".
+    """
+    if not _is_position_id(position_id):
+        return JSONResponse(status_code=404, content={
+            "error": f"no position with id {position_id}",
+            "hint": "position ids are the UUIDs GET /positions returns; this value is not one",
+        })
+    try:
+        row = await get_position(position_id)
+    except SupabaseError as exc:
+        log.error("/positions/%s failed: %s", position_id, exc)
+        return JSONResponse(
+            status_code=503,
+            content={"error": "could not read position", "detail": str(exc)},
+        )
+    if row is None:
+        return JSONResponse(status_code=404, content={
+            "error": f"no position with id {position_id}",
+            "hint": "check GET /positions",
+        })
+
+    lookups: dict[str, str] = {}
+    question = None
+    if row.simulation_id:
+        try:
+            sims = await get_simulations_by_ids([row.simulation_id])
+            raw = sims[0].get("raw_output") if sims else None
+            question = raw.get("question") if isinstance(raw, dict) else None
+            lookups["question"] = "ok" if question else "missing"
+        except SupabaseError as exc:
+            log.warning("/positions/%s: question lookup failed: %s", position_id, exc)
+            lookups["question"] = "failed"
+    else:
+        lookups["question"] = "no_simulation"
+
+    unresolved_alert_count: Optional[int]
+    try:
+        unresolved_alert_count = len(await get_unresolved_alerts(position_id))
+        lookups["alerts"] = "ok"
+    except SupabaseError as exc:
+        log.warning("/positions/%s: alert lookup failed: %s", position_id, exc)
+        unresolved_alert_count = None
+        lookups["alerts"] = "failed"
+
+    return JSONResponse(content=jsonable_encoder({
+        "position": row,
+        "status": row.status,
+        "question": question,
+        "unresolved_alert_count": unresolved_alert_count,
+        "lookups": lookups,
+    }))
+
+
 @app.get("/positions/{position_id}/alerts")
 async def position_alert_history(position_id: str) -> JSONResponse:
     """Full alert history for one position, resolved ones included."""
@@ -512,8 +600,21 @@ async def position_hold(position_id: str, request: Request) -> JSONResponse:
         )
         return JSONResponse(status_code=400, content={"error": detail})
 
+    # Same answer as POST /positions/manual-close for the same inputs. Until
+    # 2026-09-10 a composed id came back 503 here and a real id on a CLOSED
+    # position came back 200, while the close endpoint 404'd both.
+    if not _is_position_id(position_id):
+        return JSONResponse(status_code=404, content={
+            "error": f"no OPEN position with id {position_id}",
+            "hint": "position ids are the UUIDs GET /positions returns; this value is not one",
+        })
     try:
         row = await set_manual_hold(position_id, req.hold)
+    except PositionStateConflict:
+        return JSONResponse(status_code=404, content={
+            "error": f"no OPEN position with id {position_id}",
+            "hint": "check GET /positions; a closed position cannot be held or released",
+        })
     except SupabaseError as exc:
         log.error("/positions/%s/hold failed: %s", position_id, exc)
         return JSONResponse(
@@ -569,6 +670,12 @@ async def positions_manual_close(request: Request) -> JSONResponse:
             content={"error": f"exit_price must be between 0 and 1, got {req.exit_price}"},
         )
 
+    if not _is_position_id(req.position_id):
+        return JSONResponse(status_code=404, content={
+            "error": f"no OPEN position with id {req.position_id}",
+            "hint": "position ids are the UUIDs GET /positions returns; this value is not one",
+        })
+
     # Read the position first: refuse to close what is not open, and derive
     # exit_usdc from its shares when the caller did not supply proceeds.
     try:
@@ -611,8 +718,30 @@ async def positions_manual_close(request: Request) -> JSONResponse:
         "exit_reason": req.exit_reason or "manual_close",
         "closed_at": datetime.now(timezone.utc).isoformat(),
     }
+    # Conditional on status=open so two closes of the same position cannot
+    # both land. The pre-read above gives a clear 404; this filter is the
+    # guarantee, evaluated inside the UPDATE statement itself. Reproduced on
+    # 2026-09-10: without it two overlapping closes both returned 200 and the
+    # last writer's numbers stayed on the row.
     try:
-        row = await update_position(req.position_id, updates)
+        row = await update_position(
+            req.position_id, updates, require_status="open"
+        )
+    except PositionStateConflict:
+        # Open at the read, not open at the write: a concurrent close or a
+        # hand correction got there first. Nothing was written and no alert
+        # is resolved, and the caller must not be able to read this as done.
+        log.warning(
+            "/positions/manual-close lost the race for %s: no longer open",
+            req.position_id,
+        )
+        return JSONResponse(status_code=409, content={
+            "error": f"position {req.position_id} is no longer open; nothing written",
+            "hint": (
+                "it was closed between this request's read and its write; "
+                "read GET /positions/{position_id} for the state that won"
+            ),
+        })
     except SupabaseError as exc:
         log.error("/positions/manual-close write failed: %s", exc)
         return JSONResponse(

--- a/tests/skill-diagnostics.test.js
+++ b/tests/skill-diagnostics.test.js
@@ -152,27 +152,53 @@ function main() {
     fixedReport.rows[0]?.tools === 4, `got ${fixedReport.rows[0]?.tools}`);
 
   // ── 5. Unresolvable path identifiers ──
+  //
+  // This once conflated two things in one assertion against the live
+  // trading-api.md, and it broke the moment that file changed: #142 added
+  // GET /positions/{{position_id}}, so position_id started resolving and the
+  // "it is unresolvable" assertion, which read the live file, flipped. That is
+  // the same defect this whole suite exists to catch (a fixture that reads real
+  // estate a later edit can move), so the two things are now separate.
+  //
+  //  - CAPABILITY: the diagnostic detects a write path identifier with no GET
+  //    ending at it. Proved against a SYNTHETIC skill nothing in the estate can
+  //    change. This is the assertion worth keeping forever.
+  //  - LIVE FILE: what is true of trading-api.md right now. Expected to move as
+  //    endpoints are added or removed; when it does, fix THIS assertion only and
+  //    leave the capability one above untouched.
+
+  // CAPABILITY (estate-immune): a made-up skill whose write path parameter has
+  // no GET ending at it. widget_id can never be resolved, no matter what any
+  // real skill file grows to.
+  const synthUnresolvable = [
+    '## Auth',
+    'Base URL: https://example.test',
+    '',
+    '## Endpoints',
+    'POST /widgets/{{widget_id}}/close - close one widget by id',
+    'GET /widgets/alerts - list alerts; note this GET does NOT end at widget_id',
+  ].join('\n');
+  const synth = inspectSkills([{ name: 'synth-api', content: synthUnresolvable, filename: 'synth-api.md' }], null);
+  check('CAPABILITY: a write path id with no GET ending at it is flagged unresolvable',
+    synth.rows[0]?.unresolvedParams.some((u) => u.param === 'widget_id'),
+    JSON.stringify(synth.rows[0]?.unresolvedParams));
+  check('CAPABILITY: the report explains the unresolvable id in words, not a code',
+    formatReport(synth).some((l) => l.includes('widget_id') && l.includes('cannot be resolved before approval')),
+    JSON.stringify(formatReport(synth).filter((l) => l.includes('widget_id'))));
+
+  // LIVE FILE: trading-api.md now RESOLVES position_id, because it declares
+  // GET /positions/{{position_id}} (added in #142, the 404-on-non-id resolver).
+  // This reflects the current endpoints and is EXPECTED to change. If a future
+  // edit removes that GET, this flips; fix it here. The capability above does
+  // not move, because it never reads a file the estate can edit.
   const tradingRow = report.rows.find((r) => r.name === 'trading-api');
-  check('trading-api on main: position_id has no GET ending at it',
-    tradingRow?.unresolvedParams.some((u) => u.param === 'position_id'),
+  check('LIVE trading-api.md: position_id resolves (GET /positions/{{position_id}} present)',
+    tradingRow && !tradingRow.unresolvedParams.some((u) => u.param === 'position_id'),
     JSON.stringify(tradingRow?.unresolvedParams));
 
   const ghlRow = report.rows.find((r) => r.name === 'ghl-fsc');
   check('ghl-fsc: contact_id resolves, so nothing is reported',
     ghlRow?.unresolvedParams.length === 0, JSON.stringify(ghlRow?.unresolvedParams));
-
-  // PR #142 adds GET /positions/{{position_id}}. Model that here so the check
-  // is known to clear rather than assumed to.
-  const withGet = read('trading-api').replace(
-    'GET /positions/{{position_id}}/alerts',
-    'GET /positions/{{position_id}} - One position by id\nGET /positions/{{position_id}}/alerts'
-  );
-  const after142 = inspectSkills([{ name: 'trading-api', content: withGet, filename: 'trading-api.md' }], null);
-  check('PRECONDITION: the trading-api fixture actually changed',
-    withGet !== read('trading-api'));
-  check('trading-api with #142 merged: position_id resolves and clears',
-    after142.rows[0]?.unresolvedParams.length === 0,
-    JSON.stringify(after142.rows[0]?.unresolvedParams));
 
   // ── 6. The boot output ──
   const lines = formatReport(report);
@@ -184,8 +210,12 @@ function main() {
     JSON.stringify(lines.find((l) => l.includes('ads-agency'))));
   check('report says what looked like an HTTP skill',
     lines.some((l) => l.includes('it looked like an HTTP skill because of')));
-  check('report explains the unresolvable identifier in words, not a code',
-    lines.some((l) => l.includes('position_id') && l.includes('cannot be resolved before approval')),
+  // position_id resolves in the live trading-api.md now (GET present, #142), so
+  // the real report must NOT flag it. The words-not-code formatting of an
+  // unresolvable id is proved in section 5 on the synthetic fixture, where no
+  // endpoint edit can move it.
+  check('report does NOT flag position_id now that the live file resolves it',
+    !lines.some((l) => l.includes('position_id') && l.includes('cannot be resolved before approval')),
     JSON.stringify(lines.filter((l) => l.includes('position_id'))));
 
   const clean = formatReport(inspectSkills([skill('ghl-fsc')], null));

--- a/tests/test_manual_close.py
+++ b/tests/test_manual_close.py
@@ -1,0 +1,379 @@
+"""Tests for POST /positions/manual-close, POST /positions/{id}/hold and
+GET /positions/{id} in src/trade_engine/main.py.
+
+Stdlib unittest, matching tests/test_manual_position.py. No network, no
+Supabase: database._request is replaced by an in-memory PostgREST stand-in
+that honours the two filters these routes depend on (eq. and is.null), so the
+real database.py functions run and the PARAMS they send are what the tests
+pin. A fake that ignored the status filter would pass against a handler that
+never sent one, which is the fixture-agrees-with-the-hardcode trap in
+docs/trade-engine-handoff.md.
+
+Background (2026-09-10 audit of the 2026-08-27 composed-id incident):
+
+  * a composed id like "solana-110-aug-2026" got a 404 from the close route
+    but a 503 from the hold route, and a real id on a CLOSED position got a
+    200 from hold;
+  * two overlapping closes of the same open position both returned 200 and
+    the last writer's numbers stayed on the row, because the PATCH filtered
+    on id alone;
+  * nothing could read one position by id regardless of status, which the
+    approval prompt and the post-error re-read both need.
+
+Run:
+    python3 -m unittest tests/test_manual_close.py
+"""
+
+import asyncio
+import json
+import os
+import sys
+import unittest
+from typing import Any, Optional
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+for _key in (
+    "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "ANTHROPIC_API_KEY",
+    "TELEGRAM_BOT_TOKEN", "OWNER_TELEGRAM_CHAT_ID",
+    "POLYMARKET_PRIVATE_KEY", "POLYMARKET_FUNDER_ADDRESS",
+):
+    os.environ.setdefault(_key, f"test-{_key.lower()}")
+
+import httpx  # noqa: E402
+from fastapi import Request  # noqa: E402
+
+from src.trade_engine import database as db_mod  # noqa: E402
+from src.trade_engine import main as main_mod  # noqa: E402
+from src.trade_engine.database import PositionStateConflict, SupabaseError  # noqa: E402
+
+OPEN_ID = "b3cecdef-9948-40c7-9691-1b9c4ce579bc"
+CLOSED_ID = "f4be9ee8-15e5-4793-908f-0968944a1cec"
+UNKNOWN_ID = "00000000-0000-4000-8000-000000000000"
+COMPOSED_ID = "solana-110-aug-2026"  # the 2026-08-27 incident value
+SIM_ID = "d9905812-6a34-4b5b-923a-866b4d42e57f"
+QUESTION = "Will Solana reach $110 in August?"
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class FakePostgrest:
+    """Just enough PostgREST: eq./is.null filters over three tables, PATCH
+    applied only to the rows the filter matches, every call recorded."""
+
+    def __init__(self) -> None:
+        self.positions: dict[str, dict[str, Any]] = {}
+        self.alerts: list[dict[str, Any]] = []
+        self.simulations: dict[str, dict[str, Any]] = {}
+        self.calls: list[tuple[str, str, dict[str, Any], Any]] = []
+        self.after_positions_read = None  # async hook, runs after a GET is evaluated
+        self.fail_paths: set[tuple[str, str]] = set()  # (method, path) -> raise
+
+    async def request(self, method, path, *, params=None, json_body=None, write=False):
+        params = dict(params or {})
+        self.calls.append((method, path, params, json_body))
+        if (method, path) in self.fail_paths:
+            raise SupabaseError(method, path, 500, "injected failure")
+        if path == "/trading_positions":
+            if method == "GET":
+                rows = [dict(r) for r in self.positions.values() if self._match(r, params)]
+                if self.after_positions_read is not None:
+                    await self.after_positions_read()
+                return rows
+            if method == "PATCH":
+                matched = [r for r in self.positions.values() if self._match(r, params)]
+                for r in matched:
+                    r.update(json_body)
+                return [dict(r) for r in matched]
+        if path == "/trading_position_alerts":
+            matched = [a for a in self.alerts if self._match(a, params)]
+            if method == "PATCH":
+                for a in matched:
+                    a.update(json_body)
+            return [dict(a) for a in matched]
+        if path == "/trading_simulations" and method == "GET":
+            inner = params["id"][len("in.("):-1]
+            ids = [s.strip('"') for s in inner.split(",")]
+            return [self.simulations[i] for i in ids if i in self.simulations]
+        raise AssertionError(f"unexpected {method} {path} {params}")
+
+    @staticmethod
+    def _match(row: dict[str, Any], params: dict[str, Any]) -> bool:
+        for key, value in params.items():
+            if key in ("order", "limit", "select"):
+                continue
+            if value == "is.null":
+                if row.get(key) is not None:
+                    return False
+            elif isinstance(value, str) and value.startswith("eq."):
+                if str(row.get(key)) != value[3:]:
+                    return False
+            else:
+                raise AssertionError(f"unsupported filter {key}={value!r}")
+        return True
+
+    def patches(self, path="/trading_positions"):
+        return [(p, b) for (m, pth, p, b) in self.calls if m == "PATCH" and pth == path]
+
+
+def position_row(pid: str, status: str, **extra) -> dict[str, Any]:
+    base = {
+        "id": pid, "status": status, "direction": "YES", "entry_price": 0.483,
+        "shares": 20.7, "usdc_amount": 10.36, "simulation_id": SIM_ID,
+        "opened_at": "2026-08-27T12:15:30+00:00", "manual_hold": False,
+        "exit_price": None, "exit_usdc": None, "pnl": None, "closed_at": None,
+    }
+    base.update(extra)
+    return base
+
+
+def make_close_request(body: dict) -> Request:
+    """A Request the handler coroutine can consume directly, so two closes
+    can genuinely overlap. Through the HTTP client they serialise."""
+    raw = json.dumps(body).encode()
+
+    async def receive():
+        return {"type": "http.request", "body": raw, "more_body": False}
+
+    scope = {
+        "type": "http", "method": "POST", "path": "/positions/manual-close",
+        "headers": [(b"content-type", b"application/json")], "query_string": b"",
+    }
+    return Request(scope, receive)
+
+
+class CloseTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.pg = FakePostgrest()
+        self.pg.positions[OPEN_ID] = position_row(OPEN_ID, "open")
+        self.pg.positions[CLOSED_ID] = position_row(
+            CLOSED_ID, "closed", exit_price=0.565, exit_usdc=19.89, pnl=9.89,
+            closed_at="2026-08-25T10:42:19+00:00",
+        )
+        self.pg.simulations[SIM_ID] = {
+            "id": SIM_ID, "asset": "sol", "raw_output": {"question": QUESTION},
+        }
+        self.pg.alerts.append({
+            "id": "alert-1", "position_id": OPEN_ID, "alert_type": "take_profit",
+            "trigger_price": 0.8555, "triggered_at": "2026-08-27T16:55:06+00:00",
+            "resolved_at": None, "resolution_note": None,
+        })
+        self._orig_request = db_mod._request
+        db_mod._request = self.pg.request
+
+    def tearDown(self) -> None:
+        db_mod._request = self._orig_request
+
+    # --- helpers ----------------------------------------------------------
+
+    def http(self, method: str, path: str, body: Optional[dict] = None) -> httpx.Response:
+        async def _do():
+            transport = httpx.ASGITransport(app=main_mod.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+                return await c.request(method, path, json=body)
+        return run(_do())
+
+    def close(self, body: dict) -> httpx.Response:
+        return self.http("POST", "/positions/manual-close", body)
+
+
+# ── GET /positions/{id} ──────────────────────────────────────────────────
+
+class PositionByIdTests(CloseTestCase):
+    def test_closed_row_is_returned_with_status_and_question(self):
+        r = self.http("GET", f"/positions/{CLOSED_ID}")
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertEqual(body["status"], "closed")
+        self.assertEqual(body["position"]["exit_usdc"], 19.89)
+        self.assertEqual(body["question"], QUESTION)
+        self.assertEqual(body["unresolved_alert_count"], 0)
+        self.assertEqual(body["lookups"], {"question": "ok", "alerts": "ok"})
+
+    def test_open_row_reports_live_alert_count(self):
+        r = self.http("GET", f"/positions/{OPEN_ID}")
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(r.json()["status"], "open")
+        self.assertEqual(r.json()["unresolved_alert_count"], 1)
+
+    def test_unknown_uuid_is_404(self):
+        r = self.http("GET", f"/positions/{UNKNOWN_ID}")
+        self.assertEqual(r.status_code, 404, r.text)
+        self.assertIn(UNKNOWN_ID, r.json()["error"])
+
+    def test_composed_id_is_404_and_never_reaches_postgrest(self):
+        r = self.http("GET", f"/positions/{COMPOSED_ID}")
+        self.assertEqual(r.status_code, 404, r.text)
+        self.assertIn("not one", r.json()["hint"])
+        self.assertEqual(self.pg.calls, [], "a non-uuid must be refused locally")
+
+    def test_alerts_path_is_not_captured_by_the_id_route(self):
+        r = self.http("GET", "/positions/alerts")
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertIn("alerts", r.json())
+        self.assertEqual(r.json()["count"], 1)
+
+    def test_failed_secondary_lookups_are_labelled_not_defaulted(self):
+        self.pg.fail_paths.add(("GET", "/trading_simulations"))
+        self.pg.fail_paths.add(("GET", "/trading_position_alerts"))
+        r = self.http("GET", f"/positions/{OPEN_ID}")
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertEqual(body["status"], "open")
+        self.assertIsNone(body["question"])
+        self.assertIsNone(body["unresolved_alert_count"])
+        self.assertEqual(body["lookups"], {"question": "failed", "alerts": "failed"})
+
+
+# ── POST /positions/manual-close ─────────────────────────────────────────
+
+class ManualCloseTests(CloseTestCase):
+    def test_composed_id_is_404_and_writes_nothing(self):
+        r = self.close({"position_id": COMPOSED_ID, "exit_price": 0.863, "exit_usdc": 17.86})
+        self.assertEqual(r.status_code, 404, r.text)
+        self.assertIn("not one", r.json()["hint"])
+        self.assertEqual(self.pg.patches(), [])
+        self.assertEqual(self.pg.calls, [], "refused before any read or write")
+
+    def test_unknown_uuid_is_404_and_writes_nothing(self):
+        r = self.close({"position_id": UNKNOWN_ID, "exit_price": 0.863, "exit_usdc": 17.86})
+        self.assertEqual(r.status_code, 404, r.text)
+        self.assertEqual(self.pg.patches(), [])
+
+    def test_success_path_writes_once_and_resolves_the_alert(self):
+        r = self.close({"position_id": OPEN_ID, "exit_price": 0.863, "exit_usdc": 17.86})
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertTrue(body["success"])
+        self.assertEqual(body["position"]["status"], "closed")
+        self.assertEqual(body["position"]["pnl"], 7.5)
+        self.assertEqual(len(body["resolved_alerts"]), 1)
+        self.assertEqual(len(self.pg.patches()), 1)
+
+    def test_patch_is_conditional_on_status_open(self):
+        """The guarantee is the filter PostgREST evaluates, so pin the params
+        the handler sends rather than the fake's outcome alone."""
+        self.close({"position_id": OPEN_ID, "exit_price": 0.863, "exit_usdc": 17.86})
+        params, _body = self.pg.patches()[0]
+        self.assertEqual(params, {"id": f"eq.{OPEN_ID}", "status": "eq.open"})
+
+    def test_second_sequential_close_is_404(self):
+        first = self.close({"position_id": OPEN_ID, "exit_price": 0.863, "exit_usdc": 17.86})
+        second = self.close({"position_id": OPEN_ID, "exit_price": 0.50, "exit_usdc": 10.0})
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 404, second.text)
+        self.assertEqual(len(self.pg.patches()), 1)
+        self.assertEqual(self.pg.positions[OPEN_ID]["exit_usdc"], 17.86)
+
+    def test_closed_between_read_and_write_is_409_and_resolves_no_alert(self):
+        """The row is open when the handler reads it and closed by the time
+        it writes. The conditional PATCH matches nothing: 409, no alert
+        resolution, the other writer's numbers stay."""
+        async def close_underneath():
+            self.pg.positions[OPEN_ID].update(
+                status="closed", exit_price=0.50, exit_usdc=10.0, pnl=-0.36,
+            )
+        self.pg.after_positions_read = close_underneath
+
+        r = self.close({"position_id": OPEN_ID, "exit_price": 0.863, "exit_usdc": 17.86})
+        self.assertEqual(r.status_code, 409, r.text)
+        self.assertIn("nothing written", r.json()["error"])
+        self.assertEqual(len(self.pg.patches()), 1, "the PATCH was attempted")
+        self.assertEqual(self.pg.patches("/trading_position_alerts"), [],
+                         "no alert may be resolved by a close that did not land")
+        self.assertEqual(self.pg.positions[OPEN_ID]["exit_usdc"], 10.0)
+        self.assertIsNone(self.pg.alerts[0]["resolved_at"])
+
+    def test_concurrent_double_close_exactly_one_succeeds(self):
+        """Both requests read the position as open before either writes (a
+        barrier in the fake read guarantees the interleaving). Before the
+        conditional PATCH both returned 200 and both wrote."""
+        barrier = asyncio.Barrier(2)
+
+        async def wait_for_both_reads():
+            await barrier.wait()
+        self.pg.after_positions_read = wait_for_both_reads
+
+        async def _do():
+            return await asyncio.wait_for(asyncio.gather(
+                main_mod.positions_manual_close(make_close_request(
+                    {"position_id": OPEN_ID, "exit_price": 0.863, "exit_usdc": 17.86})),
+                main_mod.positions_manual_close(make_close_request(
+                    {"position_id": OPEN_ID, "exit_price": 0.50, "exit_usdc": 10.0})),
+            ), timeout=5)
+        a, b = run(_do())
+        statuses = sorted([a.status_code, b.status_code])
+        self.assertEqual(statuses, [200, 409], f"{a.body!r} {b.body!r}")
+        applied = [p for p in self.pg.patches() if p[0].get("status") == "eq.open"]
+        self.assertEqual(len(applied), 2, "both attempted the conditional PATCH")
+        winner = a if a.status_code == 200 else b
+        won = json.loads(winner.body)["position"]
+        self.assertEqual(self.pg.positions[OPEN_ID]["exit_usdc"], won["exit_usdc"],
+                         "the row carries the winner's numbers, not the last writer's")
+        self.assertEqual(len(self.pg.patches("/trading_position_alerts")), 1,
+                         "exactly one close resolved the alert")
+
+    def test_market_url_instead_of_position_id_is_400(self):
+        r = self.close({"market_url": "https://polymarket.com/event/x", "exit_price": 0.863})
+        self.assertEqual(r.status_code, 400, r.text)
+        self.assertEqual(self.pg.calls, [])
+
+
+# ── POST /positions/{id}/hold ────────────────────────────────────────────
+
+class HoldTests(CloseTestCase):
+    def test_composed_id_is_404_not_503_and_never_reaches_postgrest(self):
+        r = self.http("POST", f"/positions/{COMPOSED_ID}/hold", {"hold": True})
+        self.assertEqual(r.status_code, 404, r.text)
+        self.assertIn("no OPEN position", r.json()["error"])
+        self.assertEqual(self.pg.calls, [])
+
+    def test_closed_position_is_404_and_flag_unchanged(self):
+        r = self.http("POST", f"/positions/{CLOSED_ID}/hold", {"hold": True})
+        self.assertEqual(r.status_code, 404, r.text)
+        self.assertIn("no OPEN position", r.json()["error"])
+        self.assertFalse(self.pg.positions[CLOSED_ID]["manual_hold"])
+
+    def test_unknown_uuid_is_404(self):
+        r = self.http("POST", f"/positions/{UNKNOWN_ID}/hold", {"hold": True})
+        self.assertEqual(r.status_code, 404, r.text)
+
+    def test_open_position_hold_and_release_are_200_and_conditional(self):
+        r = self.http("POST", f"/positions/{OPEN_ID}/hold", {"hold": True})
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertTrue(self.pg.positions[OPEN_ID]["manual_hold"])
+        r = self.http("POST", f"/positions/{OPEN_ID}/hold", {"hold": False})
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertFalse(self.pg.positions[OPEN_ID]["manual_hold"])
+        for params, _body in self.pg.patches():
+            self.assertEqual(params, {"id": f"eq.{OPEN_ID}", "status": "eq.open"})
+
+    def test_transport_failure_is_still_503(self):
+        self.pg.fail_paths.add(("PATCH", "/trading_positions"))
+        r = self.http("POST", f"/positions/{OPEN_ID}/hold", {"hold": True})
+        self.assertEqual(r.status_code, 503, r.text)
+
+
+# ── database.update_position contract ────────────────────────────────────
+
+class UpdatePositionContractTests(CloseTestCase):
+    def test_unconditional_default_keeps_old_error_type(self):
+        with self.assertRaises(SupabaseError) as ctx:
+            run(db_mod.update_position(UNKNOWN_ID, {"manual_hold": True}))
+        self.assertNotIsInstance(ctx.exception, PositionStateConflict)
+        self.assertEqual(self.pg.patches()[0][0], {"id": f"eq.{UNKNOWN_ID}"})
+
+    def test_conditional_miss_raises_conflict_subclass(self):
+        with self.assertRaises(PositionStateConflict):
+            run(db_mod.update_position(CLOSED_ID, {"manual_hold": True}, require_status="open"))
+
+    def test_get_position_returns_none_for_no_row(self):
+        self.assertIsNone(run(db_mod.get_position(UNKNOWN_ID)))
+        row = run(db_mod.get_position(CLOSED_ID))
+        self.assertEqual(row.status, "closed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Engine half of the 2026-09-10 remediation. **Merge this before the approval-prompt PR**: that PR's subject resolver reads `GET /positions/{position_id}`, which this PR adds. It degrades to "NOT FOUND" without it, so the order matters for correctness of the prompt, not for CI.

Anchored to `main` @ `86cea6d`, the SHA live on qclaw-agent at the time of the audit.

## What was wrong, all executed rather than reasoned

**Concurrent double close.** `update_position` sent `PATCH ?id=eq.<id>` with no status filter (`database.py:156`). Two closes that both read the position as open both returned 200, both wrote, the last writer's numbers stayed on the row, and the first was credited with resolving the alert.

**hold and manual-close disagreed about the same inputs.**

| input | hold, before | manual-close, before | both, after |
|---|---|---|---|
| composed id `solana-110-aug-2026` | 503 | 404 | 404 |
| real id, CLOSED position | 200, flag written | 404 | 404 |
| real id, OPEN position | 200 | 200 | 200 |

**Nothing could read one position by id regardless of status.** `GET /positions` is open-only, so "closed" and "nothing" were indistinguishable to any caller.

## What changed

- `update_position(..., require_status=...)` puts the condition inside the UPDATE statement. The loser of a race gets 409, writes nothing, and resolves no alert. An alert cleared against a close that did not land would hide a live threshold crossing.
- `set_manual_hold` is conditional on `status=open`.
- A value that is not a UUID is refused locally with 404 instead of being forwarded to PostgREST, which rejects a malformed uuid filter with a 400 that surfaced as "could not write".
- `GET /positions/{position_id}` returns any status, with the market question joined from the linked simulation. Failed secondary lookups report `failed` rather than defaulting to a plausible zero inside a 200.
- Route declared after `/positions/alerts`, since FastAPI matches in declaration order and this pattern would otherwise capture `alerts`. Pinned by a test.

## Verification

`tests/test_manual_close.py`, 22 tests. The fake PostgREST honours `eq.` and `is.null`, so the tests pin the params the handler sends, not only the outcome. A fake that ignored the status filter would pass against a handler that never sent one.

The concurrency test uses `asyncio.Barrier(2)` inside the fake read, so both requests provably observe the row as open before either writes. Not a sleep, not a hope.

Full Python suite, run per file as CI does, 480 assertions across 11 files, all green.

Seven mutants, all killed. The two that matter:

- Keep the conditional PATCH and change only which status it requires, `open` to `closed`. Killed by the test that pins the params.
- Keep `_is_position_id` and every call site, make it return `True` for everything. Killed by the composed-id tests, which also assert no call reached PostgREST.

## Not done

The approval gate still cannot refuse an unresolvable identifier before prompting. That is `docs/identifier-resolution-design.md` and needs your decisions first.