### PR TITLE
docs: identifier resolution at the gate, revision 2 (derived index, split fail-closed)

### DIFF
--- a/docs/identifier-resolution-design.md
+++ b/docs/identifier-resolution-design.md
@@ -10,11 +10,15 @@ recommendation in revision 1: the identifier convention is now derived from
 what a skill already declares rather than from a new list. The measurements
 that justify the change are in section 4.
 
+**Read first:** section 4, "Resolved means the entity came back". Rule 2 as
+originally written would have validated nothing; Tyson decided the fix after
+approval, the same day.
+
 Corrected after approval, the same day. Section 3 names three broken skills,
-not four. Section 4 records two places where the derivation rule as written
-matches the wrong thing, and marks which surfacing mechanisms have shipped or
-been decided. Section 5 carries the revised countdown, section 6 the undecided
-resolver budget, and section 8 the decision to fix rather than delete.
+not four. Section 4 amends rule 2 per that decision and marks which surfacing
+mechanisms have shipped or been decided. Section 5 carries the revised
+countdown, section 6 the undecided resolver budget, and section 8 the decision
+to fix rather than delete.
 
 Anchors: QClaw `main` @ `86cea6d`. Counts re-measured against that tree and
 against the live process on `qclaw-agent`.
@@ -114,8 +118,11 @@ The rule, in three lines:
 
 1. Per skill, index every `{{param}}` that appears in any endpoint path,
    excluding `{{secrets.*}}` and `{{config.*}}`.
-2. Map each to the GET endpoint whose path **ends** at that parameter, if one
-   exists. That GET is the resolver.
+2. Map each to the GET endpoint on the same resource whose path, with any
+   query string stripped, **ends** at that parameter, if one exists. That GET
+   is the resolver. It is keyed on the endpoint, not the parameter name, and
+   it resolves only when the entity comes back (see "Resolved means the
+   entity came back" below; decided after approval).
 3. At the gate, resolve every write argument whose name matches an indexed
    parameter after normalising case and separators, **whether it arrived in
    the path or inside the body**.
@@ -174,25 +181,39 @@ anywhere, so all six of its webhook posts have nothing to resolve.
 not collapse.** A webhook post carrying no identifier is not a failure; it
 proceeds to the prompt with the subject block saying no identifier was present.
 
-### Two places the rule as written matches the wrong thing
+### Resolved means the entity came back (decided 2026-09-10, read this first)
 
-Found reading the design after approval. Both are latent today, and both need
-settling in the build rather than a redesign.
+Found reading the design after approval, and decided by Tyson the same day.
 
-- **Query-string parameters.** The parser's `path` includes the query string
-  (`src/agents/skill-parser.js:98`), so rule 2's "ends at the parameter"
-  matches filters as well as identifiers: `{{query}}` on six GHL
-  contact-search GETs, and `{{status}}` on n8n-api's executions filter. A
-  search answers 200 for any value, so a body field named `query` would come
-  back `resolved` with nothing checked. Latent as far as checked: n8n-api has
-  no writes, and GHL write payloads were not audited for a `query` field.
-  Strip the query string before applying rule 2, and count a resolve only on a
-  positive marker (the entity came back), never on a 2xx alone.
-- **One name, two entities.** n8n-api uses `{{id}}` for both
-  `GET /workflows/{{id}}` and `GET /executions/{{id}}`, so a name-keyed index
-  cannot pick the resolver. Latent because n8n-api has no writes. A path
-  identifier should resolve through the GET for the same resource, and an
-  ambiguous body name should be "could not resolve", never a guess.
+As originally written, rule 2 would have shipped a validation layer that
+validates nothing. The parser's `path` includes the query string
+(`src/agents/skill-parser.js:98`), so "ends at the parameter" matches filters
+as well as identifiers: `{{query}}` on six GHL contact-search GETs, and
+`{{status}}` on n8n-api's executions filter. A search answers 200 for any
+value, so a body field named `query` would come back `resolved` with nothing
+checked. And n8n-api uses `{{id}}` for both `GET /workflows/{{id}}` and
+`GET /executions/{{id}}`, so a name alone cannot pick between them. Both are
+latent today (n8n-api has no writes, and GHL write payloads were not audited
+for a `query` field), which is why they are settled before the gate turns on
+rather than found after.
+
+**The decision:**
+
+- **A resolve succeeds only when the entity comes back**, carrying the
+  identifier that was asked for. A 2xx alone is not a resolve: an empty list,
+  a search result, or an entity with a different identifier is "could not
+  resolve". This is the same require-a-positive-marker rule as the gate work.
+- **The resolver keys on the endpoint, not the parameter name.** That is what
+  settles `{{id}}`.
+
+What that implies for the derivation, to be pinned by tests against the real
+skill files rather than decided here:
+
+- Strip the query string before deriving resolvers. A query-string parameter
+  is never an identifier.
+- For each write, the resolver is the GET on the same resource whose path ends
+  at the parameter. A body field whose name matches more than one candidate is
+  "could not resolve", never a guess.
 
 ### What surfaces a skill with none
 

--- a/docs/identifier-resolution-design.md
+++ b/docs/identifier-resolution-design.md
@@ -2,252 +2,291 @@
 
 Design for items 2 and 3 of the remediation ordered on 2026-09-10, after the
 audit of the 2026-08-27 composed-identifier incident. **This is a proposal, not
-a built change.** It asks for three decisions, listed in "Decisions needed".
+a built change.**
 
-Anchors: QClaw `main` @ `86cea6d`, live on `qclaw-agent` 2026-09-10. Every count
-below is from that tree.
+Revision 2, 2026-09-10. Tyson decided the fail-closed question and set three
+constraints on how the split is expressed. Those constraints replaced the
+recommendation in revision 1: the identifier convention is now derived from
+what a skill already declares rather than from a new list. The measurements
+that justify the change are in section 4.
+
+Anchors: QClaw `main` @ `86cea6d`. Counts re-measured against that tree and
+against the live process on `qclaw-agent`.
 
 ---
 
-## 1. What is being fixed
+## 1. The decision, and why it must survive into the code
 
-The audit established that nothing on the financial write path verifies that a
-caller-supplied identifier resolves to an existing row before the operator is
-asked to approve the write. `ApprovalGate.check()` keys on the HTTP method
-alone (`src/security/approval-gate.js:212-219`), and the skill tool schema
-carries the whole request body as one opaque JSON string named `data`
-(`src/agents/skill-parser.js:193-195`), so `position_id` reaches the gate as
-prose. The only existence check is the trade engine's own open-position lookup,
-and it runs after approval.
+**Fail closed by classification, not uniformly.** In Tyson's words, kept here
+so the reasoning reaches whoever writes the comment:
 
-Item 1 (the prompt) makes the identifier visible. It does not make it valid.
-This design is the check.
+> Fail-closed costs a refusal every time the resolver is unavailable. That
+> price is worth paying to avoid an unvalidated financial write. It is not
+> worth paying to add a CRM note. Uniform hard-fail across five GHL brands
+> means every note, task and contact update is refused whenever GoHighLevel is
+> slow, and a control people route around is worse than no control.
 
-### It is a class, not a tool
+Three constraints follow, and each one changes the design rather than
+decorating it.
 
-Write endpoints that take a caller-supplied identifier, counted across
-`src/agents/skills/*.md`:
-
-| skill | write endpoints | of those, with a `{{path}}` identifier |
+| # | Constraint | Where it lands |
 |---|---|---|
-| ghl-crete, ghl-flowos, ghl-fsc, ghl-kairos, ghl-sproutcode | 5 each | 3 each |
-| ghl (generic, still loaded) | 5 | 1 |
-| trading-api | 5 | 1 |
-| stripe | 2 | 0, customer id travels in the body |
-| n8n-router, ads-agency, content-studio, clipper, task-queue | 14 total | 0, webhook posts |
+| 1 | The default must be the safe one. Declaring earns leniency. | Section 5: `unclassified` hard-fails |
+| 2 | No per-skill allowlist of identifier fields. Prefer deriving. | Section 4: the index is derived |
+| 3 | Soft-fail must be visible, not silent. | Section 6: the prompt and the row both say so |
 
-Body identifiers are invisible to that count because the body is one string. In
-trading-api alone, `position_id` in `manual-close` and `market_url` or
-`condition_id` in `positions/manual` are all body identifiers, and all three
-were used as the key of a real approval prompt in August.
-
----
-
-## 2. The declaration problem
-
-To resolve an identifier the gate must know two things it cannot infer:
-
-1. **Which argument fields are identifiers.** Item 1 ships a name heuristic
-   (`IDENTIFIER_NAME_RE` in `src/security/approval-summary.js`: `_id`, `_url`,
-   `uuid`, and so on). That is safe for *rendering*, where a miss costs one
-   unhelpful line. It is not safe for *validation*, where a miss is a silent
-   bypass and a false positive blocks a legitimate write. The heuristic already
-   misclassifies: `market_url` matches, `condition_id` matches, but a field
-   named `slug` or `market` would not.
-2. **What resolves each one.** A GHL `contact_id` resolves against a GHL
-   location. A `position_id` resolves against the trade engine. A Stripe
-   customer resolves against Stripe. Each is a different service, credential
-   and error shape.
-
-Skills are markdown parsed by a strict line grammar
-(`src/agents/skill-parser.js`), and the endpoint line format is a single-line
-`METHOD /path - description`. Any convention must fit that parser or change it.
-
-### Option A: a `## Identifiers` section, resolved by a declared endpoint
-
-```markdown
-## Identifiers
-position_id - GET /positions/{{position_id}} - a trading position
-contact_id  - GET /contacts/{{contact_id}}   - a CRM contact
-```
-
-One line per identifier: the field name, a GET on the same skill that resolves
-it, and a noun for the prompt. The gate resolves by calling that GET through
-the existing skill HTTP path, which already handles auth, secrets and base URL.
-
-- **For.** Same grammar as `## Endpoints`, so the parser change is small. The
-  resolver is data, not code. Auth is inherited, so no new credential wiring.
-  The same declaration serves the prompt's subject line, the gate's check and
-  the post-error re-read.
-- **Against.** Only works when the owning skill can resolve its own
-  identifiers. It cannot express "this id belongs to a different service".
-  A skill author can silently omit an identifier and lose the check with no
-  signal.
-
-### Option B: per-field declaration on the endpoint line
-
-```markdown
-POST /positions/manual-close - Log a close [id: position_id -> GET /positions/{{position_id}}]
-```
-
-- **For.** The declaration sits where the endpoint is, so it is hard to forget
-  when adding an endpoint.
-- **Against.** The endpoint line is already strict and single-line, and the
-  audit found that a `{{param}}` grammar with a nested arrow is exactly the
-  sort of thing that parses to `null` and disables a skill silently. Rejected.
-
-### Option C: code resolvers registered per skill
-
-This is what item 1 ships as a stopgap (`src/security/subject-resolvers.js`,
-one resolver for trading-api position ids, registered in `src/index.js`).
-
-- **For.** Arbitrary logic, cross-service lookups, no parser change.
-- **Against.** Every new skill needs a code change in `src/`, which is exactly
-  the coupling the skill architecture exists to avoid. Does not scale to the
-  five GHL brands, which would need five near-identical resolvers.
-
-### Recommendation
-
-**Option A, with Option C retained as an escape hatch.** Declaration in the
-skill file covers the common case (an id the skill's own service can resolve),
-which is all nine trading-api and GHL cases. A registered code resolver
-overrides the declaration when a skill needs cross-service logic. Item 1's
-resolver registry already provides that override, so this is additive.
+Constraint 2 carries a warning worth recording, because it is the reason
+revision 1's recommendation was withdrawn. A hand-maintained list has drifted
+silently four times in this repo: the six-process restart list, the two-name
+native rebuild list, the Dormancy Alerter's monitored set, and the `console.log`
+exclusion list. Each was correct when written.
 
 ---
 
-## 3. Where the check runs, and what it does
+## 2. What is being fixed
 
-In `ApprovalGate.check()`, after the HTTP-write gate decides approval is
-required and **before** `requestApproval` creates the pending row:
+Nothing on the path verifies that a caller-supplied identifier resolves to an
+existing row before the operator is asked to approve a write. The gate keys on
+the HTTP method alone, and the skill tool schema carries the whole request body
+as one opaque JSON string, so the identifier reaches the gate as prose. The
+only existence check is the trade engine's own lookup, and it runs after
+approval.
 
-```
-check() decides: approval required
-  -> for each declared identifier present in the args:
-       resolve it
-  -> all resolved      -> prompt, with the resolved subject on the prompt
-  -> any unresolvable  -> REFUSE. No prompt. Tool result states which
-                          identifier failed and what the store said.
-  -> resolution unavailable -> REFUSE (fail closed, see below)
-```
-
-Refusing rather than prompting is the point. On 2026-08-27 the composed id
-produced a prompt that was approved in eight seconds and then 404'd. Under this
-design it never becomes a prompt: Charlie gets an error naming the identifier,
-and the operator is never asked to consent to a write that cannot land.
-
-### Fail closed, matching GATE 8
-
-The instruction was to fail closed when resolution is unavailable, as executor
-GATE 8 does. Concretely: a resolver that times out, returns a 5xx, or is not
-reachable **blocks the write**. It does not degrade to a prompt.
-
-This has a cost worth stating plainly. The trade engine binds `127.0.0.1:4003`
-and is a single process; if it is down, manual-close is refused. That is the
-correct trade for a money write, and it is the same posture GATE 8 takes when
-the CLOB book is unreadable. It is the wrong trade for, say, a CRM note. So:
-
-> Fail-closed applies to identifiers declared on endpoints classified
-> `financial` or `destructive` (section 4). For `mutating` endpoints, an
-> unavailable resolver degrades to a prompt that states, in the subject block,
-> that the identifier could not be verified.
-
-That split needs Tyson's agreement; it is decision 2 below.
-
-### What it costs per approval
-
-One extra HTTP round trip per identifier before the prompt, against a service
-the skill already talks to. For trading-api that is a loopback GET. The prompt
-is already gated behind a human tap with a ten-minute window, so latency here
-is not a constraint.
+Item 1 makes the identifier visible. This is the check.
 
 ---
 
-## 4. Risk classification (item 3)
+## 3. The surface, re-measured
 
-Today, `src/security/approval-gate.js:217`:
+Revision 1 got this wrong and the correction matters, because it is itself an
+instance of the drift constraint 2 is about.
 
-```js
-riskLevel: skillWriteMethod === 'DELETE' ? 'high' : 'medium'
-```
+Four skills present as HTTP surfaces, carry endpoint lines and an `http:`
+permission, and **register zero tools**. Confirmed against the live process,
+where every boot in `tool-call.log` shows ten skills registering and these four
+absent:
 
-Executed during the audit: `POST /simulate` (pure computation, writes nothing),
-`POST /monitor/run`, `POST /positions/{id}/hold` and `POST
-/positions/manual-close` all classify `medium`. All eight trading-api approvals
-ever recorded are `medium`. The label carries no information.
+| skill | why it registers nothing |
+|---|---|
+| `ads-agency` | no `## Auth` section, so `Base URL:` is never read and the skill parses to null |
+| `content-studio` | same |
+| `clipper` | endpoint lines use an em dash, which the endpoint grammar does not match, and there is no `Base URL:` |
+| `task-queue` | `POST /rest/v1/charlie_tasks` has no ` - description`, so no endpoint matches |
 
-The HTTP verb is the wrong signal. It describes the shape of the request, not
-what the request does. `POST /simulate` and `POST /positions/manual-close`
-differ in everything that matters and agree on the only thing being measured.
+The parser requires a base URL and at least one endpoint, and returns null
+otherwise. Null means no tools. Nothing reports it.
 
-### Proposed: three levels, declared per endpoint
+**This is the failure mode constraint 2 is guarding against, already present.**
+Four skill files declare a surface that does not exist, and the only way to
+find out is to go looking. Adding a second hand-maintained declaration to the
+same files would inherit the same silence.
 
-| level | meaning | prompt behaviour |
+The real write surface is ten skills. Forty-three write endpoints parse.
+
+---
+
+## 4. Deriving the identifier index
+
+**Proposal: derive from the skill's own `## Endpoints` block. Add nothing.**
+
+A skill that has a path parameter has already declared that the token names an
+entity, and a skill that has a GET ending at that parameter has already
+declared what resolves it. Both facts are in the file today.
+
+The rule, in three lines:
+
+1. Per skill, index every `{{param}}` that appears in any endpoint path,
+   excluding `{{secrets.*}}` and `{{config.*}}`.
+2. Map each to the GET endpoint whose path **ends** at that parameter, if one
+   exists. That GET is the resolver.
+3. At the gate, resolve every write argument whose name matches an indexed
+   parameter after normalising case and separators, **whether it arrived in
+   the path or inside the body**.
+
+Step 3 is what reaches the incident. `POST /positions/manual-close` has no path
+parameter at all; `position_id` is a body field. But `position_id` is indexed
+from the sibling endpoints, so a body field of that name resolves through the
+same GET.
+
+### Measured coverage
+
+Executed against the real skill files with the real parser:
+
+| | |
+|---|---|
+| Write endpoints that parse | 43 |
+| Path identifiers across them | 17 |
+| Resolve to a GET already in the same skill, on `main` | 16 |
+| Resolve once PR #142 lands | 17 |
+
+The one miss on `main` is `position_id`, because `GET /positions/{position_id}`
+does not exist yet. PR #142 adds it, and the index then closes.
+
+Two cases worth naming because they are the ones that would have mattered:
+
+- **The incident identifier.** `position_id` in the manual-close body resolves
+  via `GET /positions/{{position_id}}`. The composed value
+  `solana-110-aug-2026` resolves to a 404, so the write is refused and never
+  becomes a prompt.
+- **Case and separator drift.** GHL sends `contactId` in a body while the path
+  declares `{{contact_id}}`. Normalising to lower case with separators removed
+  makes these the same token, verified against both spellings.
+
+### What derivation cannot see, stated plainly
+
+An identifier whose name appears in **no** path in its skill is invisible to
+the index. Two live examples:
+
+- `market_url` on manual-close, which is how approval 125 was keyed. It is not
+  a path parameter anywhere in trading-api.
+- Stripe's `customer` field on `POST /invoices`. The skill indexes
+  `customer_id` from `GET /customers/{{customer_id}}`, and `customer` does not
+  normalise to it.
+
+Under constraint 1 both hard-fail, which is the direction we can live with, and
+both are visible the first time the write runs. Neither becomes an unchecked
+write. `n8n-router` is the one parsing skill with writes and no path identifier
+anywhere, so all six of its webhook posts have nothing to resolve.
+
+**"Nothing to resolve" and "could not resolve" are different states and must
+not collapse.** A webhook post carrying no identifier is not a failure; it
+proceeds to the prompt with the subject block saying no identifier was present.
+
+### What surfaces a skill with none
+
+Constraint 2 asks this explicitly, and it is the part a derivation scheme owes.
+Three mechanisms, none of them a list:
+
+1. **Static, at boot.** `scripts/verify-coupling.js` already walks the live
+   registry. It should print, per skill: writes parsed, identifiers indexed,
+   identifiers with a resolver, and writes whose path parameter has no
+   resolver. A skill with writes and an empty index is one line of output, not
+   an archaeology exercise. This is also where the four zero-tool skills in
+   section 3 would have shown up years earlier.
+2. **A CI assertion.** A write endpoint with a `{{param}}` and no matching GET
+   in the same skill is a skill-file defect and can fail the build. That is a
+   derived check with nothing to maintain.
+3. **At runtime.** An unindexed identifier on an unclassified endpoint is
+   refused, loudly, the first time it is called. A forgotten declaration
+   produces a refused write, not a silent bypass.
+
+---
+
+## 5. Classification, and the one thing that must be declared
+
+Identifiers are derived. Classification cannot be: the whole finding of the
+audit's fifth question is that the verb does not carry the information.
+`POST /simulate` writes nothing and `POST /positions/manual-close` writes the
+profit column, and today both classify `medium`. Every trading approval ever
+recorded is `medium`; all 88 `high` rows are shell commands.
+
+So one declaration is unavoidable. Constraint 1 is what makes it safe:
+
+| level | meaning | identifier behaviour |
 |---|---|---|
-| `financial` | moves money, or writes a money column: `exit_usdc`, `pnl`, an order, a charge | Identifiers fail closed. Prompt states the money delta. |
-| `destructive` | deletes or overwrites a record such that the prior value is unrecoverable | Identifiers fail closed. |
-| `mutating` | any other state change: a flag, a note, a task, a queued job | Prompted as today. Unverifiable identifier degrades to a stated warning. |
+| `financial` | moves money or writes a money column | hard-fail |
+| `destructive` | overwrites or deletes unrecoverably | hard-fail |
+| `mutating` | any other state change | soft-fail, stated in the prompt |
+| *(undeclared)* | nobody has said | **hard-fail** |
 
-Reads stay unprompted, as now.
+Undeclared is not a fourth level. It is the absence of one, and it is
+deliberately not defaulted to `mutating`, because that is the value that would
+make a forgotten declaration silent. Showing `financial` would be a lie;
+showing `unclassified` is true and tells the operator that nobody has said what
+this endpoint does.
 
-Declared on the endpoint line so the classification lives with the endpoint:
+`DELETE` with no declaration reads as `destructive`, so current behaviour is
+never weakened by omission.
 
-```markdown
-POST /positions/manual-close - [financial] Log a position Tyson closed by hand; body position_id, exit_price, ...
+This inverts revision 1, which defaulted to `mutating`. That was wrong for
+exactly the reason constraint 1 gives.
+
+### The migration cost, stated rather than discovered
+
+On the day this turns on, every write on every skill is unclassified and
+therefore hard-fails. That is 43 endpoints. **The rollout order is: declare
+first, enable second**, and the coupling script's per-skill count is how you
+know you are done. It should be a countdown to zero unclassified writes, run
+before the gate change ships, not after.
+
+---
+
+## 6. Soft-fail must be visible
+
+Constraint 3. A `mutating` write that proceeds with an unresolved identifier
+must say so, or the operator cannot tell a validated approval from an
+unvalidated one, which is the same defect as a risk label that never varies.
+
+Two places, because the prompt is a moment and the row is the record.
+
+**In the prompt**, using the subject block item 1 already ships:
+
+```
+Subject:
+  contact_id ocQHyuzHvysMo5N5VsXc: NOT VERIFIED
+  The CRM did not answer within 5s. This approval was not validated.
+  Approving it accepts an identifier nobody has checked.
 ```
 
-An endpoint with no declaration defaults to `mutating`, and a `DELETE` with no
-declaration defaults to `destructive` so the current behaviour is never
-weakened by omission.
+**In the approvals row**, a `validated` column recording `resolved`,
+`unverified`, or `none_present`. Without it, a month later the row for a
+validated approval and the row for an unvalidated one are identical, and the
+question "was this one checked?" has no answer. This is a small schema
+addition to a table created with `CREATE TABLE IF NOT EXISTS`, so it needs a
+migration step rather than an edit to the create statement.
 
-Three levels, not five, per the instruction. `financial` versus `mutating` is
-the distinction that would have changed the 2026-08-27 outcome; further
-subdivision buys nothing today.
-
-### Applying it to the current surface
-
-- `financial`: trading-api `manual-close`, `positions/manual`; stripe
-  `POST /customers`, `POST /invoices`.
-- `destructive`: no current endpoint. The GHL `PUT /contacts/{{contact_id}}`
-  family overwrites fields and is arguably here; recommend `mutating`, since
-  GHL retains field history and the write is recoverable.
-- `mutating`: everything else, including `POST /simulate` and
-  `POST /monitor/run`, which today share a label with a money write.
+The machinery exists: item 1 already carries a `subjectStatus` of `resolved`,
+`failed`, `no_resolver`, `no_identifiers` or `empty` through to the notifier.
+This is wiring it to a column and a sentence, not new plumbing.
 
 ---
 
-## 5. Sequencing
+## 7. The three questions, answered
 
-1. Item 1 (prompt) and the engine changes ship first. They are independent and
-   already built.
-2. Parser change: `## Identifiers` section plus the `[level]` endpoint prefix.
-   Both are additive, and a skill with neither behaves exactly as today.
-3. Gate change: resolve-before-prompt, fail-closed by level.
-4. Declare identifiers and levels on trading-api first, since it is the surface
-   the incident came from and the only one with a loopback resolver already.
-5. GHL brands next, five skills sharing one endpoint shape.
+**1. Declaration convention.** Derive the identifier index from the skill's own
+endpoint block (section 4). Declare classification only (section 5). Code
+resolvers stay as an override for the cross-service case, which is the one
+thing derivation structurally cannot express. Revision 1's `## Identifiers`
+section is withdrawn: it was a maintained list, and section 3 is what those go
+on to look like.
 
-Steps 2 and 3 want separate PRs: a parser change that returns `null` disables a
-skill silently, and that failure mode deserves its own review and its own
-`scripts/verify-coupling.js` run.
+**2. Fail-closed split.** Decided: split. Expressed as section 5, with
+undeclared hard-failing.
 
----
+**3. GHL `PUT /contacts/{{contact_id}}`.** Recommend leaving it **unclassified
+for now**, which hard-fails, rather than classifying it `mutating`.
 
-## 6. Decisions needed
+Revision 1 recommended `mutating` on the grounds that GHL retains field
+history and the write is therefore recoverable. **That claim was not verified
+and should not have been stated.** Checking it needs a write against a real
+location, which is not something to do to settle a documentation question.
 
-1. **Option A** for the declaration convention, with code resolvers retained as
-   an override? Or a different shape.
-2. **The fail-closed split**: hard-fail for `financial` and `destructive`,
-   degrade-with-warning for `mutating`. Or fail closed for everything, which is
-   simpler to reason about and will block CRM writes whenever GHL is slow.
-3. **The GHL `PUT /contacts` classification**: `mutating` as recommended, or
-   `destructive`.
+Constraint 1 makes this decision cheap: unclassified is safe, so the cost of
+not deciding is a refusal rather than an unchecked overwrite. Classify it
+`mutating` when someone has confirmed recoverability, and record how they
+confirmed it.
 
 ---
 
-## 7. What this design does NOT do
+## 8. Sequencing
 
-Constraining Charlie from composing identifiers is deliberately out of scope,
-per the instruction of 2026-09-10. The audit's finding was that nothing checks,
-and Charlie is one of several callers. A model-side constraint would not have
-prevented the incident and cannot be verified.
+1. PR #142 and PR #143 land. #142 also closes the last hole in the derived
+   index.
+2. Coupling script reports the per-skill counts. Read them. Fix the four
+   zero-tool skills in section 3, or delete them if they are dead.
+3. Parser change: the `[level]` endpoint prefix, plus the derived index built
+   at registration. Additive; a skill with neither behaves exactly as today.
+4. Declare classifications across all 43 writes. Countdown to zero.
+5. Gate change: resolve before prompting, fail by level.
+
+Steps 3 and 5 want separate PRs. A parser change that returns null disables a
+skill silently, which section 3 shows is not hypothetical, and it deserves its
+own review and its own coupling run.
+
+---
+
+## 9. Out of scope
+
+Constraining Charlie from composing identifiers, per the instruction of
+2026-09-10. The finding was that nothing checks, and Charlie is one of several
+callers.

--- a/docs/identifier-resolution-design.md
+++ b/docs/identifier-resolution-design.md
@@ -1,0 +1,253 @@
+# Resolving identifiers before the approval prompt
+
+Design for items 2 and 3 of the remediation ordered on 2026-09-10, after the
+audit of the 2026-08-27 composed-identifier incident. **This is a proposal, not
+a built change.** It asks for three decisions, listed in "Decisions needed".
+
+Anchors: QClaw `main` @ `86cea6d`, live on `qclaw-agent` 2026-09-10. Every count
+below is from that tree.
+
+---
+
+## 1. What is being fixed
+
+The audit established that nothing on the financial write path verifies that a
+caller-supplied identifier resolves to an existing row before the operator is
+asked to approve the write. `ApprovalGate.check()` keys on the HTTP method
+alone (`src/security/approval-gate.js:212-219`), and the skill tool schema
+carries the whole request body as one opaque JSON string named `data`
+(`src/agents/skill-parser.js:193-195`), so `position_id` reaches the gate as
+prose. The only existence check is the trade engine's own open-position lookup,
+and it runs after approval.
+
+Item 1 (the prompt) makes the identifier visible. It does not make it valid.
+This design is the check.
+
+### It is a class, not a tool
+
+Write endpoints that take a caller-supplied identifier, counted across
+`src/agents/skills/*.md`:
+
+| skill | write endpoints | of those, with a `{{path}}` identifier |
+|---|---|---|
+| ghl-crete, ghl-flowos, ghl-fsc, ghl-kairos, ghl-sproutcode | 5 each | 3 each |
+| ghl (generic, still loaded) | 5 | 1 |
+| trading-api | 5 | 1 |
+| stripe | 2 | 0, customer id travels in the body |
+| n8n-router, ads-agency, content-studio, clipper, task-queue | 14 total | 0, webhook posts |
+
+Body identifiers are invisible to that count because the body is one string. In
+trading-api alone, `position_id` in `manual-close` and `market_url` or
+`condition_id` in `positions/manual` are all body identifiers, and all three
+were used as the key of a real approval prompt in August.
+
+---
+
+## 2. The declaration problem
+
+To resolve an identifier the gate must know two things it cannot infer:
+
+1. **Which argument fields are identifiers.** Item 1 ships a name heuristic
+   (`IDENTIFIER_NAME_RE` in `src/security/approval-summary.js`: `_id`, `_url`,
+   `uuid`, and so on). That is safe for *rendering*, where a miss costs one
+   unhelpful line. It is not safe for *validation*, where a miss is a silent
+   bypass and a false positive blocks a legitimate write. The heuristic already
+   misclassifies: `market_url` matches, `condition_id` matches, but a field
+   named `slug` or `market` would not.
+2. **What resolves each one.** A GHL `contact_id` resolves against a GHL
+   location. A `position_id` resolves against the trade engine. A Stripe
+   customer resolves against Stripe. Each is a different service, credential
+   and error shape.
+
+Skills are markdown parsed by a strict line grammar
+(`src/agents/skill-parser.js`), and the endpoint line format is a single-line
+`METHOD /path - description`. Any convention must fit that parser or change it.
+
+### Option A: a `## Identifiers` section, resolved by a declared endpoint
+
+```markdown
+## Identifiers
+position_id - GET /positions/{{position_id}} - a trading position
+contact_id  - GET /contacts/{{contact_id}}   - a CRM contact
+```
+
+One line per identifier: the field name, a GET on the same skill that resolves
+it, and a noun for the prompt. The gate resolves by calling that GET through
+the existing skill HTTP path, which already handles auth, secrets and base URL.
+
+- **For.** Same grammar as `## Endpoints`, so the parser change is small. The
+  resolver is data, not code. Auth is inherited, so no new credential wiring.
+  The same declaration serves the prompt's subject line, the gate's check and
+  the post-error re-read.
+- **Against.** Only works when the owning skill can resolve its own
+  identifiers. It cannot express "this id belongs to a different service".
+  A skill author can silently omit an identifier and lose the check with no
+  signal.
+
+### Option B: per-field declaration on the endpoint line
+
+```markdown
+POST /positions/manual-close - Log a close [id: position_id -> GET /positions/{{position_id}}]
+```
+
+- **For.** The declaration sits where the endpoint is, so it is hard to forget
+  when adding an endpoint.
+- **Against.** The endpoint line is already strict and single-line, and the
+  audit found that a `{{param}}` grammar with a nested arrow is exactly the
+  sort of thing that parses to `null` and disables a skill silently. Rejected.
+
+### Option C: code resolvers registered per skill
+
+This is what item 1 ships as a stopgap (`src/security/subject-resolvers.js`,
+one resolver for trading-api position ids, registered in `src/index.js`).
+
+- **For.** Arbitrary logic, cross-service lookups, no parser change.
+- **Against.** Every new skill needs a code change in `src/`, which is exactly
+  the coupling the skill architecture exists to avoid. Does not scale to the
+  five GHL brands, which would need five near-identical resolvers.
+
+### Recommendation
+
+**Option A, with Option C retained as an escape hatch.** Declaration in the
+skill file covers the common case (an id the skill's own service can resolve),
+which is all nine trading-api and GHL cases. A registered code resolver
+overrides the declaration when a skill needs cross-service logic. Item 1's
+resolver registry already provides that override, so this is additive.
+
+---
+
+## 3. Where the check runs, and what it does
+
+In `ApprovalGate.check()`, after the HTTP-write gate decides approval is
+required and **before** `requestApproval` creates the pending row:
+
+```
+check() decides: approval required
+  -> for each declared identifier present in the args:
+       resolve it
+  -> all resolved      -> prompt, with the resolved subject on the prompt
+  -> any unresolvable  -> REFUSE. No prompt. Tool result states which
+                          identifier failed and what the store said.
+  -> resolution unavailable -> REFUSE (fail closed, see below)
+```
+
+Refusing rather than prompting is the point. On 2026-08-27 the composed id
+produced a prompt that was approved in eight seconds and then 404'd. Under this
+design it never becomes a prompt: Charlie gets an error naming the identifier,
+and the operator is never asked to consent to a write that cannot land.
+
+### Fail closed, matching GATE 8
+
+The instruction was to fail closed when resolution is unavailable, as executor
+GATE 8 does. Concretely: a resolver that times out, returns a 5xx, or is not
+reachable **blocks the write**. It does not degrade to a prompt.
+
+This has a cost worth stating plainly. The trade engine binds `127.0.0.1:4003`
+and is a single process; if it is down, manual-close is refused. That is the
+correct trade for a money write, and it is the same posture GATE 8 takes when
+the CLOB book is unreadable. It is the wrong trade for, say, a CRM note. So:
+
+> Fail-closed applies to identifiers declared on endpoints classified
+> `financial` or `destructive` (section 4). For `mutating` endpoints, an
+> unavailable resolver degrades to a prompt that states, in the subject block,
+> that the identifier could not be verified.
+
+That split needs Tyson's agreement; it is decision 2 below.
+
+### What it costs per approval
+
+One extra HTTP round trip per identifier before the prompt, against a service
+the skill already talks to. For trading-api that is a loopback GET. The prompt
+is already gated behind a human tap with a ten-minute window, so latency here
+is not a constraint.
+
+---
+
+## 4. Risk classification (item 3)
+
+Today, `src/security/approval-gate.js:217`:
+
+```js
+riskLevel: skillWriteMethod === 'DELETE' ? 'high' : 'medium'
+```
+
+Executed during the audit: `POST /simulate` (pure computation, writes nothing),
+`POST /monitor/run`, `POST /positions/{id}/hold` and `POST
+/positions/manual-close` all classify `medium`. All eight trading-api approvals
+ever recorded are `medium`. The label carries no information.
+
+The HTTP verb is the wrong signal. It describes the shape of the request, not
+what the request does. `POST /simulate` and `POST /positions/manual-close`
+differ in everything that matters and agree on the only thing being measured.
+
+### Proposed: three levels, declared per endpoint
+
+| level | meaning | prompt behaviour |
+|---|---|---|
+| `financial` | moves money, or writes a money column: `exit_usdc`, `pnl`, an order, a charge | Identifiers fail closed. Prompt states the money delta. |
+| `destructive` | deletes or overwrites a record such that the prior value is unrecoverable | Identifiers fail closed. |
+| `mutating` | any other state change: a flag, a note, a task, a queued job | Prompted as today. Unverifiable identifier degrades to a stated warning. |
+
+Reads stay unprompted, as now.
+
+Declared on the endpoint line so the classification lives with the endpoint:
+
+```markdown
+POST /positions/manual-close - [financial] Log a position Tyson closed by hand; body position_id, exit_price, ...
+```
+
+An endpoint with no declaration defaults to `mutating`, and a `DELETE` with no
+declaration defaults to `destructive` so the current behaviour is never
+weakened by omission.
+
+Three levels, not five, per the instruction. `financial` versus `mutating` is
+the distinction that would have changed the 2026-08-27 outcome; further
+subdivision buys nothing today.
+
+### Applying it to the current surface
+
+- `financial`: trading-api `manual-close`, `positions/manual`; stripe
+  `POST /customers`, `POST /invoices`.
+- `destructive`: no current endpoint. The GHL `PUT /contacts/{{contact_id}}`
+  family overwrites fields and is arguably here; recommend `mutating`, since
+  GHL retains field history and the write is recoverable.
+- `mutating`: everything else, including `POST /simulate` and
+  `POST /monitor/run`, which today share a label with a money write.
+
+---
+
+## 5. Sequencing
+
+1. Item 1 (prompt) and the engine changes ship first. They are independent and
+   already built.
+2. Parser change: `## Identifiers` section plus the `[level]` endpoint prefix.
+   Both are additive, and a skill with neither behaves exactly as today.
+3. Gate change: resolve-before-prompt, fail-closed by level.
+4. Declare identifiers and levels on trading-api first, since it is the surface
+   the incident came from and the only one with a loopback resolver already.
+5. GHL brands next, five skills sharing one endpoint shape.
+
+Steps 2 and 3 want separate PRs: a parser change that returns `null` disables a
+skill silently, and that failure mode deserves its own review and its own
+`scripts/verify-coupling.js` run.
+
+---
+
+## 6. Decisions needed
+
+1. **Option A** for the declaration convention, with code resolvers retained as
+   an override? Or a different shape.
+2. **The fail-closed split**: hard-fail for `financial` and `destructive`,
+   degrade-with-warning for `mutating`. Or fail closed for everything, which is
+   simpler to reason about and will block CRM writes whenever GHL is slow.
+3. **The GHL `PUT /contacts` classification**: `mutating` as recommended, or
+   `destructive`.
+
+---
+
+## 7. What this design does NOT do
+
+Constraining Charlie from composing identifiers is deliberately out of scope,
+per the instruction of 2026-09-10. The audit's finding was that nothing checks,
+and Charlie is one of several callers. A model-side constraint would not have
+prevented the incident and cannot be verified.

--- a/docs/identifier-resolution-design.md
+++ b/docs/identifier-resolution-design.md
@@ -1,14 +1,20 @@
 # Resolving identifiers before the approval prompt
 
 Design for items 2 and 3 of the remediation ordered on 2026-09-10, after the
-audit of the 2026-08-27 composed-identifier incident. **This is a proposal, not
-a built change.**
+audit of the 2026-08-27 composed-identifier incident. **Approved by Tyson on
+2026-09-10 as designed. Not built.**
 
 Revision 2, 2026-09-10. Tyson decided the fail-closed question and set three
 constraints on how the split is expressed. Those constraints replaced the
 recommendation in revision 1: the identifier convention is now derived from
 what a skill already declares rather than from a new list. The measurements
 that justify the change are in section 4.
+
+Corrected after approval, the same day. Section 3 names three broken skills,
+not four. Section 4 records two places where the derivation rule as written
+matches the wrong thing, and marks which surfacing mechanisms have shipped or
+been decided. Section 5 carries the revised countdown, section 6 the undecided
+resolver budget, and section 8 the decision to fix rather than delete.
 
 Anchors: QClaw `main` @ `86cea6d`. Counts re-measured against that tree and
 against the live process on `qclaw-agent`.
@@ -61,24 +67,35 @@ Item 1 makes the identifier visible. This is the check.
 Revision 1 got this wrong and the correction matters, because it is itself an
 instance of the drift constraint 2 is about.
 
-Four skills present as HTTP surfaces, carry endpoint lines and an `http:`
+Three skills present as HTTP surfaces, carry endpoint lines and an `http:`
 permission, and **register zero tools**. Confirmed against the live process,
-where every boot in `tool-call.log` shows ten skills registering and these four
-absent:
+where every boot in `tool-call.log` shows ten skills registering and these
+three absent:
 
-| skill | why it registers nothing |
-|---|---|
-| `ads-agency` | no `## Auth` section, so `Base URL:` is never read and the skill parses to null |
-| `content-studio` | same |
-| `clipper` | endpoint lines use an em dash, which the endpoint grammar does not match, and there is no `Base URL:` |
-| `task-queue` | `POST /rest/v1/charlie_tasks` has no ` - description`, so no endpoint matches |
+| skill | why it registers nothing | issue |
+|---|---|---|
+| `ads-agency` | no `## Auth` section, so `Base URL:` is never read and the skill parses to null | #149 |
+| `content-studio` | same | #150 |
+| `clipper` | no `Base URL:`, endpoint lines use an em dash the endpoint grammar does not match, and a single-brace `{job_id}` the parser does not treat as a parameter | #151 |
 
 The parser requires a base URL and at least one endpoint, and returns null
-otherwise. Null means no tools. Nothing reports it.
+otherwise. Null means no tools. Nothing reported it until PR #148.
+
+None of the three ever parsed, in any commit. The services behind all three
+answered throughout. Tyson's decision is to fix them, not delete them. Two of
+them need more than the parse fix: `ads-agency` and `content-studio` are
+`category: specialist-scope`, which Charlie's router never routes, and
+specialist spawning was retired on 2026-08-14, so a parse fix alone registers
+tools that no turn activates.
+
+An earlier draft of this section also listed `task-queue`. That was wrong: it
+is `surface: prompt` with no `## Endpoints` section, its
+`POST /rest/v1/charlie_tasks` is documentation prose, and it was delivered as
+prompt content nine times in the live log. It is working as designed.
 
 **This is the failure mode constraint 2 is guarding against, already present.**
-Four skill files declare a surface that does not exist, and the only way to
-find out is to go looking. Adding a second hand-maintained declaration to the
+Three skill files declare a surface that does not exist, and the only way to
+find out was to go looking. Adding a second hand-maintained declaration to the
 same files would inherit the same silence.
 
 The real write surface is ten skills. Forty-three write endpoints parse.
@@ -107,6 +124,11 @@ Step 3 is what reaches the incident. `POST /positions/manual-close` has no path
 parameter at all; `position_id` is a body field. But `position_id` is indexed
 from the sibling endpoints, so a body field of that name resolves through the
 same GET.
+
+PR #148 already implements the derivation in rules 1 and 2, in
+`src/agents/skill-diagnostics.js`, for its boot-time report. The build should
+import that, not write a second one: two implementations of one rule are a
+maintained list by another name.
 
 ### Measured coverage
 
@@ -152,20 +174,41 @@ anywhere, so all six of its webhook posts have nothing to resolve.
 not collapse.** A webhook post carrying no identifier is not a failure; it
 proceeds to the prompt with the subject block saying no identifier was present.
 
+### Two places the rule as written matches the wrong thing
+
+Found reading the design after approval. Both are latent today, and both need
+settling in the build rather than a redesign.
+
+- **Query-string parameters.** The parser's `path` includes the query string
+  (`src/agents/skill-parser.js:98`), so rule 2's "ends at the parameter"
+  matches filters as well as identifiers: `{{query}}` on six GHL
+  contact-search GETs, and `{{status}}` on n8n-api's executions filter. A
+  search answers 200 for any value, so a body field named `query` would come
+  back `resolved` with nothing checked. Latent as far as checked: n8n-api has
+  no writes, and GHL write payloads were not audited for a `query` field.
+  Strip the query string before applying rule 2, and count a resolve only on a
+  positive marker (the entity came back), never on a 2xx alone.
+- **One name, two entities.** n8n-api uses `{{id}}` for both
+  `GET /workflows/{{id}}` and `GET /executions/{{id}}`, so a name-keyed index
+  cannot pick the resolver. Latent because n8n-api has no writes. A path
+  identifier should resolve through the GET for the same resource, and an
+  ambiguous body name should be "could not resolve", never a guess.
+
 ### What surfaces a skill with none
 
 Constraint 2 asks this explicitly, and it is the part a derivation scheme owes.
 Three mechanisms, none of them a list:
 
-1. **Static, at boot.** `scripts/verify-coupling.js` already walks the live
-   registry. It should print, per skill: writes parsed, identifiers indexed,
-   identifiers with a resolver, and writes whose path parameter has no
-   resolver. A skill with writes and an empty index is one line of output, not
-   an archaeology exercise. This is also where the four zero-tool skills in
-   section 3 would have shown up years earlier.
-2. **A CI assertion.** A write endpoint with a `{{param}}` and no matching GET
-   in the same skill is a skill-file defect and can fail the build. That is a
-   derived check with nothing to maintain.
+1. **Static, at boot. Shipped in PR #148**, as a boot-time diagnostic called
+   from `src/agents/registry.js` rather than in `scripts/verify-coupling.js`.
+   It names the file, the line, the cause and the fix for a skill that declares
+   an HTTP surface and registers nothing, and it reports a write whose path
+   parameter has no resolver. The per-skill counts are still owed and belong
+   beside it: writes parsed, identifiers indexed, identifiers with a resolver,
+   writes unclassified.
+2. **A CI assertion. Decided against as a build gate.** Tyson preferred the
+   boot-time error, because a skill can be edited on the host where CI never
+   runs.
 3. **At runtime.** An unindexed identifier on an unclassified endpoint is
    refused, loudly, the first time it is called. A forgotten declaration
    produces a refused write, not a silent bypass.
@@ -204,10 +247,12 @@ exactly the reason constraint 1 gives.
 ### The migration cost, stated rather than discovered
 
 On the day this turns on, every write on every skill is unclassified and
-therefore hard-fails. That is 43 endpoints. **The rollout order is: declare
-first, enable second**, and the coupling script's per-skill count is how you
-know you are done. It should be a countdown to zero unclassified writes, run
-before the gate change ships, not after.
+therefore hard-fails. That is 43 endpoints on `main` @ `86cea6d`, or 49 if
+#149 to #151 land first: fixing those three skills adds six writes
+(`ads-agency` 4, `content-studio` 1, `clipper` 1). **The rollout order is:
+declare first, enable second**, and the per-skill count is how you know you
+are done. It should be a countdown to zero unclassified writes, run before the
+gate change ships, not after.
 
 ---
 
@@ -227,6 +272,11 @@ Subject:
   The CRM did not answer within 5s. This approval was not validated.
   Approving it accepts an identifier nobody has checked.
 ```
+
+The `5s` is illustrative. The resolver's own timeout budget has not been
+decided: skill fetches on `main` use 15s (`src/agents/skill-parser.js:260`)
+and PR #143 raises writes to 45s. The resolver GET sits between the call and
+the prompt, so its budget is a design decision for the build, not a default.
 
 **In the approvals row**, a `validated` column recording `resolved`,
 `unverified`, or `none_present`. Without it, a month later the row for a
@@ -272,16 +322,17 @@ confirmed it.
 
 1. PR #142 and PR #143 land. #142 also closes the last hole in the derived
    index.
-2. Coupling script reports the per-skill counts. Read them. Fix the four
-   zero-tool skills in section 3, or delete them if they are dead.
+2. Read the boot diagnostic from PR #148. Fix the three zero-tool skills in
+   section 3 (#149, #150, #151). Tyson decided fix, not delete.
 3. Parser change: the `[level]` endpoint prefix, plus the derived index built
-   at registration. Additive; a skill with neither behaves exactly as today.
-4. Declare classifications across all 43 writes. Countdown to zero.
+   at registration, importing #148's derivation. Additive; a skill with
+   neither behaves exactly as today.
+4. Declare classifications across all writes. Countdown to zero.
 5. Gate change: resolve before prompting, fail by level.
 
 Steps 3 and 5 want separate PRs. A parser change that returns null disables a
 skill silently, which section 3 shows is not hypothetical, and it deserves its
-own review and its own coupling run.
+own review and its own boot-diagnostic run.
 
 ---
 


### PR DESCRIPTION
Items 2 and 3 of the 2026-09-10 remediation.

**Status, 2026-09-10: revision 2 APPROVED by Tyson as designed. Not built.** The build goes to a fresh session, which gets the doc, the inherited notes below, and **the "Read first" section before anything else**. The doc was corrected after approval; head is `cadc0f5` (what changed is listed below).

**Update 2026-09-11: position_id is no longer a composed-value special case (read with Read first).** PR #142 has merged, adding `GET /positions/{{position_id}}` to `trading-api.md` (one position by id, ANY status, 404 when the value is not a position id). That is exactly the resolver this design specifies: a GET whose path ends at the identifier, returns the entity, and answers 404 as the negative marker. So `position_id` now resolves like any path identifier through a real GET. It does NOT need composed-value special handling, and it must NOT be re-derived as unresolvable, which was the pre-#142 state. The body below says `position_id` "is indexed from its sibling endpoints"; that is now literally true on main because the sibling GET exists. #148's `skill-diagnostics` test was split on #142's branch: the unresolvable-detection CAPABILITY is proved on a synthetic fixture nothing in the estate can move, and the live `trading-api.md` gets its own assertion that `position_id` resolves. Follow that split; do not re-pin an assertion to a live file an endpoint edit can change under it.

## Read first: resolved means the entity came back (decided)

As originally written, "a GET whose path ends at the parameter" would ship a validation layer that validates nothing. The parsed `path` includes the query string (`src/agents/skill-parser.js:98`), so the rule matches `{{query}}` on six GHL contact searches and `{{status}}` on n8n-api's executions filter, and a search answers 200 for any value. Separately, n8n-api uses `{{id}}` for both workflows and executions, so a name alone cannot pick the resolver.

**Decided by Tyson, 2026-09-10:**

- **A resolve succeeds only when the ENTITY comes back**, carrying the identifier asked for. Not when the call succeeds. An empty list, a search hit, or an entity with a different id is "could not resolve". Same require-a-positive-marker rule as the gate work.
- **The resolver keys on the endpoint, not the parameter name.** That settles `{{id}}`.

Implications for the derivation, to be pinned by tests against the real skill files: strip the query string before deriving resolvers (a query-string parameter is never an identifier); for each write, the resolver is the GET on the same resource whose path ends at the parameter; a body field matching more than one candidate is "could not resolve", never a guess. Doc section 4, rule 2 and "Resolved means the entity came back".

## Build conditions (Tyson, 2026-09-10)

> - The migration order stated in the PR body: declare first, enable second. All 43 unclassified on day one is expected, not a fault.
> - market_url and Stripe's customer field named explicitly as hard-failing because they are invisible to the index. Someone will hit that and should find the reason rather than rediscover it.
> - Soft-fail visible in the prompt, per my constraint 3.

**Correction:** the session that wrote revision 2 reported these as recorded in this body. They were not, until the edit at `71dea5a`. Recorded in the build log (#152).

Where each lands in the doc: declare-first is section 5, "The migration cost". `market_url` and Stripe's `customer` are section 4, "What derivation cannot see". Soft-fail visibility is section 6.

## Briefing the build session

Write the brief the way [`docs/trade-engine-handoff.md`](https://github.com/tysonven/QClaw/blob/main/docs/trade-engine-handoff.md) is written. It is the model: a document a session can pick up without reading the conversation that produced it, where every state claim is anchored to a SHA, a PR or issue number, or a live read, and anything unanchored says so. Its sections, which this brief should mirror:

1. **Where the work stands.** Merged vs open, each with its SHA or PR.
2. **The gate.** What must be true before the gate change turns on, and who decides. Here: declare first, enable second, with the countdown at zero.
3. **Open queue, and what blocks what.** #142 before the index closes; #149 to #151 before or after classification (it changes the count, see below).
4. **Verification rules the work established.** Each with the failing example that taught it.
5. **Deliberately not done, and why.** So nobody "fixes" a decision. Here: no per-skill identifier list, no build gate for skill files, Charlie's composing left out of scope.
6. **Practical notes.** Worktree per job, open the PR and stop, what cannot run locally.

## Decided since revision 2 was written

1. **The zero-tool skills: fix, do not delete** (Tyson). There are three, not four: `task-queue` is prompt-only and working. None is dead; all three have live services behind them. Filed as #149 (`ads-agency`), #150 (`content-studio`), #151 (`clipper`). Two of them also need a routing change, not just the parse fix: `specialist-scope` skills are never routed to Charlie, and delegation was retired on 2026-08-14. Done means an `activation` record in `tool-call.log`, not a registration line.
2. **Loud failure for an unparseable skill or an unresolvable path parameter: a boot-time error naming the file and line, not a build gate**, because a skill can be edited on the host (Tyson). Shipped as #148, which is also section 4's surfacing mechanism 1.
3. **Resolved means the entity came back; the resolver keys on the endpoint** (Tyson). See "Read first".

## What the build session inherits, not written down elsewhere

1. **Why a fresh session.** Four seams: the parser change (level prefix and derived index at registration), classification, resolve-before-prompt at the gate, and the soft-fail rendering in both the prompt and the approvals row. The value in the #142/#143 round came from mutation testing catching the author's own vacuous assertions, and that needs room.
2. **Test each seam at the seam.** In #143, tests that drove the gate directly would have passed with the executor wiring absent, and an executor-seam test had to be added before mutating. Expect the same shape here: a green gate with the index never built at registration.
3. **This code path already has a known trap.** `getSkillToolContext` returns `{}` for anything that is not skill-parsed before the `startsWith('skill:')` discriminator runs, so a builtin fixture never reaches it (build log 2026-09-10, #145). Resolve-before-prompt sits on that path. Choose fixtures that reach the line, not ones that produce the expected return.
4. **Assert timeouts by intercepting `AbortSignal.timeout`** and reading the milliseconds the call site asked for (same entry). "A signal is present" cannot tell one budget from another.
5. **Reuse #148's derivation; do not write a second one.** `src/agents/skill-diagnostics.js` already derives "a `{{param}}` with a GET ending at it". Two implementations of one rule is a maintained list by another name, which is constraint 2. It will need the "Read first" amendments too, so change it in one place.
6. **The countdown is 49, not 43, if #149 to #151 land first.** They add six writes (ads-agency 4, content-studio 1, clipper 1), all unclassified and hard-failing until declared, and none with a path identifier (the "nothing to resolve" state, like `n8n-router`).
7. **The resolver's timeout budget is undecided.** The `5s` in section 6 is illustrative. Skill fetches on main use 15s (`src/agents/skill-parser.js:260`) and #143 raises writes to 45s. The resolver GET sits between the call and the prompt, and nobody has chosen its budget.
8. **Resolve on the entity, key on the endpoint.** Decided; see "Read first". Kept in this list so the numbering the earlier discussion used still points somewhere.
9. **`{{id}}` names two entities in n8n-api.** Folded into item 8 by the endpoint-keying decision.

## What changed in the doc since approval

- Header: approved status, and a pointer to what was corrected.
- Section 3: three skills, not four, with the issue numbers and the routing layer.
- Section 4: rule 2 amended per the decision; "Resolved means the entity came back" added and marked read-first; surfacing mechanism 1 marked as shipped in #148, mechanism 2 marked as decided against; reuse of #148's derivation stated.
- Section 5: the 49 countdown.
- Section 6: the undecided resolver budget.
- Section 8: fix, not delete, pointing at #149 to #151.

## Revision 2 as reviewed

Unchanged below, except the zero-tool table, which is corrected above and in the doc.

### Constraint 2 withdrew my recommendation

You said not to build a per-skill allowlist and to prefer deriving from something already present. Revision 1's `## Identifiers` section was exactly the maintained list you warned about, so it is withdrawn.

**Revision 2 derives the index from the skill's own `## Endpoints` block.** A path parameter already declares that a token names an entity. A GET ending at that parameter already declares what resolves it. Both facts are in the file today, and nothing new gets maintained. ("Read first" above is where that sentence was not quite true.)

Measured with the real parser against the real files:

| | |
|---|---|
| write endpoints that parse | 43 |
| path identifiers across them | 17 |
| resolve to a GET already in the same skill | 16 |
| resolve once #142 lands | 17 |

**Body identifiers resolve through the same index**, which is what reaches the incident. `POST /positions/manual-close` has no path parameter, but `position_id` is indexed from its sibling endpoints, so the composed value resolves to a 404 and is refused before it becomes a prompt. Verified, including the `contactId` versus `contact_id` case drift on the GHL side.

The limits are stated rather than left to be found: an identifier whose name appears in no path is invisible. `market_url` on manual-close and Stripe's `customer` field are both live examples. Both hard-fail under constraint 1.

### Constraint 1 inverted the default

Undeclared now hard-fails instead of reading as `mutating`. `mutating` was the value that would have made a forgotten declaration silent, which is what you were pointing at. Undeclared shows as `unclassified` rather than being defaulted to a level, because showing `financial` would be a lie and showing nothing tells the operator less than telling them nobody has said.

The migration cost is stated rather than discovered: on the day this turns on, all 43 writes are unclassified and hard-fail. Declare first, enable second.

### Constraint 3 needs a column, not just a line

The prompt line was the easy half. A month later, the row for a validated approval and the row for an unvalidated one are identical, so `validated` becomes a column. Small migration, since the table is created with `IF NOT EXISTS`.

### Question 3, answered differently

Revision 1 recommended `mutating` for the GHL contact update because GHL retains field history. **I never verified that and should not have written it.** Confirming it needs a write against a real location.

Under constraint 1 the decision is now cheap: leaving it unclassified hard-fails, so not deciding costs a refusal rather than an unchecked overwrite. Classify it when someone has confirmed recoverability and recorded how.

