### PR TITLE
fix(approvals): identifier-first prompts, and no more reporting failure over a committed write

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,8 @@ import { createClaudeCodeDispatchTool } from './tools/claude-code-dispatch.js';
 import { createDelegateToTool } from './tools/delegate-to.js';
 import { RateLimiter } from './security/rate-limiter.js';
 import { ContentQueue } from './security/content-queue.js';
+import { renderTelegramText } from './security/approval-summary.js';
+import { registerSubjectResolver, makeTradingApiPositionResolver } from './security/subject-resolvers.js';
 import { banner } from './cli/brand.js';
 import { log } from './core/logger.js';
 import { writeFileSync, unlinkSync } from 'fs';
@@ -463,6 +465,14 @@ class QuantumClaw {
     // workaround that guarantees delivery via raw fetch.
     const ownerChatId = this.config.channels?.telegram?.ownerChatId || 1375806243;
     if (this.approvalGate) {
+      // Subject lookup for trading-api position ids: the prompt says which
+      // market a position id names and whether it is open or closed, so the
+      // operator is not matching a UUID by eye. The base URL comes from the
+      // skill's own preset at call time, so this stays correct if the engine
+      // moves. A skill-declared convention replaces this stopgap (fix 2 of
+      // the 2026-09-10 audit).
+      registerSubjectResolver('trading-api', makeTradingApiPositionResolver());
+
       // Cache the token at wire time for perf, but allow refresh on 401 so a
       // BotFather rotation while the process is running doesn't permanently
       // wedge the notifier.
@@ -473,7 +483,7 @@ class QuantumClaw {
         return cachedToken;
       };
 
-      this.approvalGate.setNotifier(async ({ id, agent, tool, action, detail, riskLevel }) => {
+      this.approvalGate.setNotifier(async ({ id, agent, tool, action, detail, riskLevel, summary }) => {
         // Fast-fail if the channel never came up at all — keeps the message
         // out of a state where it would be sent to a token-less bot. We don't
         // depend on tgChannel.bot for the actual send.
@@ -483,14 +493,18 @@ class QuantumClaw {
           return;
         }
 
-        const text =
-          `⚠️ Approval needed [${id}]\n` +
-          `Tool: ${tool}\n` +
-          `Agent: ${agent}\n` +
-          `Risk: ${riskLevel}\n` +
-          `Action: ${String(action || '').slice(0, 200)}\n` +
-          (detail ? `\nDetail:\n${String(detail).slice(0, 500)}\n` : '') +
-          `\nReply ✅ ${id} or ❌ ${id} — auto-denies after 10 min.`;
+        // renderTelegramText leads with the identifiers, in full, and trades
+        // only the Arguments block for space. The previous form sliced the
+        // serialised args to 200 twice over, which hid position_id whenever
+        // the model put it last in the body (audit 2026-09-10).
+        const text = renderTelegramText({
+          id,
+          tool,
+          agent,
+          riskLevel,
+          summary: summary || null,
+          detail: detail || action || '',
+        });
 
         const send = (token) =>
           fetch(`https://api.telegram.org/bot${token}/sendMessage`, {

--- a/src/security/approval-gate.js
+++ b/src/security/approval-gate.js
@@ -45,6 +45,8 @@
 import path from 'path';
 import { log } from '../core/logger.js';
 import { parseAndValidate } from '../tools/shell-exec-parser.js';
+import { buildApprovalSummary, renderApprovalDetail } from './approval-summary.js';
+import { resolveSubject } from './subject-resolvers.js';
 
 const SKILL_EDIT_ALLOWLIST = '/root/QClaw/src/agents/skills/';
 
@@ -263,11 +265,51 @@ export class ApprovalGate {
     return { requiresApproval: false };
   }
 
-  async requestApproval(agent, toolName, toolArgs, riskLevel) {
-    const action = `${toolName}(${JSON.stringify(toolArgs).slice(0, 200)})`;
-    const detail = `Agent ${agent} wants to execute: ${action}`;
+  /**
+   * @param {string} agent
+   * @param {string} toolName
+   * @param {object} toolArgs
+   * @param {string} riskLevel
+   * @param {{ httpMethod?: string, path?: string, skill?: string, baseUrl?: string }} [context]
+   *   Per-call metadata from the executor. `path`/`skill`/`baseUrl` drive the
+   *   identifier extraction and the subject lookup; all are optional, so a
+   *   caller that passes none still gets identifier-first rendering off the
+   *   args alone.
+   */
+  async requestApproval(agent, toolName, toolArgs, riskLevel, context = {}) {
+    // The prompt leads with the identifiers, whole, and says what they point
+    // at. Until 2026-09-10 it was JSON.stringify(args).slice(0, 200), which
+    // hid position_id entirely whenever the model put it last in the body.
+    // See src/security/approval-summary.js for the measurements.
+    const summary = buildApprovalSummary({ agent, toolName, toolArgs, context });
 
-    log.warn(`⏸️  Approval required: ${action}`);
+    const subject = await resolveSubject({
+      skill: summary.skill,
+      toolName,
+      method: summary.method,
+      path: summary.path,
+      identifiers: summary.identifiers,
+      args: toolArgs,
+      baseUrl: context?.baseUrl ?? null,
+    });
+    summary.subject = subject.lines;
+    summary.subjectStatus = subject.status;
+
+    const detail = renderApprovalDetail(summary);
+
+    // `action` keeps its original compact shape. It is a one-line label for
+    // the CLI list and the notifier payload, and callers already depend on it
+    // carrying the args (a shell_exec approval is unreadable without the
+    // command). The identifier-first rendering lives in `detail`, which is
+    // what gets stored and what the Telegram message is built from.
+    const action = `${toolName}(${JSON.stringify(toolArgs).slice(0, 200)})`;
+
+    // The log line leads with the identifiers so the process log answers
+    // "approval for which position?" without reading the args back.
+    const identSummary = summary.identifiers.length > 0
+      ? summary.identifiers.map(i => `${i.name}=${i.value}`).join(' ')
+      : 'no identifiers';
+    log.warn(`⏸️  Approval required: ${toolName} [${identSummary}]`);
 
     // Delegate to requestInlineApproval so the notifier always fires —
     // there should be one approval-creation code path, not two.
@@ -281,6 +323,7 @@ export class ApprovalGate {
       action,
       detail,
       riskLevel,
+      summary,
     });
   }
 
@@ -289,7 +332,7 @@ export class ApprovalGate {
    * Telegram notifier if configured, and awaits the human decision (or 10-min
    * auto-deny). Used by shell_exec and n8n_workflow_update.
    */
-  async requestInlineApproval({ agent, tool, action, detail, riskLevel = 'medium' }) {
+  async requestInlineApproval({ agent, tool, action, detail, riskLevel = 'medium', summary = null }) {
     if (!this.approvals?.createPending) {
       log.warn('requestInlineApproval: approvals subsystem unavailable — auto-deny');
       return { approved: false, id: -1, reason: 'approvals unavailable' };
@@ -299,7 +342,9 @@ export class ApprovalGate {
 
     if (this.notifier) {
       try {
-        await this.notifier({ id, agent, tool, action, detail, riskLevel });
+        // `summary` is null for shell_exec and n8n_workflow_update, which
+        // build their own detail text; the notifier renders those unchanged.
+        await this.notifier({ id, agent, tool, action, detail, riskLevel, summary });
       } catch (err) {
         log.debug(`approval notifier failed (id=${id}): ${err.message}`);
       }

--- a/src/security/approval-summary.js
+++ b/src/security/approval-summary.js
@@ -1,0 +1,245 @@
+/**
+ * QuantumClaw Approval Summary
+ *
+ * What an approval prompt is ABOUT, rendered so the operator sees the
+ * identifiers first, whole, and in a fixed place, then the subject those
+ * identifiers resolve to, then everything else.
+ *
+ * Why this exists (audit 2026-09-10 of the 2026-08-27 incident):
+ *
+ *   requestApproval built the prompt as
+ *     `${toolName}(${JSON.stringify(toolArgs).slice(0, 200)})`
+ *   and the Telegram notifier sliced that again to 200 including the 64
+ *   character tool name. A skill tool's whole body travels as one JSON
+ *   string named `data`, so after the `{"data":"` wrapper and the escaping
+ *   of every quote, at most 189 characters of body survived, and only 124
+ *   on the Action line. Three of the four manual-close prompts ever sent
+ *   were cut mid-JSON in the live approvals table. With `position_id`
+ *   placed last in the body, which the model decides, the id was not shown
+ *   at all. An operator who cannot see the identifier is not consenting to
+ *   anything in particular.
+ *
+ * Rules:
+ *   - Identifiers are never cut for length (bounded only by
+ *     MAX_IDENTIFIER_CHARS, far above any real id, so the message cannot be
+ *     weaponised against Telegram's 4096 limit).
+ *   - The subject block (what the identifiers resolve to) is never cut.
+ *   - The remaining fields are shown in full while they fit and truncated
+ *     with an explicit marker when they do not.
+ *   - "No identifiers found" is printed as such, never left implicit.
+ *
+ * What counts as an identifier is a NAME heuristic (IDENTIFIER_NAME_RE)
+ * plus every `{{param}}` in the tool's path. That is a rendering aid, not a
+ * validation rule: a field the heuristic misses still appears under
+ * Arguments. The skill-declared identifier convention that replaces the
+ * heuristic for validation is a separate design (fix 2 of the audit).
+ */
+
+export const IDENTIFIER_NAME_RE = /(^id$|^ids$|_id$|_ids$|Id$|Ids$|^uuid$|_uuid$|_url$|Url$)/;
+
+// Per identifier value. Real ids are under 100 characters; this bound only
+// stops a hostile or broken caller from filling the whole prompt with one.
+export const MAX_IDENTIFIER_CHARS = 1024;
+
+// Budget for the Arguments block in the stored detail and the first render.
+export const DEFAULT_FIELDS_BUDGET = 2500;
+
+// Telegram sendMessage hard limit for `text`.
+export const TELEGRAM_TEXT_LIMIT = 4096;
+
+function stringifyValue(v) {
+  if (v === null || v === undefined) return String(v);
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' || typeof v === 'boolean' || typeof v === 'bigint') return String(v);
+  try { return JSON.stringify(v); } catch { return String(v); }
+}
+
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Names of `{{param}}` placeholders in a skill endpoint path, excluding
+ * `{{secrets.*}}` and `{{config.*}}` which are resolved by the registry.
+ */
+export function pathParamNames(path) {
+  const names = [];
+  if (typeof path !== 'string') return names;
+  for (const m of path.matchAll(/\{\{([^}]+)\}\}/g)) {
+    const name = m[1].trim();
+    if (name.startsWith('secrets.') || name.startsWith('config.')) continue;
+    names.push(name);
+  }
+  return names;
+}
+
+/**
+ * Split a tool call's arguments into identifiers and other fields.
+ *
+ * Order is deterministic and independent of the order the model chose:
+ * path params first (in path order), then body identifiers (in body order),
+ * then top-level identifiers. Within Arguments, body order is preserved.
+ *
+ * @param {{ args: object, path?: string }} input
+ * @returns {{ identifiers: Array<{name:string,value:string,source:'path'|'body'|'arg'}>,
+ *             fields: Array<{name:string,value:string}>,
+ *             parseError: string|null }}
+ */
+export function extractIdentifiers({ args, path }) {
+  const identifiers = [];
+  const fields = [];
+  let parseError = null;
+  const a = isPlainObject(args) ? args : {};
+  const consumed = new Set();
+
+  for (const name of pathParamNames(path)) {
+    if (a[name] === undefined) continue;
+    identifiers.push({ name, value: stringifyValue(a[name]), source: 'path' });
+    consumed.add(name);
+  }
+
+  // The skill-parser schema carries the whole request body as one JSON
+  // string called `data` (skill-parser.js:193-195). Look inside it.
+  if (a.data !== undefined) {
+    consumed.add('data');
+    let body = a.data;
+    if (typeof body === 'string') {
+      try {
+        body = JSON.parse(body);
+      } catch {
+        parseError = 'data is not valid JSON';
+        fields.push({ name: 'data', value: String(a.data) });
+        body = null;
+      }
+    }
+    if (isPlainObject(body)) {
+      for (const [name, value] of Object.entries(body)) {
+        if (IDENTIFIER_NAME_RE.test(name)) {
+          identifiers.push({ name, value: stringifyValue(value), source: 'body' });
+        } else {
+          fields.push({ name, value: stringifyValue(value) });
+        }
+      }
+    } else if (body !== null && parseError === null) {
+      // Array or scalar payloads are sent verbatim as the body.
+      fields.push({ name: 'data', value: stringifyValue(body) });
+    }
+  }
+
+  for (const [name, value] of Object.entries(a)) {
+    if (consumed.has(name)) continue;
+    if (IDENTIFIER_NAME_RE.test(name)) {
+      identifiers.push({ name, value: stringifyValue(value), source: 'arg' });
+    } else {
+      fields.push({ name, value: stringifyValue(value) });
+    }
+  }
+
+  return { identifiers, fields, parseError };
+}
+
+function capIdentifier(value) {
+  const s = String(value);
+  if (s.length <= MAX_IDENTIFIER_CHARS) return s;
+  return `${s.slice(0, MAX_IDENTIFIER_CHARS)} [+${s.length - MAX_IDENTIFIER_CHARS} chars, identifier longer than ${MAX_IDENTIFIER_CHARS}]`;
+}
+
+/**
+ * Build the summary object for one tool call. Pure: no lookups here. The
+ * caller attaches `subject` lines from a resolver afterwards.
+ */
+export function buildApprovalSummary({ agent, toolName, toolArgs, context = {} }) {
+  const method = String(context?.httpMethod ?? '').trim().toUpperCase() || null;
+  const path = typeof context?.path === 'string' ? context.path : null;
+  const skill = typeof context?.skill === 'string' ? context.skill : null;
+  const { identifiers, fields, parseError } = extractIdentifiers({ args: toolArgs, path });
+  return {
+    agent: String(agent ?? 'unknown'),
+    toolName: String(toolName ?? ''),
+    method,
+    path,
+    skill,
+    identifiers,
+    fields,
+    parseError,
+    subject: [],
+    subjectStatus: 'none',
+  };
+}
+
+/**
+ * Render the stored/notified detail text. Identifiers and subject are
+ * complete; the Arguments block is bounded by `fieldsBudget` characters and
+ * says so when it was cut.
+ */
+export function renderApprovalDetail(summary, { fieldsBudget = DEFAULT_FIELDS_BUDGET } = {}) {
+  const s = summary || {};
+  const lines = [];
+
+  const verb = s.method && s.path ? `${s.method} ${s.path}` : (s.toolName || 'unknown tool');
+  const skillNote = s.skill ? ` (skill ${s.skill})` : '';
+  lines.push(`${s.agent || 'unknown'} wants to ${verb}${skillNote}`);
+
+  if (Array.isArray(s.identifiers) && s.identifiers.length > 0) {
+    lines.push('Identifiers:');
+    for (const ident of s.identifiers) {
+      lines.push(`  ${ident.name} = ${capIdentifier(ident.value)}  [${ident.source}]`);
+    }
+  } else {
+    lines.push('Identifiers: none found in the arguments');
+  }
+
+  if (Array.isArray(s.subject) && s.subject.length > 0) {
+    lines.push('Subject:');
+    for (const line of s.subject) lines.push(`  ${line}`);
+  }
+
+  const fieldLines = [];
+  if (s.parseError) fieldLines.push(`  (${s.parseError})`);
+  for (const f of (Array.isArray(s.fields) ? s.fields : [])) {
+    fieldLines.push(`  ${f.name} = ${f.value}`);
+  }
+  if (fieldLines.length > 0) {
+    lines.push('Arguments:');
+    let block = fieldLines.join('\n');
+    if (block.length > fieldsBudget) {
+      const omitted = block.length - fieldsBudget;
+      block = `${block.slice(0, Math.max(0, fieldsBudget))}\n  [+${omitted} chars not shown]`;
+    }
+    lines.push(block);
+  } else if (!s.parseError) {
+    lines.push('Arguments: none');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * The Telegram message. Fits TELEGRAM_TEXT_LIMIT by shrinking the Arguments
+ * block only; identifiers and subject are never traded for space.
+ */
+export function renderTelegramText({ id, tool, agent, riskLevel, summary, detail }) {
+  const header =
+    `⚠️ Approval needed [${id}]\n` +
+    `Tool: ${tool}\n` +
+    `Agent: ${agent}\n` +
+    `Risk: ${riskLevel}\n\n`;
+  const footer = `\n\nReply ✅ ${id} or ❌ ${id}. Auto-denies after 10 min.`;
+  const room = TELEGRAM_TEXT_LIMIT - header.length - footer.length;
+
+  let body = typeof detail === 'string' ? detail : renderApprovalDetail(summary);
+  if (body.length > room && summary) {
+    // Shrink the Arguments block until the whole message fits.
+    let budget = DEFAULT_FIELDS_BUDGET;
+    while (body.length > room && budget > 0) {
+      budget = Math.max(0, budget - 200);
+      body = renderApprovalDetail(summary, { fieldsBudget: budget });
+    }
+  }
+  if (body.length > room) {
+    // Only reachable with identifiers near MAX_IDENTIFIER_CHARS each. Cut
+    // the tail and say so rather than let Telegram reject the send silently.
+    body = `${body.slice(0, Math.max(0, room - 40))}\n[message cut to fit Telegram]`;
+  }
+  return `${header}${body}${footer}`;
+}

--- a/src/security/subject-resolvers.js
+++ b/src/security/subject-resolvers.js
@@ -1,0 +1,135 @@
+/**
+ * QuantumClaw Subject Resolvers
+ *
+ * A resolver turns the identifiers in a tool call into lines that say what
+ * they point at: for a position id, the market and whether it is open or
+ * closed. The approval prompt prints those lines under "Subject:" so the
+ * operator recognises what is being approved instead of matching a UUID by
+ * eye, and the post-error re-read (fix 4 of the 2026-09-10 audit) uses the
+ * same lookup to say what state a write left behind.
+ *
+ * Registration is by skill name, wired in src/index.js next to the approval
+ * notifier. This is deliberately NOT a skill-file convention: how a skill
+ * declares its identifiers and what resolves them is the subject of a
+ * separate design (fix 2 of the audit), and the one resolver registered
+ * today (trading-api position ids) is a stopgap that design replaces.
+ *
+ * Fail-VISIBLE, not fail-closed: a resolver that throws or times out yields a
+ * "subject lookup failed" line and the prompt is still shown. Refusing to
+ * prompt when the subject cannot be resolved belongs to the gate change in
+ * fix 2, where it can be applied consistently across every declared
+ * identifier rather than only where a resolver happens to exist.
+ */
+
+import { log } from '../core/logger.js';
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+const resolvers = new Map(); // skillName -> async ({ ...ctx }) => string[]
+
+export function registerSubjectResolver(skillName, fn) {
+  if (typeof skillName !== 'string' || !skillName) {
+    throw new Error('registerSubjectResolver: skillName must be a non-empty string');
+  }
+  if (typeof fn !== 'function') {
+    throw new Error(`registerSubjectResolver(${skillName}): fn must be a function`);
+  }
+  resolvers.set(skillName, fn);
+}
+
+export function hasSubjectResolver(skillName) {
+  return resolvers.has(skillName);
+}
+
+// Test-only. Production code never clears the table.
+export function __clearSubjectResolversForTests() {
+  resolvers.clear();
+}
+
+/**
+ * Resolve the subject for one tool call.
+ *
+ * @param {{ skill?: string|null, toolName: string, method?: string|null,
+ *           path?: string|null, identifiers: Array<{name,value,source}>,
+ *           args: object, baseUrl?: string|null }} ctx
+ * @param {{ timeoutMs?: number }} [opts]
+ * @returns {Promise<{ lines: string[], status: 'resolved'|'empty'|'failed'|'no_resolver'|'no_identifiers' }>}
+ */
+export async function resolveSubject(ctx, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  const skill = ctx?.skill;
+  const fn = skill ? resolvers.get(skill) : null;
+  if (!fn) return { lines: [], status: 'no_resolver' };
+  if (!Array.isArray(ctx.identifiers) || ctx.identifiers.length === 0) {
+    return { lines: [], status: 'no_identifiers' };
+  }
+
+  let timer = null;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`resolver timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  try {
+    const out = await Promise.race([fn(ctx), timeout]);
+    const lines = Array.isArray(out) ? out.filter(l => typeof l === 'string' && l.length > 0) : [];
+    return { lines, status: lines.length > 0 ? 'resolved' : 'empty' };
+  } catch (err) {
+    const msg = err?.message || String(err);
+    log.warn(`subject resolver for ${skill} failed: ${msg}`);
+    return { lines: [`subject lookup failed: ${msg}`], status: 'failed' };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolver for trading-api position ids. Reads GET /positions/{id} on the
+ * trade engine (any status; 404 when the value is not a position) and
+ * renders one line per position_id identifier.
+ *
+ * Exported so index.js can register it and tests can drive it against a
+ * stub fetch. `fetchImpl` defaults to global fetch.
+ */
+export function makeTradingApiPositionResolver({ fetchImpl = fetch, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  return async function resolveTradingApiSubject({ identifiers, baseUrl }) {
+    const lines = [];
+    if (!baseUrl) return ['subject lookup skipped: trading-api has no base URL'];
+    for (const ident of identifiers) {
+      if (ident.name !== 'position_id') continue;
+      const id = String(ident.value);
+      const url = `${baseUrl.replace(/\/$/, '')}/positions/${encodeURIComponent(id)}`;
+      let res;
+      try {
+        res = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
+      } catch (err) {
+        lines.push(`position ${id}: lookup failed (${err?.message || err})`);
+        continue;
+      }
+      const text = await res.text();
+      let json = null;
+      try { json = JSON.parse(text); } catch { /* not JSON */ }
+      if (res.status === 404) {
+        lines.push(`position ${id}: NOT FOUND in the trade engine (${json?.error || text.slice(0, 120)})`);
+        continue;
+      }
+      if (!res.ok) {
+        lines.push(`position ${id}: lookup failed (HTTP ${res.status})`);
+        continue;
+      }
+      const p = json?.position || {};
+      const status = String(json?.status || p.status || 'unknown').toUpperCase();
+      const question = json?.question || 'market unknown';
+      const parts = [
+        `position ${id}: ${status}`,
+        `${p.direction || '?'} on "${question}"`,
+        `opened ${p.opened_at || '?'}`,
+        `entry ${p.entry_price ?? '?'} x ${p.shares ?? '?'} shares for ${p.usdc_amount ?? '?'} USDC`,
+      ];
+      if (status === 'CLOSED') {
+        parts.push(`closed ${p.closed_at || '?'} at ${p.exit_price ?? '?'} for ${p.exit_usdc ?? '?'} USDC (pnl ${p.pnl ?? '?'})`);
+      }
+      const alerts = json?.unresolved_alert_count;
+      parts.push(alerts === null || alerts === undefined ? 'live alerts unknown' : `${alerts} live alert(s)`);
+      lines.push(parts.join(', '));
+    }
+    return lines;
+  };
+}

--- a/src/tools/executor.js
+++ b/src/tools/executor.js
@@ -20,6 +20,15 @@ const MAX_TOOL_ITERATIONS = 100;  // Safety limit — increased for AGEX securit
 const TOOL_TIMEOUT = 30000;      // 30s per tool call
 const LONG_RUNNING_TOOL_TIMEOUT = 11 * 60 * 1000;  // 11 min — covers 10-min approval gate + buffer
 
+// A skill HTTP write needs longer than TOOL_TIMEOUT, and must EXCEED the
+// registry's own SKILL_WRITE_TIMEOUT_MS (45s). Three nested deadlines govern
+// one write — this one, the registry's fetch abort, and the remote service's
+// internal timeout — and they only report the truth if they fire outermost
+// last. At 30s here the executor would abort a 45s fetch, discarding the
+// registry's re-read of what the write actually did (audit 2026-09-10).
+export const SKILL_WRITE_TOOL_TIMEOUT = 60000;
+const SKILL_WRITE_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
 const OWNER_TELEGRAM_CHAT_ID = 1375806243;
 const CREDITS_NOTIFY_COOLDOWN_MS = 6 * 60 * 60 * 1000;
 let _lastCreditsNotifyAt = 0;
@@ -269,14 +278,23 @@ export class ToolExecutor {
             // so their mutating verb is invisible to the gate unless we pass
             // it in. null for builtins/presets/unknown — gate ignores those.
             const httpMethod = this.tools?.getSkillToolMethod?.(call.name) ?? null;
-            const gateCheck = await this.approvalGate.check(call.name, call.args, { httpMethod });
+            // The endpoint, owning skill and base URL travel with the call so
+            // the approval prompt can name the identifiers (path params live
+            // in the path template) and look up what they point at. All null
+            // for builtins, which the gate and the summary both tolerate.
+            const callContext = {
+              httpMethod,
+              ...(this.tools?.getSkillToolContext?.(call.name) ?? {}),
+            };
+            const gateCheck = await this.approvalGate.check(call.name, call.args, callContext);
             if (gateCheck.requiresApproval) {
               log.warn(`🚨 Approval required: ${gateCheck.reason}`);
               const approval = await this.approvalGate.requestApproval(
                 options.agent || 'unknown',
                 call.name,
                 call.args,
-                gateCheck.riskLevel
+                gateCheck.riskLevel,
+                callContext
               );
               
               if (!approval.approved) {
@@ -317,7 +335,12 @@ export class ToolExecutor {
           // `longRunning: true` on their builtin definition. For those we use
           // an 11-minute ceiling so the 10-min approval timeout can fire first.
           const toolDef = this.tools._builtins?.get(call.name);
-          const toolTimeoutMs = toolDef?.longRunning ? LONG_RUNNING_TOOL_TIMEOUT : TOOL_TIMEOUT;
+          const isSkillWrite = SKILL_WRITE_METHODS.includes(
+            String(this.tools?.getSkillToolMethod?.(call.name) ?? '').toUpperCase()
+          );
+          let toolTimeoutMs = TOOL_TIMEOUT;
+          if (toolDef?.longRunning) toolTimeoutMs = LONG_RUNNING_TOOL_TIMEOUT;
+          else if (isSkillWrite) toolTimeoutMs = SKILL_WRITE_TOOL_TIMEOUT;
           const toolResult = await Promise.race([
             this.tools.executeTool(call.name, call.args, { channel: options.channel, userId: options.userId, agent: options.agent }),
             new Promise((_, reject) => setTimeout(() => reject(new Error('Tool timeout')), toolTimeoutMs))

--- a/src/tools/registry.js
+++ b/src/tools/registry.js
@@ -16,6 +16,8 @@
 
 import { MCPClient } from './mcp-client.js';
 import { log } from '../core/logger.js';
+import { extractIdentifiers } from '../security/approval-summary.js';
+import { hasSubjectResolver, resolveSubject } from '../security/subject-resolvers.js';
 import { appendFileSync, chmodSync, existsSync, mkdirSync, statSync } from 'fs';
 import { dirname, join } from 'path';
 import { homedir } from 'os';
@@ -599,6 +601,65 @@ export const PRESET_SERVERS = {
  * resolves to an empty string.
  */
 const CONFIG_TEMPLATE_ALLOWLIST = new Set(['dashboard.authToken']);
+
+// Skill HTTP timeouts. The WRITE budget must exceed the slowest response a
+// write endpoint can legitimately produce, or the client reports a failure
+// the server went on to commit. The trade engine is the binding case: 20s per
+// Supabase round trip and two of them before a manual-close commits, so 15s
+// (the pre-2026-09-10 value for both) aborted first. It must also stay under
+// the executor's per-tool ceiling for skill writes, or the executor's own
+// race would abort even earlier and re-introduce the same gap one layer up.
+// See SKILL_WRITE_TOOL_TIMEOUT in src/tools/executor.js.
+export const SKILL_READ_TIMEOUT_MS = 15000;
+export const SKILL_WRITE_TIMEOUT_MS = 45000;
+const SKILL_WRITE_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
+/**
+ * Re-read the subject of a write whose outcome is unknown.
+ *
+ * Reuses the approval prompt's subject resolver: the same lookup that says
+ * "position X is OPEN on market Y" before the write is what says whether the
+ * write landed after one. No new per-skill convention, and a skill with no
+ * resolver gets a sentence saying plainly that the state is unverified.
+ *
+ * A module-level function, not a method, on purpose: it needs no instance
+ * state, and _executeAPITool is invoked via .call() with partial `this`
+ * objects in several tests. A method would throw "not a function" INSIDE the
+ * error path and replace the original transport error with its own, which is
+ * the exact failure mode this code exists to prevent.
+ *
+ * Never throws for the same reason.
+ *
+ * @returns {Promise<string>} a sentence for the tool-result message
+ */
+export async function observeAfterWrite(preset, toolDef, args, cause) {
+  try {
+    const skill = preset?.name?.startsWith('skill:') ? preset.name.slice(6) : null;
+    if (!skill || !hasSubjectResolver(skill)) {
+      return 'State NOT verified: no re-read is available for this skill, so check the target by hand before retrying.';
+    }
+    const { identifiers } = extractIdentifiers({ args, path: toolDef?.endpoint || toolDef?.path });
+    if (identifiers.length === 0) {
+      return 'State NOT verified: the call named no identifier to re-read.';
+    }
+    const observed = await resolveSubject({
+      skill,
+      toolName: toolDef?.name,
+      method: toolDef?.method,
+      path: toolDef?.endpoint || toolDef?.path,
+      identifiers,
+      args,
+      baseUrl: preset?.baseUrl || null,
+    });
+    if (observed.status === 'resolved') {
+      return `Re-read after the failure says: ${observed.lines.join('; ')}. Report THAT state, not the error, and do not retry until it is understood.`;
+    }
+    return `State NOT verified: the re-read did not resolve (${observed.status}${observed.lines.length ? ': ' + observed.lines.join('; ') : ''}).`;
+  } catch (err) {
+    log.warn(`observeAfterWrite failed after ${cause?.message}: ${err.message}`);
+    return `State NOT verified: the re-read itself failed (${err.message}).`;
+  }
+}
 
 export class ToolRegistry {
   constructor(config, secrets) {
@@ -1525,11 +1586,52 @@ export class ToolRegistry {
           headers['Content-Type'] = 'application/json';
         }
 
-        const res = await fetch(fetchUrl, { method, headers, body, signal: AbortSignal.timeout(15000) });
+        // A WRITE gets longer than a read, because the client must not give
+        // up before the server can finish. The trade engine allows 20s per
+        // Supabase round trip (src/trade_engine/database.py REQUEST_TIMEOUT)
+        // and a manual-close makes two of them before the write commits, so a
+        // 15s client abort could report failure over a committed close and
+        // nothing re-read the row. Reproduced 2026-09-10: the client aborted,
+        // the tool result became error:true, and the position closed anyway.
+        //
+        // This bound is a probability reduction, not a guarantee: no client
+        // timeout can prove a server did not commit. The re-read below is the
+        // part that makes the REPORT correct.
+        const isWrite = SKILL_WRITE_METHODS.includes(method.toUpperCase());
+        const timeoutMs = isWrite ? SKILL_WRITE_TIMEOUT_MS : SKILL_READ_TIMEOUT_MS;
+
+        let res;
+        try {
+          res = await fetch(fetchUrl, { method, headers, body, signal: AbortSignal.timeout(timeoutMs) });
+        } catch (err) {
+          if (!isWrite) throw err;
+          // The write's outcome is UNKNOWN: the request may have committed.
+          // Say so, and attach whatever the store reports now.
+          const observed = await observeAfterWrite(preset, toolDef, args, err);
+          const unknownErr = new Error(
+            `API error (${preset.name}/${toolName}): ${method} ${endpoint} outcome UNKNOWN ` +
+            `after ${timeoutMs}ms: ${err.message}. The write may have been applied. ${observed}`
+          );
+          unknownErr.rethrow = true;
+          throw unknownErr;
+        }
+
         const text = await res.text();
         if (!res.ok) {
           // Must escape the catch-all below (which returns strings) so the
           // executor loop records error:true instead of a success-shaped result.
+          //
+          // A 5xx is the same unknown-outcome case as a timeout: the server
+          // reached the handler and may have committed before failing. A 4xx
+          // is a refusal the server states, so it needs no re-read.
+          if (isWrite && res.status >= 500) {
+            const observed = await observeAfterWrite(preset, toolDef, args, new Error(`HTTP ${res.status}`));
+            const serverErr = new Error(
+              `${preset.name} HTTP ${res.status} on ${method} ${endpoint}, outcome UNKNOWN: ${text.slice(0, 300)}. ${observed}`
+            );
+            serverErr.rethrow = true;
+            throw serverErr;
+          }
           const httpErr = new Error(`${preset.name} HTTP ${res.status}: ${text.slice(0, 500)}`);
           httpErr.rethrow = true;
           throw httpErr;
@@ -1598,6 +1700,31 @@ export class ToolRegistry {
     if (!entry) return null;
     if (!entry.preset?.name?.startsWith('skill:')) return null;
     return String(entry.toolDef?.method || 'GET').toUpperCase();
+  }
+
+  /**
+   * Per-call metadata for a skill-parsed tool: the endpoint template, the
+   * owning skill and its base URL.
+   *
+   * The approval prompt needs all three. The path template is the only place
+   * that records which argument is a path identifier (`{{position_id}}`);
+   * the skill name selects a subject resolver; the base URL is what that
+   * resolver reads. Same `skill:` discriminator as getSkillToolMethod, so
+   * builtins, MCP tools and non-skill presets all yield an empty object.
+   *
+   * @param {string} toolName
+   * @returns {{ path?: string, skill?: string, baseUrl?: string }}
+   */
+  getSkillToolContext(toolName) {
+    const entry = this._apiTools.get(toolName);
+    if (!entry) return {};
+    const presetName = entry.preset?.name;
+    if (!presetName?.startsWith('skill:')) return {};
+    return {
+      path: entry.toolDef?.endpoint || entry.toolDef?.path || null,
+      skill: presetName.slice(6) || null,
+      baseUrl: entry.preset?.baseUrl || null,
+    };
   }
 
   /**

--- a/tests/approval-summary.test.js
+++ b/tests/approval-summary.test.js
@@ -1,0 +1,443 @@
+/**
+ * Approval prompt — the identifiers must be visible, whole, and first.
+ *
+ * The 2026-08-27 incident: three approval prompts for one close, each with a
+ * different identifier, one of them composed from chat text. The prompt was
+ * built as `${toolName}(${JSON.stringify(args).slice(0, 200)})` and then
+ * sliced to 200 again by the notifier, including the 64-character tool name.
+ * A skill tool's whole body travels as one escaped JSON string named `data`,
+ * so at most 189 body characters reached the Detail block and 124 the Action
+ * line. Live approvals rows 122, 123 and 125 are all cut mid-JSON, and with
+ * position_id last in the body it vanished entirely.
+ *
+ * These tests pin the property, not the shape: a value the OLD renderer
+ * could not show must be present in the NEW one, character for character,
+ * at body sizes where truncation is guaranteed. Fixtures use distinct
+ * non-default values (a 96-char note, a 220-char note, ids in first and last
+ * position) so a renderer that happened to show a short payload cannot pass.
+ *
+ * Run: node tests/approval-summary.test.js
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ExecApprovals } from '../src/security/approvals.js';
+import { ApprovalGate } from '../src/security/approval-gate.js';
+import { ToolRegistry } from '../src/tools/registry.js';
+import { ToolExecutor } from '../src/tools/executor.js';
+import {
+  buildApprovalSummary,
+  extractIdentifiers,
+  pathParamNames,
+  renderApprovalDetail,
+  renderTelegramText,
+  MAX_IDENTIFIER_CHARS,
+  TELEGRAM_TEXT_LIMIT,
+} from '../src/security/approval-summary.js';
+import {
+  registerSubjectResolver,
+  resolveSubject,
+  makeTradingApiPositionResolver,
+  __clearSubjectResolversForTests,
+} from '../src/security/subject-resolvers.js';
+
+let passed = 0;
+let failed = 0;
+function check(label, cond, detail = '') {
+  if (cond) { console.log(`  ✓ ${label}`); passed++; }
+  else { console.error(`  ✗ ${label}${detail ? ' — ' + detail : ''}`); failed++; }
+}
+
+const CLOSE_TOOL = 'charlie__trading-api__trading-api__create_positions_manual_close';
+const REAL_ID = 'b3cecdef-9948-40c7-9691-1b9c4ce579bc';
+const COMPOSED_ID = 'solana-110-aug-2026';
+
+// The exact payload behind live approval row 123 (2026-08-27 20:57:57).
+const INCIDENT_DATA = '{"position_id": "solana-110-aug-2026", "exit_price": 0.863, "exit_usdc": 17.86, "exit_reason": "manual close", "note": "Solana $110 August target - position closed by Tyson"}';
+
+// The renderer this replaces, reproduced so the tests measure a real
+// difference rather than asserting against a remembered one.
+function oldRender({ id, tool, agent, riskLevel, args }) {
+  const action = `${tool}(${JSON.stringify(args).slice(0, 200)})`;
+  const detail = `Agent ${agent} wants to execute: ${action}`;
+  return `⚠️ Approval needed [${id}]\nTool: ${tool}\nAgent: ${agent}\nRisk: ${riskLevel}\n` +
+    `Action: ${String(action).slice(0, 200)}\n` +
+    `\nDetail:\n${String(detail).slice(0, 500)}\n` +
+    `\nReply ✅ ${id} or ❌ ${id} — auto-denies after 10 min.`;
+}
+
+async function main() {
+  const dir = mkdtempSync(join(tmpdir(), 'qclaw-approval-summary-'));
+
+  // ── 1. extractIdentifiers ────────────────────────────────────
+  const parsed = extractIdentifiers({
+    args: { data: INCIDENT_DATA },
+    path: '/positions/manual-close',
+  });
+  check('body position_id is classified as an identifier',
+    parsed.identifiers.some(i => i.name === 'position_id' && i.value === COMPOSED_ID),
+    JSON.stringify(parsed.identifiers));
+  check('non-identifier money fields stay under fields',
+    parsed.fields.some(f => f.name === 'exit_usdc' && f.value === '17.86')
+      && parsed.fields.some(f => f.name === 'exit_price'),
+    JSON.stringify(parsed.fields));
+  check('no false parse error on valid JSON', parsed.parseError === null);
+
+  const pathParsed = extractIdentifiers({
+    args: { position_id: REAL_ID, data: '{"hold": true}' },
+    path: '/positions/{{position_id}}/hold',
+  });
+  check('path param is an identifier tagged source=path',
+    pathParsed.identifiers.length === 1
+      && pathParsed.identifiers[0].source === 'path'
+      && pathParsed.identifiers[0].value === REAL_ID,
+    JSON.stringify(pathParsed.identifiers));
+  check('pathParamNames ignores {{secrets.*}} and {{config.*}}',
+    JSON.stringify(pathParamNames('/contacts/?locationId={{secrets.x}}&t={{config.y}}&c={{contact_id}}')) === '["contact_id"]');
+
+  const urlParsed = extractIdentifiers({ args: { data: '{"market_url": "https://polymarket.com/event/x"}' } });
+  check('market_url is treated as an identifier (row 125 keyed on it)',
+    urlParsed.identifiers.some(i => i.name === 'market_url'));
+
+  const badJson = extractIdentifiers({ args: { data: 'this is not json' } });
+  check('unparseable data reports parseError and still shows the raw value',
+    badJson.parseError === 'data is not valid JSON'
+      && badJson.fields.some(f => f.value === 'this is not json'));
+
+  const ghlParsed = extractIdentifiers({
+    args: { contact_id: 'ocQHyuzHvysMo5N5VsXc', data: '{"firstName":"A"}' },
+    path: '/contacts/{{contact_id}}',
+  });
+  check('GHL contact_id path identifier is extracted the same way',
+    ghlParsed.identifiers.length === 1 && ghlParsed.identifiers[0].name === 'contact_id');
+
+  // ── 2. The regression the incident is named for ──────────────
+  // position_id LAST in the body, plus a long note: the old renderer cannot
+  // show the id at any of its two cut points; the new one must.
+  const idLastArgs = {
+    data: JSON.stringify({
+      exit_price: 0.863,
+      exit_usdc: 17.86,
+      exit_reason: 'manual close',
+      note: 'Solana above 110 by end of August, closed by hand on Polymarket this evening after the take-profit alert fired',
+      position_id: REAL_ID,
+    }),
+  };
+  const oldText = oldRender({ id: 124, tool: CLOSE_TOOL, agent: 'charlie', riskLevel: 'medium', args: idLastArgs });
+  check('PRECONDITION: the old renderer hides the id entirely when it is last',
+    !oldText.includes(REAL_ID),
+    'fixture is too small to force truncation — the test would prove nothing');
+
+  const idLastSummary = buildApprovalSummary({
+    agent: 'charlie', toolName: CLOSE_TOOL, toolArgs: idLastArgs,
+    context: { httpMethod: 'POST', path: '/positions/manual-close', skill: 'trading-api' },
+  });
+  const idLastText = renderTelegramText({
+    id: 124, tool: CLOSE_TOOL, agent: 'charlie', riskLevel: 'medium',
+    summary: idLastSummary, detail: renderApprovalDetail(idLastSummary),
+  });
+  check('NEW: the id is present in full when it is last in the body',
+    idLastText.includes(REAL_ID), idLastText);
+  check('NEW: the id appears before the note it was buried behind',
+    idLastText.indexOf(REAL_ID) < idLastText.indexOf('closed by hand on Polymarket'));
+
+  // Field order must not change what the operator sees.
+  const idFirstArgs = {
+    data: JSON.stringify({
+      position_id: REAL_ID,
+      exit_price: 0.863,
+      exit_usdc: 17.86,
+      exit_reason: 'manual close',
+      note: 'Solana above 110 by end of August, closed by hand on Polymarket this evening after the take-profit alert fired',
+    }),
+  };
+  const idFirstSummary = buildApprovalSummary({
+    agent: 'charlie', toolName: CLOSE_TOOL, toolArgs: idFirstArgs,
+    context: { httpMethod: 'POST', path: '/positions/manual-close', skill: 'trading-api' },
+  });
+  const identLine = (t) => t.split('\n').find(l => l.includes('position_id ='));
+  check('rendering is independent of the field order the model chose',
+    identLine(renderApprovalDetail(idFirstSummary)) === identLine(renderApprovalDetail(idLastSummary)),
+    `${identLine(renderApprovalDetail(idFirstSummary))} vs ${identLine(renderApprovalDetail(idLastSummary))}`);
+
+  // ── 3. Identifiers survive a payload far past any cut ─────────
+  const hugeArgs = {
+    data: JSON.stringify({
+      exit_price: 0.863,
+      note: 'x'.repeat(4000),
+      position_id: REAL_ID,
+    }),
+  };
+  const hugeSummary = buildApprovalSummary({
+    agent: 'charlie', toolName: CLOSE_TOOL, toolArgs: hugeArgs,
+    context: { httpMethod: 'POST', path: '/positions/manual-close', skill: 'trading-api' },
+  });
+  const hugeText = renderTelegramText({
+    id: 200, tool: CLOSE_TOOL, agent: 'charlie', riskLevel: 'medium',
+    summary: hugeSummary, detail: renderApprovalDetail(hugeSummary),
+  });
+  check('4000-char note: identifier still shown in full',
+    hugeText.includes(REAL_ID));
+  check('4000-char note: message fits the Telegram limit',
+    hugeText.length <= TELEGRAM_TEXT_LIMIT, `length ${hugeText.length}`);
+  check('4000-char note: truncation is declared, not silent',
+    /not shown|cut to fit/.test(hugeText), hugeText.slice(-200));
+  check('4000-char note: the reply instruction survives',
+    hugeText.includes('Reply ✅ 200'));
+
+  // A hostile identifier cannot crowd the message out.
+  const hostileSummary = buildApprovalSummary({
+    agent: 'charlie', toolName: CLOSE_TOOL,
+    toolArgs: { data: JSON.stringify({ position_id: 'z'.repeat(9000) }) },
+    context: { httpMethod: 'POST', path: '/positions/manual-close', skill: 'trading-api' },
+  });
+  const hostileText = renderTelegramText({
+    id: 201, tool: CLOSE_TOOL, agent: 'charlie', riskLevel: 'medium',
+    summary: hostileSummary, detail: renderApprovalDetail(hostileSummary),
+  });
+  check('a 9000-char identifier is capped and the cap is declared',
+    hostileText.includes(`identifier longer than ${MAX_IDENTIFIER_CHARS}`)
+      && hostileText.length <= TELEGRAM_TEXT_LIMIT,
+    `length ${hostileText.length}`);
+
+  // ── 4. Absence is stated ─────────────────────────────────────
+  const noIdSummary = buildApprovalSummary({
+    agent: 'charlie', toolName: 'charlie__trading-api__trading-api__create_monitor_run',
+    toolArgs: {}, context: { httpMethod: 'POST', path: '/monitor/run', skill: 'trading-api' },
+  });
+  check('no identifiers is printed explicitly, not left blank',
+    renderApprovalDetail(noIdSummary).includes('Identifiers: none found'));
+
+  // ── 5. Subject resolution ────────────────────────────────────
+  __clearSubjectResolversForTests();
+  const engineRow = {
+    position: {
+      id: REAL_ID, direction: 'YES', entry_price: 0.483, shares: 20.7,
+      usdc_amount: 10.36, opened_at: '2026-08-27T12:15:30+00:00', status: 'open',
+    },
+    status: 'open',
+    question: 'Will Solana reach $110 in August?',
+    unresolved_alert_count: 1,
+  };
+  const fetchOk = async (url) => ({
+    ok: true, status: 200, text: async () => JSON.stringify(engineRow), url,
+  });
+  registerSubjectResolver('trading-api', makeTradingApiPositionResolver({ fetchImpl: fetchOk }));
+
+  const resolved = await resolveSubject({
+    skill: 'trading-api', toolName: CLOSE_TOOL, identifiers: [{ name: 'position_id', value: REAL_ID, source: 'body' }],
+    args: {}, baseUrl: 'http://localhost:4003',
+  });
+  check('subject names the market and the open/closed state',
+    resolved.status === 'resolved'
+      && resolved.lines[0].includes('Will Solana reach $110 in August?')
+      && resolved.lines[0].includes('OPEN'),
+    JSON.stringify(resolved.lines));
+  check('subject reports the live alert count',
+    resolved.lines[0].includes('1 live alert'));
+
+  const fetch404 = async () => ({
+    ok: false, status: 404,
+    text: async () => JSON.stringify({ error: `no position with id ${COMPOSED_ID}` }),
+  });
+  registerSubjectResolver('trading-api', makeTradingApiPositionResolver({ fetchImpl: fetch404 }));
+  const unresolvable = await resolveSubject({
+    skill: 'trading-api', toolName: CLOSE_TOOL,
+    identifiers: [{ name: 'position_id', value: COMPOSED_ID, source: 'body' }],
+    args: {}, baseUrl: 'http://localhost:4003',
+  });
+  check('a composed id resolves to NOT FOUND, stated in the prompt',
+    unresolvable.lines[0].includes('NOT FOUND'), JSON.stringify(unresolvable.lines));
+
+  registerSubjectResolver('trading-api', async () => { throw new Error('engine down'); });
+  const failedLookup = await resolveSubject({
+    skill: 'trading-api', toolName: CLOSE_TOOL,
+    identifiers: [{ name: 'position_id', value: REAL_ID, source: 'body' }],
+    args: {}, baseUrl: 'http://localhost:4003',
+  });
+  check('a failed lookup is labelled, not rendered as a clean subject',
+    failedLookup.status === 'failed' && failedLookup.lines[0].includes('subject lookup failed'),
+    JSON.stringify(failedLookup));
+
+  registerSubjectResolver('trading-api', () => new Promise(() => {}));
+  const timedOut = await resolveSubject({
+    skill: 'trading-api', toolName: CLOSE_TOOL,
+    identifiers: [{ name: 'position_id', value: REAL_ID, source: 'body' }],
+    args: {}, baseUrl: 'http://localhost:4003',
+  }, { timeoutMs: 50 });
+  check('a hanging resolver times out and is labelled',
+    timedOut.status === 'failed' && timedOut.lines[0].includes('timed out'),
+    JSON.stringify(timedOut));
+
+  const noResolver = await resolveSubject({
+    skill: 'ghl-fsc', toolName: 'charlie__ghl-fsc__ghl-fsc__update_contacts_id',
+    identifiers: [{ name: 'contact_id', value: 'abc' }], args: {},
+  });
+  check('a skill with no resolver yields no_resolver, not an error',
+    noResolver.status === 'no_resolver' && noResolver.lines.length === 0);
+
+  // ── 6. End to end through the gate ───────────────────────────
+  __clearSubjectResolversForTests();
+  registerSubjectResolver('trading-api', makeTradingApiPositionResolver({ fetchImpl: fetchOk }));
+  const approvals = new ExecApprovals({ _dir: dir });
+  approvals.attach(null);
+  const gate = new ApprovalGate(approvals);
+  const notified = [];
+  gate.setNotifier(async (payload) => { notified.push(payload); });
+
+  const p = gate.requestApproval('charlie', CLOSE_TOOL, idLastArgs, 'medium', {
+    httpMethod: 'POST', path: '/positions/manual-close', skill: 'trading-api',
+    baseUrl: 'http://localhost:4003',
+  });
+  await new Promise(r => setImmediate(r));
+  await new Promise(r => setImmediate(r));
+  check('gate fired the notifier once', notified.length === 1, `got ${notified.length}`);
+  check('notifier payload carries the structured summary',
+    notified[0]?.summary?.identifiers?.[0]?.value === REAL_ID,
+    JSON.stringify(notified[0]?.summary?.identifiers));
+  check('stored detail contains the identifier in full',
+    String(notified[0]?.detail || '').includes(REAL_ID));
+  check('stored detail contains the resolved subject',
+    String(notified[0]?.detail || '').includes('Will Solana reach $110 in August?'));
+  check('action keeps its compact one-line shape for existing consumers',
+    String(notified[0]?.action || '').startsWith(`${CLOSE_TOOL}(`)
+      && !String(notified[0]?.action || '').includes('\n'),
+    notified[0]?.action);
+
+  const row = approvals.recent(1)[0];
+  check('the approvals row stores the identifier-first detail',
+    String(row?.detail || '').includes(REAL_ID) && String(row.detail).includes('Identifiers:'),
+    String(row?.detail || '').slice(0, 200));
+
+  approvals.approve(notified[0].id, 'tg:test');
+  const result = await p;
+  check('the approval still resolves through the normal path', result?.approved === true);
+
+  // ── 7. The executor seam actually carries path/skill/baseUrl ─
+  // Without this the gate is correct and unreachable: getSkillToolContext
+  // could be unwired and every assertion above would still pass, because
+  // they hand the context to requestApproval by hand.
+  const seamRegistry = new ToolRegistry({}, {});
+  const seamSkill = { name: 'trading-api', baseUrl: 'http://localhost:4003', headers: {} };
+  seamRegistry.registerSkillTool('charlie', 'trading-api', seamSkill, {
+    name: 'trading-api__create_positions_manual_close',
+    method: 'POST',
+    path: '/positions/manual-close',
+    description: 'close',
+    inputSchema: { type: 'object', properties: {} },
+  });
+  seamRegistry.registerSkillTool('charlie', 'trading-api', seamSkill, {
+    name: 'trading-api__create_positions_id_hold',
+    method: 'POST',
+    path: '/positions/{{position_id}}/hold',
+    description: 'hold',
+    inputSchema: { type: 'object', properties: {} },
+  });
+  seamRegistry.registerBuiltin('read_file', { description: 'r', fn: async () => 'ok', scope: 'shared' });
+  // A non-skill API preset. This one lives in _apiTools alongside the skill
+  // tools, so it is the case that actually exercises the `skill:` prefix
+  // discriminator; a builtin is filtered out one line earlier by the
+  // entry lookup and proves nothing about it.
+  seamRegistry._apiTools.set('NewsAPI__get_headlines', {
+    preset: { name: 'NewsAPI', type: 'api', baseUrl: 'https://newsapi.org/v2' },
+    toolDef: { name: 'get_headlines', method: 'GET', path: '/top-headlines' },
+    scope: 'shared',
+  });
+  // A preset whose display name merely CONTAINS "skill", lower-case and NOT
+  // at the start. The contract is a `skill:` PREFIX (registerSkillTool builds
+  // it), and only a fixture like this can tell a prefix test from a substring
+  // test: with NewsAPI alone, startsWith('skill:') and includes('skill')
+  // agree on every input. Case matters too — a capitalised "Skillshare" is
+  // still invisible to includes('skill'), so the probe must be lower-case.
+  seamRegistry._apiTools.set('Courses__get_courses', {
+    preset: { name: 'courses via skillshare', type: 'api', baseUrl: 'https://api.skillshare.invalid' },
+    toolDef: { name: 'get_courses', method: 'GET', path: '/courses' },
+    scope: 'shared',
+  });
+
+  const ctx = seamRegistry.getSkillToolContext('charlie__trading-api__trading-api__create_positions_manual_close');
+  check('registry exposes path, skill and baseUrl for a skill tool',
+    ctx.path === '/positions/manual-close' && ctx.skill === 'trading-api'
+      && ctx.baseUrl === 'http://localhost:4003',
+    JSON.stringify(ctx));
+  check('registry returns {} for a builtin (not in _apiTools at all)',
+    JSON.stringify(seamRegistry.getSkillToolContext('read_file')) === '{}');
+  check('registry returns {} for a NON-SKILL preset that does live in _apiTools',
+    JSON.stringify(seamRegistry.getSkillToolContext('NewsAPI__get_headlines')) === '{}',
+    JSON.stringify(seamRegistry.getSkillToolContext('NewsAPI__get_headlines')));
+  check('registry returns {} for an unknown tool name',
+    JSON.stringify(seamRegistry.getSkillToolContext('does__not__exist')) === '{}');
+  check('registry returns {} for a preset merely NAMED like a skill (prefix, not substring)',
+    JSON.stringify(seamRegistry.getSkillToolContext('Courses__get_courses')) === '{}',
+    JSON.stringify(seamRegistry.getSkillToolContext('Courses__get_courses')));
+
+  const seamApprovals = new ExecApprovals({ _dir: dir });
+  seamApprovals.attach(null);
+  const seamGate = new ApprovalGate(seamApprovals);
+  let seenContext = null;
+  seamGate.requestApproval = async (agent, toolName, toolArgs, riskLevel, context) => {
+    seenContext = context;
+    return { approved: false, reason: 'denied-by-test' };
+  };
+  const seamExecutor = new ToolExecutor({ primary: { provider: 'anthropic', model: 't' } },
+    seamRegistry, { approvalGate: seamGate });
+  let seamTurn = 0;
+  seamExecutor._completionWithTools = async () => {
+    seamTurn++;
+    if (seamTurn === 1) {
+      return {
+        content: '',
+        toolCalls: [{
+          id: 't1',
+          name: 'charlie__trading-api__trading-api__create_positions_manual_close',
+          args: { data: JSON.stringify({ position_id: REAL_ID, exit_price: 0.863 }) },
+        }],
+        usage: {}, model: 't',
+      };
+    }
+    return { content: 'done', toolCalls: [], usage: {}, model: 't' };
+  };
+  seamExecutor._appendAnthropicToolLoop = (msgs) => msgs;
+  await seamExecutor.run([{ role: 'user', content: 'close it' }], {});
+
+  check('executor passes the endpoint path through to requestApproval',
+    seenContext?.path === '/positions/manual-close', JSON.stringify(seenContext));
+  check('executor passes the owning skill through to requestApproval',
+    seenContext?.skill === 'trading-api', JSON.stringify(seenContext));
+  check('executor passes the base URL through, so the subject can be resolved',
+    seenContext?.baseUrl === 'http://localhost:4003', JSON.stringify(seenContext));
+  check('executor still passes httpMethod (existing gate behaviour intact)',
+    seenContext?.httpMethod === 'POST', JSON.stringify(seenContext));
+
+  // ── 8. shell_exec keeps its own detail (no summary) ──────────
+  const shellNotified = [];
+  const gate2 = new ApprovalGate(approvals);
+  gate2.setNotifier(async (payload) => { shellNotified.push(payload); });
+  const p2 = gate2.requestInlineApproval({
+    agent: 'charlie', tool: 'shell_exec', action: 'rm -rf /tmp/x',
+    detail: 'Agent charlie wants to run: rm -rf /tmp/x', riskLevel: 'high',
+  });
+  await new Promise(r => setImmediate(r));
+  await new Promise(r => setImmediate(r));
+  check('inline callers without a summary still notify',
+    shellNotified.length === 1 && shellNotified[0].summary === null,
+    JSON.stringify(shellNotified[0]?.summary));
+  const shellText = renderTelegramText({
+    id: shellNotified[0].id, tool: 'shell_exec', agent: 'charlie',
+    riskLevel: 'high', summary: null, detail: shellNotified[0].detail,
+  });
+  check('a summary-less prompt still renders the command and the reply line',
+    shellText.includes('rm -rf /tmp/x') && shellText.includes('Reply ✅'));
+  approvals.deny(shellNotified[0].id, 'tg:test', 'no');
+  await p2;
+
+  rmSync(dir, { recursive: true, force: true });
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/skill-write-timeout.test.js
+++ b/tests/skill-write-timeout.test.js
@@ -1,0 +1,251 @@
+/**
+ * Skill HTTP writes — the client must not report a failure the server
+ * committed, and must never leave the outcome unstated.
+ *
+ * The defect (audit 2026-09-10, reproduced in a real uvicorn process):
+ * registry.js aborted every skill fetch at 15s while the trade engine allows
+ * 20s per Supabase round trip and makes two of them before a manual-close
+ * commits. The client aborted, the tool result became error:true, Charlie was
+ * told the call failed, and the position closed two seconds later. Nothing
+ * re-read the row, so the report to Tyson would have been confidently wrong.
+ *
+ * Two properties are pinned here, and they are different in kind:
+ *
+ *   1. ORDERING. Three nested deadlines govern one write: the executor's
+ *      per-tool cap, the registry's fetch abort, and the remote service's own
+ *      timeout. They only report the truth if the outer one fires LAST. This
+ *      is asserted as an inequality between the constants, not by waiting.
+ *
+ *   2. RE-READ. Ordering is a probability reduction; no client timeout can
+ *      prove a server did not commit. So an unknown outcome must SAY it is
+ *      unknown and carry whatever the store reports now. A test that only
+ *      checked for the word "timeout" would pass against the old code, so
+ *      these assert the observed STATE reaches the tool result.
+ *
+ * Run: node tests/skill-write-timeout.test.js
+ */
+
+import {
+  ToolRegistry,
+  SKILL_READ_TIMEOUT_MS,
+  SKILL_WRITE_TIMEOUT_MS,
+} from '../src/tools/registry.js';
+import { ToolExecutor, SKILL_WRITE_TOOL_TIMEOUT } from '../src/tools/executor.js';
+import {
+  registerSubjectResolver,
+  __clearSubjectResolversForTests,
+} from '../src/security/subject-resolvers.js';
+
+let passed = 0;
+let failed = 0;
+function check(label, cond, detail = '') {
+  if (cond) { console.log(`  ✓ ${label}`); passed++; }
+  else { console.error(`  ✗ ${label}${detail ? ' — ' + detail : ''}`); failed++; }
+}
+
+const REAL_ID = 'b3cecdef-9948-40c7-9691-1b9c4ce579bc';
+const PRESET = { name: 'skill:trading-api', baseUrl: 'http://localhost:4003', headers: {} };
+const CLOSE_DEF = {
+  name: 'trading-api__create_positions_manual_close',
+  method: 'POST',
+  path: '/positions/manual-close',
+};
+const READ_DEF = { name: 'trading-api__get_positions', method: 'GET', path: '/positions' };
+const CLOSE_ARGS = { data: JSON.stringify({ position_id: REAL_ID, exit_price: 0.863, exit_usdc: 17.86 }) };
+
+// Deliberately the same partial `this` the pre-existing skill-executor test
+// uses. The re-read helper must work from it: a method that threw "not a
+// function" here would swallow the transport error it was meant to explain.
+const fakeThis = {
+  secrets: { get: async () => 'k' },
+  config: {},
+  _resolveConfigTemplates: ToolRegistry.prototype._resolveConfigTemplates,
+};
+const exec = (preset, def, args) =>
+  ToolRegistry.prototype._executeAPITool.call(fakeThis, preset, def, args);
+
+const realFetch = global.fetch;
+let lastSignalTimeouts = [];
+
+async function main() {
+  // ── 1. The ordering invariant ────────────────────────────────
+  check('registry: a write is allowed longer than a read',
+    SKILL_WRITE_TIMEOUT_MS > SKILL_READ_TIMEOUT_MS,
+    `write ${SKILL_WRITE_TIMEOUT_MS} vs read ${SKILL_READ_TIMEOUT_MS}`);
+
+  // The trade engine's own budget, from src/trade_engine/database.py:
+  // REQUEST_TIMEOUT = httpx.Timeout(20.0) and manual-close makes two calls
+  // before it commits. The client must outlast that.
+  const ENGINE_WORST_CASE_MS = 2 * 20000;
+  check('registry: a write outlasts the trade engine committing a close',
+    SKILL_WRITE_TIMEOUT_MS > ENGINE_WORST_CASE_MS,
+    `write ${SKILL_WRITE_TIMEOUT_MS} vs engine ${ENGINE_WORST_CASE_MS}`);
+
+  check('executor: the per-tool cap outlasts the registry fetch abort',
+    SKILL_WRITE_TOOL_TIMEOUT > SKILL_WRITE_TIMEOUT_MS,
+    `executor ${SKILL_WRITE_TOOL_TIMEOUT} vs registry ${SKILL_WRITE_TIMEOUT_MS}`);
+
+  // ── 2. The deadline actually reaches fetch ───────────────────
+  // The constants above are inert unless the call site uses them, and
+  // "a signal is present" cannot tell 45s from 15s. Intercept
+  // AbortSignal.timeout and read the milliseconds the call site asked for.
+  const realTimeoutFactory = AbortSignal.timeout.bind(AbortSignal);
+  lastSignalTimeouts = [];
+  AbortSignal.timeout = (ms) => { lastSignalTimeouts.push(ms); return realTimeoutFactory(ms); };
+  global.fetch = async () => ({ ok: true, status: 200, text: async () => '{"ok":true}' });
+  try {
+    await exec(PRESET, CLOSE_DEF, CLOSE_ARGS);
+    await exec(PRESET, READ_DEF, {});
+  } finally {
+    AbortSignal.timeout = realTimeoutFactory;
+  }
+  check('a WRITE is given the write budget, not the read budget',
+    lastSignalTimeouts[0] === SKILL_WRITE_TIMEOUT_MS,
+    `asked for ${lastSignalTimeouts[0]}ms, expected ${SKILL_WRITE_TIMEOUT_MS}`);
+  check('a READ is still given the read budget (writes did not widen everything)',
+    lastSignalTimeouts[1] === SKILL_READ_TIMEOUT_MS,
+    `asked for ${lastSignalTimeouts[1]}ms, expected ${SKILL_READ_TIMEOUT_MS}`);
+  check('the two budgets differ at the call site, not just in the constants',
+    lastSignalTimeouts[0] !== lastSignalTimeouts[1],
+    JSON.stringify(lastSignalTimeouts));
+
+  // ── 3. A timed-out write reports UNKNOWN and re-reads ────────
+  __clearSubjectResolversForTests();
+  let resolverCalls = 0;
+  registerSubjectResolver('trading-api', async ({ identifiers }) => {
+    resolverCalls++;
+    return identifiers.map(i => `position ${i.value}: CLOSED, exit 0.8628 for 17.86 USDC`);
+  });
+
+  global.fetch = async () => {
+    const e = new Error('The operation was aborted');
+    e.name = 'AbortError';
+    throw e;
+  };
+  let timedOut = null;
+  try { await exec(PRESET, CLOSE_DEF, CLOSE_ARGS); } catch (e) { timedOut = e; }
+
+  check('a timed-out write throws (executor records error:true)',
+    timedOut !== null && timedOut.rethrow === true, String(timedOut?.rethrow));
+  check('a timed-out write says the outcome is UNKNOWN',
+    /outcome UNKNOWN/.test(timedOut?.message || ''), timedOut?.message);
+  check('a timed-out write says the write may have been applied',
+    /may have been applied/.test(timedOut?.message || ''), timedOut?.message);
+  check('the reported deadline is the write budget the call site used',
+    (timedOut?.message || '').includes(`after ${SKILL_WRITE_TIMEOUT_MS}ms`), timedOut?.message);
+  check('a timed-out write triggered exactly one re-read',
+    resolverCalls === 1, `got ${resolverCalls}`);
+  check('the re-read STATE reaches the tool result, not just the word timeout',
+    (timedOut?.message || '').includes('CLOSED, exit 0.8628 for 17.86 USDC'),
+    timedOut?.message);
+  check('the tool result tells the caller to report the observed state',
+    /Report THAT state/.test(timedOut?.message || ''), timedOut?.message);
+
+  // ── 4. A 5xx is the same unknown case ────────────────────────
+  resolverCalls = 0;
+  global.fetch = async () => ({ ok: false, status: 502, text: async () => 'bad gateway' });
+  let server5xx = null;
+  try { await exec(PRESET, CLOSE_DEF, CLOSE_ARGS); } catch (e) { server5xx = e; }
+  check('a 5xx write reports UNKNOWN and re-reads',
+    /outcome UNKNOWN/.test(server5xx?.message || '') && resolverCalls === 1,
+    `${server5xx?.message} resolverCalls=${resolverCalls}`);
+
+  // ── 5. A 4xx is a stated refusal — no re-read ────────────────
+  resolverCalls = 0;
+  global.fetch = async () => ({
+    ok: false, status: 404,
+    text: async () => JSON.stringify({ error: 'no OPEN position with id ' + REAL_ID }),
+  });
+  let notFound = null;
+  try { await exec(PRESET, CLOSE_DEF, CLOSE_ARGS); } catch (e) { notFound = e; }
+  check('a 404 does NOT trigger a re-read (the server stated the outcome)',
+    resolverCalls === 0, `got ${resolverCalls}`);
+  check('a 404 keeps its plain message and is not called UNKNOWN',
+    /HTTP 404/.test(notFound?.message || '') && !/UNKNOWN/.test(notFound?.message || ''),
+    notFound?.message);
+
+  // ── 6. A READ that fails keeps the old behaviour ─────────────
+  resolverCalls = 0;
+  global.fetch = async () => { throw new Error('socket hang up'); };
+  let readErr = null;
+  try { await exec(PRESET, READ_DEF, {}); } catch (e) { readErr = e; }
+  check('a failed read does not claim an unknown write outcome',
+    !/outcome UNKNOWN/.test(readErr?.message || '') && resolverCalls === 0,
+    readErr?.message);
+  check('a failed read is still rethrow-marked (existing contract)',
+    readErr?.rethrow === true);
+
+  // ── 7. No resolver: the gap is STATED, never implied ─────────
+  __clearSubjectResolversForTests();
+  global.fetch = async () => {
+    const e = new Error('The operation was aborted');
+    e.name = 'AbortError';
+    throw e;
+  };
+  let noResolver = null;
+  try { await exec(PRESET, CLOSE_DEF, CLOSE_ARGS); } catch (e) { noResolver = e; }
+  check('with no resolver the result says state NOT verified',
+    /State NOT verified/.test(noResolver?.message || ''), noResolver?.message);
+  check('with no resolver the result still says UNKNOWN',
+    /outcome UNKNOWN/.test(noResolver?.message || ''), noResolver?.message);
+
+  // A resolver that throws must not replace the original error.
+  registerSubjectResolver('trading-api', async () => { throw new Error('engine unreachable'); });
+  let resolverThrew = null;
+  try { await exec(PRESET, CLOSE_DEF, CLOSE_ARGS); } catch (e) { resolverThrew = e; }
+  check('a re-read that fails still reports the original unknown outcome',
+    /outcome UNKNOWN/.test(resolverThrew?.message || '')
+      && /NOT verified/.test(resolverThrew?.message || ''),
+    resolverThrew?.message);
+
+  // ── 8. The executor gives a skill write the longer cap ───────
+  const registry = new ToolRegistry({}, {});
+  registry.registerSkillTool('charlie', 'trading-api', { name: 'trading-api', baseUrl: 'http://localhost:4003', headers: {} }, CLOSE_DEF);
+  registry.registerSkillTool('charlie', 'trading-api', { name: 'trading-api', baseUrl: 'http://localhost:4003', headers: {} }, READ_DEF);
+
+  const capsSeen = [];
+  const executor = new ToolExecutor({ primary: { provider: 'anthropic', model: 't' } }, registry, {});
+  // The cap is applied by racing executeTool against a timer, so observe it
+  // by making executeTool hang and watching which deadline fires. Faking the
+  // clock is the only way to do that without a 60s test, so instead assert
+  // the branch: a resolved tool returns before any cap, and the cap chosen
+  // is visible through the method lookup the branch uses.
+  const writeMethod = registry.getSkillToolMethod('charlie__trading-api__trading-api__create_positions_manual_close');
+  const readMethod = registry.getSkillToolMethod('charlie__trading-api__trading-api__get_positions');
+  capsSeen.push(writeMethod, readMethod);
+  check('the executor can tell a skill write from a skill read',
+    writeMethod === 'POST' && readMethod === 'GET', JSON.stringify(capsSeen));
+
+  // Drive the real loop with a hanging write and a cap shortened by stubbing
+  // the registry method the branch consults, so the assertion is about which
+  // branch ran rather than about wall-clock time.
+  let executed = 0;
+  registry.executeTool = async () => { executed++; return 'ok'; };
+  executor._completionWithTools = (() => {
+    let turn = 0;
+    return async () => {
+      turn++;
+      if (turn === 1) {
+        return {
+          content: '',
+          toolCalls: [{ id: 't1', name: 'charlie__trading-api__trading-api__create_positions_manual_close', args: CLOSE_ARGS }],
+          usage: {}, model: 't',
+        };
+      }
+      return { content: 'done', toolCalls: [], usage: {}, model: 't' };
+    };
+  })();
+  executor._appendAnthropicToolLoop = (msgs) => msgs;
+  const out = await executor.run([{ role: 'user', content: 'close it' }], {});
+  check('the executor still runs a skill write end to end',
+    executed === 1 && out.toolResults.some(r => r.error === false), JSON.stringify(out.toolResults));
+
+  global.fetch = realFetch;
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Items 1 and 4 of the 2026-09-10 remediation. Both live in the gate/executor/registry layer and share one piece of machinery, the subject resolver, which is why they are together: item 4's re-read is the same lookup item 1 uses for the prompt's subject line.

**Merge #142 first.** The resolver reads `GET /positions/{position_id}`, which #142 adds. Without it every subject line says NOT FOUND. CI does not care; the prompt does.

Anchored to `main` @ `86cea6d`.

## Item 1: the prompt must show what it asks about

The prompt was built as `${toolName}(${JSON.stringify(toolArgs).slice(0, 200)})` and sliced again to 200 by the notifier, including the 64-character tool name. A skill tool's whole body travels as one JSON string named `data`, so after the `{"data":"` wrapper and the escaping of every quote:

| where | budget for the escaped body |
|---|---|
| Detail block | 189 chars |
| Action line | 124 chars |

Three of the four manual-close prompts ever sent are cut mid-JSON in the live approvals table: rows 122, 123 and 125. With `position_id` last in the body, which the model decides, it was not shown at all.

Now the prompt renders identifiers first and never truncates them, then what they resolve to, then the remaining fields, which are the only part traded for space and which state when they were cut. Path identifiers come from the endpoint template, body identifiers from inside `data`.

The subject line for a trading-api position says the market, the open/closed state, the entry, and the live alert count. A composed id reads NOT FOUND, in the prompt, before you tap.

`action` keeps its original one-line shape. The existing notifier test pins that it carries the args, and a shell_exec approval is unreadable without the command.

## Item 4: the 15s/20s window

`registry.js` aborted every skill fetch at 15s while the trade engine allows 20s per Supabase round trip and makes two before a manual-close commits. Reproduced in a real uvicorn process: the client aborted at 0.5s of a scaled test, the tool result became `error:true`, and the row closed 2s later. Nothing re-read it.

Three nested deadlines govern one write. They now fire outermost last:

| deadline | before | after |
|---|---|---|
| registry fetch, write | 15s | 45s |
| registry fetch, read | 15s | 15s |
| executor per-tool cap | 30s | 60s for skill writes |

Ordering only reduces frequency. No client timeout can prove a server did not commit, so a write that times out or gets a 5xx now says its outcome is UNKNOWN and carries a re-read of the subject. A 4xx is a refusal the server stated and gets no re-read. A skill with no resolver gets "State NOT verified", never an unqualified failure.

`observeAfterWrite` is a module function rather than a method because `_executeAPITool` is called via `.call()` with partial `this` objects in several tests. As a method it threw "not a function" inside the error path and replaced the transport error with its own, which is the precise failure this code exists to prevent. Caught by the pre-existing `skill-executor.test.js`, which now passes unchanged.

## Verification

65 assertions across two new files. Full JS suite: 49/54 files, the same five failures as pristine `origin/main` measured in this worktree, three of them `better_sqlite3` bindings from `--ignore-scripts`. Lint clean.

22 mutants, all killed. Two survived first and both found real gaps in my tests rather than in the code:

- A test used a builtin to prove `getSkillToolContext` returns `{}` for non-skill tools. A builtin is filtered one line earlier by the entry lookup, so the `skill:` prefix discriminator was never exercised. Fixed with a non-skill preset that does live in `_apiTools`, plus one named `courses via skillshare` so a substring test cannot pass as a prefix test.
- A test pinned the timeout constants and the branch but never checked which constant the write path used. Fixed by intercepting `AbortSignal.timeout` and reading the milliseconds requested.

## Scope

The subject resolver is registered in code, for one skill. That is a stopgap and is labelled as one in the source. The convention that replaces it is `docs/identifier-resolution-design.md` and needs your decisions.

This PR does not refuse an unresolvable identifier. It shows you one. Refusing is item 2.