### PR TITLE
docs: build log 2026-09-10, unreachable discriminators and a green CI on the opposite branch

### DIFF
--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -26520,3 +26520,66 @@ Tracked as issue #136. The leaning is to drop the `branches: [main]` filter
 under `pull_request`, with the caveat that `deploy`'s `push`-only gating must be
 re-read afterwards rather than assumed, since widening the trigger must not make
 it reachable from a pull request.
+
+## 2026-09-10: the discriminator under test was unreachable, and a green CI that proved the opposite branch
+
+Two findings from the approval-gate remediation, both of the same class as the
+`assertIn` finding of 2026-09-09: a test that passes for a reason other than the
+one it names.
+
+**A test proved the guard clause above the guard it was written for.**
+`getSkillToolContext` returns `{}` for anything that is not a skill-parsed tool,
+and the discriminator that decides it is `preset.name.startsWith('skill:')`. The
+test asserted the contract using a builtin. A builtin is not in `_apiTools` at
+all, so the lookup one line earlier returns `{}` and the discriminator never
+runs. The mutant that exposed it changed the discriminator to return a populated
+object for non-skill presets and survived: the test could not reach the line it
+was written to protect.
+
+The fixture that kills it is a non-skill API preset, which does live in
+`_apiTools` alongside skill tools. A second mutant then survived that one too,
+loosening `startsWith('skill:')` to `includes('skill')`, because no fixture had
+a preset name that could tell a prefix from a substring. The probe that kills
+both is a preset named with a lower-case `skill` somewhere other than the start.
+Case matters here and cost a round: a capitalised `Skillshare` is invisible to
+`includes('skill')`, so the first attempt at that fixture also survived.
+
+> A guard clause earlier in the function can make the guard under test
+> unreachable. Choose the fixture that reaches the line, not the one that
+> produces the expected return value.
+
+**A test pinned the constants and the branch, and not the wiring between them.**
+The skill-write timeout fix sets one budget for writes and another for reads.
+The tests asserted the inequality between the constants, asserted that a signal
+was attached to the fetch, and asserted the branch could tell a write from a
+read. All three passed against a mutant that kept the whole branch and gave
+writes the READ budget, which is the entire defect restored. "A signal is
+present" cannot distinguish 45s from 15s. What kills it is intercepting
+`AbortSignal.timeout` and reading the milliseconds the call site asked for.
+
+Same shape as the GATE 8 lesson: keep the entire shape and change only the
+source of the substance.
+
+**CI green and local red, explained rather than declared.** Five test files
+failed locally and passed in CI. Four were native bindings, from installing with
+`--ignore-scripts`: three `better_sqlite3` and one `canvas`. The fifth was not.
+
+`tests/probes.test.js` asserts that any probe returning `ok: false` carries an
+error string. The pm2 probe's final return, the one reached when the process
+list parses cleanly, has no `error` key at all. It is reached whenever
+`allOnline` is false, which is precisely the condition the probe exists to
+detect. CI passes because pm2 is not installed there, so `execSync` throws and
+the catch path, which does set `error`, runs instead. The two environments were
+executing different branches, and neither was the correct one.
+
+Reproduced on the host without touching pm2: a shim on `PATH` emitted the real
+`pm2 jlist` output with one status flipped to `stopped`, and the probe returned
+`ok: false` with `error` undefined. Real pm2 state was verified unchanged
+afterwards. The consumer at `bootstrap.js` renders
+`probe pm2_processes failed: no detail`, and the name of the stopped process,
+which the probe does put in `detail.offline`, is dropped by both the warning
+line and the markdown renderer. So the bootstrap reports an outage without
+saying what is down, at the moment something is down.
+
+> Two environments disagreeing is the signal. Declaring one of them correct
+> without explaining the disagreement discards it.

--- a/QCLAW_BUILD_LOG.md
+++ b/QCLAW_BUILD_LOG.md
@@ -26560,17 +26560,26 @@ present" cannot distinguish 45s from 15s. What kills it is intercepting
 Same shape as the GATE 8 lesson: keep the entire shape and change only the
 source of the substance.
 
-**CI green and local red, explained rather than declared.** Five test files
-failed locally and passed in CI. Four were native bindings, from installing with
-`--ignore-scripts`: three `better_sqlite3` and one `canvas`. The fifth was not.
+**Two environments executing different branches, neither of them the branch
+under test.** Five test files failed locally and passed in CI. Four were native
+bindings, from installing with `--ignore-scripts`: three `better_sqlite3` and
+one `canvas`. The fifth was not, and it is a new variant worth naming.
 
 `tests/probes.test.js` asserts that any probe returning `ok: false` carries an
-error string. The pm2 probe's final return, the one reached when the process
-list parses cleanly, has no `error` key at all. It is reached whenever
-`allOnline` is false, which is precisely the condition the probe exists to
-detect. CI passes because pm2 is not installed there, so `execSync` throws and
-the catch path, which does set `error`, runs instead. The two environments were
-executing different branches, and neither was the correct one.
+error string. The pm2 probe has two failure returns. The `execSync` catch sets
+an error. The final return, reached when the process list parses cleanly, has no
+`error` key, and it is reached exactly when a process is down, which is the
+condition the probe exists for.
+
+CI passes because pm2 is absent there, so the throw path runs and that path sets
+an error. A developer machine has pm2 but none of the six processes, so the list
+parses, the final return runs, and the assertion fails. Each environment ran a
+different branch of the same function and **neither ran the branch under test**.
+Nobody was testing the probe's actual job.
+
+> Green here and red there is not a verdict on either environment. Find which
+> branch each one runs, because the answer can be "neither runs the one that
+> matters".
 
 Reproduced on the host without touching pm2: a shim on `PATH` emitted the real
 `pm2 jlist` output with one status flipped to `stopped`, and the probe returned
@@ -26578,8 +26587,13 @@ Reproduced on the host without touching pm2: a shim on `PATH` emitted the real
 afterwards. The consumer at `bootstrap.js` renders
 `probe pm2_processes failed: no detail`, and the name of the stopped process,
 which the probe does put in `detail.offline`, is dropped by both the warning
-line and the markdown renderer. So the bootstrap reports an outage without
-saying what is down, at the moment something is down.
+line and the markdown renderer. So the bootstrap reported an outage without
+saying what was down, at the moment something was down, on the host that runs
+the trade engine.
+
+Tracked as issue #146 and fixed in PR #147, which also makes the branch
+reachable from a test: the result-building logic became a pure function the
+tests drive with fixtures identical in both environments.
 
 > Two environments disagreeing is the signal. Declaring one of them correct
 > without explaining the disagreement discards it.


### PR DESCRIPTION
Three entries, all the same class as the `assertIn` finding of 2026-09-09: a test that passes for a reason other than the one it names.

Two came from mutation-testing my own work on #143 and are the ones you flagged as worth recording. The third is the CI-versus-local disagreement, which turned out to contain a real defect rather than an environmental difference.

- **A guard clause earlier in the function made the guard under test unreachable.** The fixture returned the expected value via a branch that ran one line sooner. Includes the follow-on: the fixture that fixes it still could not tell a prefix match from a substring match, and the case of the probe string mattered.
- **Constants and branch pinned, wiring between them not.** A mutant that kept the whole timeout branch and gave writes the read budget restored the entire defect and survived three assertions.
- **The pm2 probe returns `ok: false` with no `error`.** Reported separately as issue #146. CI was green because pm2 is absent there, so the throw path ran instead of the clean-parse path.

No code changes.