### PR TITLE
feat(skills): name a skill that declares an HTTP surface and registers nothing

### DIFF
--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -9,6 +9,7 @@ import { readdirSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { log } from '../core/logger.js';
 import { parseSkill, skillToTools, executeSkillTool } from './skill-parser.js';
+import { inspectSkills, formatReport } from './skill-diagnostics.js';
 import { loadSkills } from './skill-loader.js';
 import { scanSpecialistResults } from '../tools/delegate-to.js';
 import { regenerateWithGates, isGatedTurn, buildProvenanceText } from './gates.js';
@@ -310,6 +311,27 @@ export class Agent {
             }
             log.debug(`Skill [${skill.name}]: registered ${tools.length} tools (scope: ${this.name})`);
           }
+        }
+
+        // A skill that declares an HTTP surface and registers nothing is an
+        // error, named at boot with its file and line. parseSkill returns null
+        // silently, and four skill files sat broken from the day they were
+        // created because nothing ever said so: two with `Base URL:` under the
+        // wrong heading, one with an em dash the endpoint grammar rejects, all
+        // three with live services behind them. Charlie appeared to have
+        // capabilities he did not have.
+        //
+        // Prose-only skills produce nothing here: the signal is derived from
+        // the file (an `## Endpoints` heading, a `Base URL:` line, or a
+        // non-empty http permission), never from a list of skill names.
+        try {
+          const report = inspectSkills(this.skills, this.services.secrets);
+          for (const line of formatReport(report)) {
+            if (line.startsWith('  ')) log.warn(line);
+            else log.error(line);
+          }
+        } catch (err) {
+          log.warn(`skill diagnostics failed: ${err.message}`);
         }
       }
     }

--- a/src/agents/skill-diagnostics.js
+++ b/src/agents/skill-diagnostics.js
@@ -1,0 +1,243 @@
+/**
+ * QuantumClaw — Skill parse diagnostics
+ *
+ * Answers one question at boot: does this skill file declare an HTTP surface
+ * that it then fails to deliver?
+ *
+ * WHY THIS EXISTS
+ *
+ * `parseSkill` returns null when a skill has no base URL or no endpoint that
+ * matches the endpoint grammar, and null means the skill registers zero tools.
+ * Nothing reported that. On 2026-09-10 an audit found four skill files that
+ * present as HTTP surfaces and register nothing, and had done since the day
+ * each was created:
+ *
+ *   ads-agency      `Base URL:` sits under `## Endpoints`, but the parser only
+ *   content-studio  reads it under `## Auth`, so baseUrl stays null
+ *   clipper         endpoint lines separate path from description with an em
+ *                   dash, which the grammar does not match, and there is no
+ *                   `Base URL:` line at all
+ *   task-queue      NOT a defect: prompt-only, no `## Endpoints` section
+ *
+ * Charlie appeared to have four capabilities he did not have. The webhooks and
+ * services behind three of them were live the whole time.
+ *
+ * WHAT COUNTS AS "DECLARES AN HTTP SURFACE"
+ *
+ * Derived from the file, never from a maintained list of skill names. A file
+ * is treated as intending to be an HTTP surface if ANY of these is true:
+ *
+ *   - it has an `## Endpoints` section heading
+ *   - it has a `Base URL:` line anywhere
+ *   - it declares a non-empty `http:` permission
+ *
+ * A prose-only skill has none of the three and is silently fine, which is why
+ * `identity`, `build`, `lanes` and the rest never appear. `task-queue` has
+ * none of them either: its `POST /rest/v1/charlie_tasks` sits under
+ * "Creating Tasks Programmatically" as documentation, and the file is
+ * `surface: prompt`. Deriving the signal from the file rather than naming the
+ * skills is deliberate. A list of "skills that are allowed to fail" is the
+ * thing that drifts.
+ */
+
+import { parseSkill, skillToTools } from './skill-parser.js';
+
+const ENDPOINT_RE = /^(GET|POST|PUT|PATCH|DELETE)\s+(\/[^\s]*)\s*-\s*(.+)/i;
+const VERB_LINE_RE = /^(GET|POST|PUT|PATCH|DELETE)\s+\S/i;
+
+/**
+ * Does this file present as an HTTP surface?
+ * @param {string} content
+ * @returns {{ intends: boolean, signals: string[] }}
+ */
+export function declaresHttpSurface(content) {
+  const signals = [];
+  const lines = String(content ?? '').split('\n');
+  if (lines.some((l) => l.trim().startsWith('## Endpoints'))) signals.push('## Endpoints section');
+  if (lines.some((l) => l.trim().startsWith('Base URL:'))) signals.push('Base URL: line');
+  const httpPerm = lines.find((l) => /^-\s+http:/i.test(l.trim()));
+  if (httpPerm) {
+    const value = httpPerm.replace(/^-\s+http:\s*/i, '').trim();
+    // Only a HOST LIST counts. The permission line is free text in practice:
+    // `business-intelligence` writes "Inherited from Echo's skills (GHL,
+    // Stripe, n8n)", which is a sentence about where its data comes from, not
+    // a declaration that this file makes HTTP calls. That file is
+    // surface: prompt with no endpoints and is correctly silent. Treating any
+    // non-"none" value as a signal reported it as broken, which is how a
+    // diagnostic earns being ignored.
+    const hosts = value
+      .replace(/[[\]]/g, '')
+      .split(',')
+      .map((h) => h.trim())
+      // A host has a dot, or is localhost. A bare word does not qualify:
+      // "Stripe" and "n8n" are service NAMES in a sentence, and even "none"
+      // is a bare word, so a looser pattern matched the very value that means
+      // this skill makes no HTTP calls.
+      .filter((h) => /^(localhost(:\d+)?|[a-z0-9][a-z0-9-]*(\.[a-z0-9-]+)+(:\d+)?)$/i.test(h));
+    if (hosts.length > 0) signals.push(`http permission [${hosts.join(', ')}]`);
+  }
+  return { intends: signals.length > 0, signals };
+}
+
+/**
+ * Explain, in terms an operator can act on, why a file that declares an HTTP
+ * surface produced no tools. Returns the specific cause and the line it is on
+ * where one can be identified.
+ *
+ * @param {string} content
+ * @returns {{ reason: string, line: number|null, hint: string }}
+ */
+export function diagnose(content) {
+  const lines = String(content ?? '').split('\n');
+
+  // Which section is each line in? The parser only reads `Base URL:` while it
+  // is inside `## Auth`, which is the failure ads-agency and content-studio hit.
+  let section = null;
+  let baseUrlLine = null;
+  let baseUrlSection = null;
+  let sawEndpointsHeading = false;
+  const verbLines = [];
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (t.startsWith('## Auth')) { section = 'auth'; continue; }
+    if (t.startsWith('## Endpoints')) { section = 'endpoints'; sawEndpointsHeading = true; continue; }
+    if (t.startsWith('## Permissions')) { section = 'permissions'; continue; }
+    if (t.startsWith('## Usage Notes') || t.startsWith('## Source')) { section = 'notes'; continue; }
+    if (t.startsWith('## ')) { section = 'other'; continue; }
+
+    if (t.startsWith('Base URL:') && baseUrlLine === null) {
+      baseUrlLine = i + 1;
+      baseUrlSection = section;
+    }
+    if (VERB_LINE_RE.test(t)) verbLines.push({ n: i + 1, text: t, inEndpoints: section === 'endpoints' });
+  }
+
+  if (baseUrlLine !== null && baseUrlSection !== 'auth') {
+    return {
+      reason: `"Base URL:" is inside ${baseUrlSection ? `the ${baseUrlSection} section` : 'no section'}, and the parser only reads it under "## Auth"`,
+      line: baseUrlLine,
+      hint: 'move the "Base URL:" line under a "## Auth" heading',
+    };
+  }
+  if (baseUrlLine === null) {
+    return {
+      reason: 'no "Base URL:" line, so the skill has no base URL to build requests from',
+      line: null,
+      hint: 'add a "## Auth" section containing "Base URL: https://..."',
+    };
+  }
+
+  // Base URL is fine, so the endpoints are the problem.
+  const inEndpoints = verbLines.filter((v) => v.inEndpoints);
+  const matching = inEndpoints.filter((v) => ENDPOINT_RE.test(v.text));
+  if (matching.length === 0) {
+    if (inEndpoints.length > 0) {
+      const first = inEndpoints[0];
+      const emDash = first.text.includes('—') || first.text.includes('–');
+      return {
+        reason: emDash
+          ? 'endpoint lines separate the path from the description with a dash the grammar does not accept'
+          : 'no endpoint line matches "METHOD /path - description"',
+        line: first.n,
+        hint: emDash
+          ? 'use a plain hyphen-minus "-" between the path and the description'
+          : 'each endpoint must be one line: METHOD /path - description',
+      };
+    }
+    return {
+      reason: sawEndpointsHeading
+        ? 'the "## Endpoints" section contains no METHOD /path lines'
+        : 'no "## Endpoints" section, so no endpoint is ever read',
+      line: null,
+      hint: 'add endpoint lines as "METHOD /path - description" under "## Endpoints"',
+    };
+  }
+  return {
+    reason: 'the skill parsed but produced no tools',
+    line: null,
+    hint: 'check that at least one endpoint has a path',
+  };
+}
+
+/**
+ * Inspect every loaded skill and return one report row per file that declares
+ * an HTTP surface. Pure: no logging, no process state, so it can be tested.
+ *
+ * @param {Array<{name: string, content: string, filename?: string}>} skills
+ * @param {object|null} secrets
+ * @returns {{ rows: Array<object>, broken: Array<object>, unresolved: Array<object> }}
+ */
+export function inspectSkills(skills, secrets = null) {
+  const rows = [];
+  for (const skill of skills || []) {
+    const { intends, signals } = declaresHttpSurface(skill.content);
+    if (!intends) continue;
+
+    const file = skill.filename || `${skill.name}.md`;
+    const parsed = parseSkill(skill.name, skill.content, secrets);
+    if (!parsed) {
+      const d = diagnose(skill.content);
+      rows.push({
+        file, name: skill.name, ok: false, tools: 0, signals,
+        reason: d.reason, line: d.line, hint: d.hint, unresolvedParams: [],
+      });
+      continue;
+    }
+
+    const tools = skillToTools(parsed);
+
+    // A write endpoint with a {{param}} and no GET in the same skill ending at
+    // that param cannot have its identifier checked before approval. Derived
+    // from the endpoint block, so there is nothing to maintain.
+    const norm = (s) => s.toLowerCase().replace(/[_-]/g, '');
+    const resolvers = new Set();
+    for (const e of parsed.endpoints) {
+      if (e.method !== 'GET') continue;
+      const m = e.path.match(/\{\{([^}]+)\}\}\/?$/);
+      if (m) resolvers.add(norm(m[1].trim()));
+    }
+    const unresolvedParams = [];
+    for (const e of parsed.endpoints) {
+      if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(e.method)) continue;
+      for (const m of e.path.matchAll(/\{\{([^}]+)\}\}/g)) {
+        const n = m[1].trim();
+        if (n.startsWith('secrets.') || n.startsWith('config.')) continue;
+        if (!resolvers.has(norm(n))) unresolvedParams.push({ param: n, endpoint: `${e.method} ${e.path}` });
+      }
+    }
+
+    rows.push({
+      file, name: skill.name, ok: tools.length > 0, tools: tools.length, signals,
+      reason: tools.length > 0 ? null : 'parsed but produced no tools',
+      line: null, hint: null, unresolvedParams,
+    });
+  }
+
+  return {
+    rows,
+    broken: rows.filter((r) => !r.ok),
+    unresolved: rows.filter((r) => r.unresolvedParams.length > 0),
+  };
+}
+
+/**
+ * Format the report for the boot log. Returns an array of lines, empty when
+ * everything is healthy, so a clean boot stays quiet.
+ */
+export function formatReport(report) {
+  const lines = [];
+  for (const r of report.broken) {
+    lines.push(
+      `skill "${r.name}" (${r.file}${r.line ? `:${r.line}` : ''}) declares an HTTP surface but registered 0 tools: ${r.reason}. Fix: ${r.hint}.`
+    );
+    lines.push(`  it looked like an HTTP skill because of: ${r.signals.join(', ')}`);
+  }
+  for (const r of report.unresolved) {
+    for (const u of r.unresolvedParams) {
+      lines.push(
+        `skill "${r.name}" (${r.file}): ${u.endpoint} takes {{${u.param}}} but no GET in this skill ends at {{${u.param}}}, so that identifier cannot be resolved before approval.`
+      );
+    }
+  }
+  return lines;
+}

--- a/tests/skill-diagnostics.test.js
+++ b/tests/skill-diagnostics.test.js
@@ -1,0 +1,203 @@
+/**
+ * A skill that declares an HTTP surface and registers nothing must say so.
+ *
+ * Four skill files presented as HTTP surfaces and registered zero tools, on
+ * every boot since the day each was created. Verified against the live
+ * tool-call.log on 2026-09-10, where ten skills register and these never
+ * appear. The services behind three of them were live the whole time: four
+ * n8n webhooks answering, and clipper-worker serving 200 on :4002.
+ *
+ * `parseSkill` returns null and nothing reported it.
+ *
+ * These tests use the REAL skill files as fixtures, not hand-written strings,
+ * because a hand-written fixture proves the diagnostic can explain a file I
+ * wrote to be explained. The real files are the ones that fooled everybody.
+ *
+ * The prose-only skills matter as much as the broken ones: a diagnostic that
+ * shouts about `identity.md` gets muted, and a muted diagnostic is the
+ * original defect wearing a hat.
+ *
+ * Run: node tests/skill-diagnostics.test.js
+ */
+
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  declaresHttpSurface,
+  diagnose,
+  inspectSkills,
+  formatReport,
+} from '../src/agents/skill-diagnostics.js';
+
+const SKILLS = join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'agents', 'skills');
+
+let passed = 0;
+let failed = 0;
+function check(label, cond, detail = '') {
+  if (cond) { console.log(`  ✓ ${label}`); passed++; }
+  else { console.error(`  ✗ ${label}${detail ? ': ' + detail : ''}`); failed++; }
+}
+
+const read = (n) => readFileSync(join(SKILLS, `${n}.md`), 'utf8');
+const skill = (n) => ({ name: n, content: read(n), filename: `${n}.md` });
+
+function main() {
+  // ── 1. The signal is derived, and it separates the two groups ──
+  //
+  // Broken-but-intending on one side, legitimately prose-only on the other.
+  for (const n of ['ads-agency', 'content-studio', 'clipper', 'trading-api', 'ghl-fsc', 'stripe']) {
+    const { intends, signals } = declaresHttpSurface(read(n));
+    check(`${n}: recognised as declaring an HTTP surface`, intends === true, JSON.stringify(signals));
+  }
+  for (const n of ['identity', 'build', 'lanes', 'delegation', 'security', 'task-queue', 'business-intelligence']) {
+    check(`${n}: correctly NOT treated as an HTTP surface`,
+      declaresHttpSurface(read(n)).intends === false,
+      JSON.stringify(declaresHttpSurface(read(n)).signals));
+  }
+
+  // task-queue is the one that could plausibly be misread. It has a
+  // `POST /rest/v1/charlie_tasks` line, but under "Creating Tasks
+  // Programmatically", and the file is surface: prompt. It was routed 9 times
+  // as prompt content in the live log, which is it working.
+  check('task-queue has a POST line and is still not an HTTP surface',
+    read('task-queue').includes('POST /rest/v1/charlie_tasks')
+      && declaresHttpSurface(read('task-queue')).intends === false);
+
+  // business-intelligence is the other near-miss, and it caught a real flaw in
+  // an earlier version of this heuristic. Its permission line reads
+  // "http: Inherited from Echo's skills (GHL, Stripe, n8n)", a sentence rather
+  // than a host list, and treating any non-"none" value as a signal reported a
+  // healthy prompt-only skill as broken.
+  check('business-intelligence: a prose http permission is not a host list',
+    read('business-intelligence').includes("Inherited from Echo's skills")
+      && declaresHttpSurface(read('business-intelligence')).intends === false,
+    JSON.stringify(declaresHttpSurface(read('business-intelligence')).signals));
+  check('a real host list IS still a signal, so the tightening did not gut it',
+    declaresHttpSurface('- http: [services.leadconnectorhq.com]').intends === true
+      && declaresHttpSurface('- http: [localhost:4003]').intends === true);
+  check('http: none is still not a signal',
+    declaresHttpSurface('- http: none').intends === false);
+
+  // ── 2. Every real skill file is classified, none crash ──
+  const all = readdirSync(SKILLS).filter((f) => f.endsWith('.md'))
+    .map((f) => ({ name: f.replace(/\.md$/, ''), content: readFileSync(join(SKILLS, f), 'utf8'), filename: f }));
+  let threw = null;
+  let report;
+  try { report = inspectSkills(all, null); } catch (e) { threw = e; }
+  check('inspectSkills survives every real skill file', threw === null, String(threw));
+
+  const brokenNames = report.broken.map((r) => r.name).sort();
+  check('exactly the three known-broken skills are reported',
+    JSON.stringify(brokenNames) === JSON.stringify(['ads-agency', 'clipper', 'content-studio']),
+    JSON.stringify(brokenNames));
+
+  const okNames = report.rows.filter((r) => r.ok).map((r) => r.name).sort();
+  check('the ten working HTTP skills are reported healthy',
+    okNames.length >= 8 && okNames.includes('trading-api') && okNames.includes('ghl-fsc')
+      && okNames.includes('stripe') && okNames.includes('n8n-router'),
+    JSON.stringify(okNames));
+
+  check('no prose-only skill appears in the report at all',
+    !report.rows.some((r) => ['identity', 'build', 'lanes', 'task-queue', 'security'].includes(r.name)),
+    JSON.stringify(report.rows.map((r) => r.name)));
+
+  // ── 3. The cause is specific and actionable, per file ──
+  //
+  // Pinned per skill because a diagnostic that says "failed to parse" for all
+  // three is the same as no diagnostic. The three causes are different.
+  const ads = diagnose(read('ads-agency'));
+  check('ads-agency: names the Base URL section placement as the cause',
+    /Base URL/.test(ads.reason) && /## Auth/.test(ads.reason), ads.reason);
+  check('ads-agency: reports the line number of the Base URL',
+    ads.line === 14, `got ${ads.line}`);
+  check('ads-agency: hint says to move it under ## Auth',
+    /## Auth/.test(ads.hint), ads.hint);
+
+  const cs = diagnose(read('content-studio'));
+  check('content-studio: same cause, its own line number',
+    /Base URL/.test(cs.reason) && cs.line === 21, `${cs.reason} line ${cs.line}`);
+
+  const clip = diagnose(read('clipper'));
+  check('clipper: names the missing Base URL, which it hits first',
+    /no "Base URL:" line/.test(clip.reason), clip.reason);
+
+  // clipper has a second, independent defect: em-dash endpoint lines. Once the
+  // base URL is supplied, that is what it fails on. A fix for one is not a fix
+  // for the other, and the diagnostic must say so at each stage.
+  const clipWithBase = read('clipper').replace('## Service', '## Auth\nBase URL: http://localhost:4002\n\n## Service');
+  const clip2 = diagnose(clipWithBase);
+  check('clipper: with a Base URL added, the em dash becomes the reported cause',
+    /dash/.test(clip2.reason), clip2.reason);
+  check('clipper: the em-dash hint names the hyphen-minus fix',
+    /hyphen/.test(clip2.hint), clip2.hint);
+  check('clipper: reports the line of the first offending endpoint',
+    typeof clip2.line === 'number' && clip2.line > 0, `got ${clip2.line}`);
+
+  // ── 4. Fixing a file really does clear it ──
+  //
+  // The mutation-proof direction: not "the diagnostic fires", but "it stops
+  // firing for the right reason". A check that only ever sees red cannot tell
+  // a working diagnostic from a stuck one.
+  const adsFixed = read('ads-agency').replace(
+    '## Endpoints\nBase URL: https://webhook.flowos.tech',
+    '## Auth\nBase URL: https://webhook.flowos.tech\n\n## Endpoints'
+  );
+  check('PRECONDITION: the ads-agency fix actually changed the file',
+    adsFixed !== read('ads-agency'));
+  const fixedReport = inspectSkills([{ name: 'ads-agency', content: adsFixed, filename: 'ads-agency.md' }], null);
+  check('ads-agency: moving Base URL under ## Auth clears the error',
+    fixedReport.broken.length === 0, JSON.stringify(fixedReport.broken.map((b) => b.reason)));
+  check('ads-agency: and it then registers its four webhook tools',
+    fixedReport.rows[0]?.tools === 4, `got ${fixedReport.rows[0]?.tools}`);
+
+  // ── 5. Unresolvable path identifiers ──
+  const tradingRow = report.rows.find((r) => r.name === 'trading-api');
+  check('trading-api on main: position_id has no GET ending at it',
+    tradingRow?.unresolvedParams.some((u) => u.param === 'position_id'),
+    JSON.stringify(tradingRow?.unresolvedParams));
+
+  const ghlRow = report.rows.find((r) => r.name === 'ghl-fsc');
+  check('ghl-fsc: contact_id resolves, so nothing is reported',
+    ghlRow?.unresolvedParams.length === 0, JSON.stringify(ghlRow?.unresolvedParams));
+
+  // PR #142 adds GET /positions/{{position_id}}. Model that here so the check
+  // is known to clear rather than assumed to.
+  const withGet = read('trading-api').replace(
+    'GET /positions/{{position_id}}/alerts',
+    'GET /positions/{{position_id}} - One position by id\nGET /positions/{{position_id}}/alerts'
+  );
+  const after142 = inspectSkills([{ name: 'trading-api', content: withGet, filename: 'trading-api.md' }], null);
+  check('PRECONDITION: the trading-api fixture actually changed',
+    withGet !== read('trading-api'));
+  check('trading-api with #142 merged: position_id resolves and clears',
+    after142.rows[0]?.unresolvedParams.length === 0,
+    JSON.stringify(after142.rows[0]?.unresolvedParams));
+
+  // ── 6. The boot output ──
+  const lines = formatReport(report);
+  check('report names each broken skill and its file',
+    ['ads-agency', 'content-studio', 'clipper'].every((n) => lines.some((l) => l.includes(`"${n}"`))),
+    JSON.stringify(lines.slice(0, 2)));
+  check('report includes a file:line for ads-agency',
+    lines.some((l) => l.includes('ads-agency.md:14')),
+    JSON.stringify(lines.find((l) => l.includes('ads-agency'))));
+  check('report says what looked like an HTTP skill',
+    lines.some((l) => l.includes('it looked like an HTTP skill because of')));
+  check('report explains the unresolvable identifier in words, not a code',
+    lines.some((l) => l.includes('position_id') && l.includes('cannot be resolved before approval')),
+    JSON.stringify(lines.filter((l) => l.includes('position_id'))));
+
+  const clean = formatReport(inspectSkills([skill('ghl-fsc')], null));
+  check('a healthy estate produces NO output, so the diagnostic stays loud',
+    clean.length === 0, JSON.stringify(clean));
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+if (!existsSync(SKILLS)) {
+  console.error(`skills dir missing at ${SKILLS}`);
+  process.exit(1);
+}
+main();


### PR DESCRIPTION
The mechanism you approved: a boot-time error naming the file and the line, not a build gate, since a skill can be edited on the host where a gate would never run.

Independent of #142, #143 and #147. It reports on the four skills but does not change them, so it can land before you decide what happens to them.

## What it prints on the current tree

```
skill "ads-agency" (ads-agency.md:14) declares an HTTP surface but registered 0 tools:
  "Base URL:" is inside the endpoints section, and the parser only reads it under "## Auth".
  Fix: move the "Base URL:" line under a "## Auth" heading.
  it looked like an HTTP skill because of: ## Endpoints section, Base URL: line, http permission [webhook.flowos.tech]

skill "clipper" (clipper.md) declares an HTTP surface but registered 0 tools:
  no "Base URL:" line, so the skill has no base URL to build requests from.

skill "content-studio" (content-studio.md:21) ... same cause as ads-agency

skill "trading-api" (trading-api.md): POST /positions/{{position_id}}/hold takes {{position_id}}
  but no GET in this skill ends at {{position_id}}, so that identifier cannot be resolved before approval.
```

Seven lines. A healthy estate prints nothing.

## The signal is derived, not a list

An `## Endpoints` heading, a `Base URL:` line, or an http permission that parses as a host list. Never a list of skill names, because a list of skills allowed to fail is the thing that drifts, which is how these four went unnoticed for months.

**The host-list condition earned its precision by getting it wrong twice**, and the real files caught both:

- Counting any http permission that was not `none` reported `business-intelligence`, a healthy prompt-only skill whose permission line reads "Inherited from Echo's skills (GHL, Stripe, n8n)". A sentence, not a declaration.
- Accepting any bare word then matched `Stripe`, and also matched `none` itself.

A host now needs a dot, or is localhost. A diagnostic that cries wolf gets muted, and a muted diagnostic is the original defect wearing a hat.

## Also the surfacing mechanism #144 owes

The unresolvable-identifier check is the same derivation the identifier design proposes: a write with a `{{param}}` and no GET in the same skill ending at that param. So this ships the "what surfaces a skill that has none" half of #144 ahead of the gate work, and it is how you would have found these four years ago.

The `trading-api` line clears when #142 lands. The tests model that rather than assume it.

## Tests

41 assertions, driven off the **real skill files** rather than hand-written fixtures. A fixture I wrote to be explained proves only that the diagnostic can explain it; these are the files that fooled everybody.

Both directions are pinned, including that fixing `ads-agency` clears its error and yields its four webhook tools. A check that only ever sees red cannot tell a working diagnostic from a stuck one.

Nine mutants, all killed, including treating any GET as a resolver rather than one ending at the parameter, and skipping unparseable skills silently, which is the original defect restored.