### PR TITLE
fix(trade-engine): stop /health access polls burying the boot banner

### DIFF
--- a/src/trade_engine/config.py
+++ b/src/trade_engine/config.py
@@ -341,5 +341,52 @@ def install_bot_token_redaction() -> None:
             target.addFilter(_RedactBotToken())
 
 
+# The dashboard polls /health on a short interval. At INFO, uvicorn logs one
+# access line per poll, so on 2026-09-11 633 of 662 out-log lines were
+# 'GET /health 200 OK' and the boot banner was unreachable in any reasonable
+# window (it obstructed deploy verification three times). Drop the SUCCESSFUL
+# /health access lines only: a 4xx/5xx health check still logs, so a degraded
+# engine (the handler returns 503 on a Supabase failure) stays visible.
+_HEALTH_ACCESS_RE = re.compile(r'"(?:GET|HEAD) /health(?:[/?]\S*)? HTTP/[\d.]+"\s+(\d{3})')
+
+
+class _SuppressHealthAccess(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        # uvicorn's access record carries structured args:
+        # (client_addr, method, full_path, http_version, status_code). Prefer
+        # them, so the decision does not depend on the formatted string.
+        args = record.args
+        if isinstance(args, tuple) and len(args) >= 5:
+            method, path, status = args[1], args[2], args[4]
+            try:
+                if (
+                    method in ("GET", "HEAD")
+                    and str(path).split("?", 1)[0] == "/health"
+                    and 200 <= int(status) < 400
+                ):
+                    return False
+            except (TypeError, ValueError):
+                return True
+            return True
+        # Fall back to the formatted line for any other uvicorn version/shape.
+        try:
+            match = _HEALTH_ACCESS_RE.search(record.getMessage())
+        except Exception:  # noqa: BLE001 - logging must never raise
+            return True
+        return not (match and match.group(1)[0] in "23")
+
+
+def install_health_access_suppression() -> None:
+    """Drop successful /health access lines from uvicorn's access log.
+
+    Idempotent. Call it from the app lifespan, i.e. AFTER uvicorn has applied
+    its own logging dictConfig, so the filter is attached to the live
+    `uvicorn.access` logger and cannot be cleared by that config.
+    """
+    target = logging.getLogger("uvicorn.access")
+    if not any(isinstance(f, _SuppressHealthAccess) for f in target.filters):
+        target.addFilter(_SuppressHealthAccess())
+
+
 # Module-level singleton. Import failure here is intentional and fatal.
 config = Config()

--- a/src/trade_engine/main.py
+++ b/src/trade_engine/main.py
@@ -35,7 +35,11 @@ from pydantic import ValidationError  # noqa: E402
 
 from src.trade_engine.approval import ApprovalGate, run_update_poller  # noqa: E402
 from src.trade_engine.executor import TradeExecutor  # noqa: E402
-from src.trade_engine.config import config, configure_logging  # noqa: E402
+from src.trade_engine.config import (  # noqa: E402
+    config,
+    configure_logging,
+    install_health_access_suppression,
+)
 from src.trade_engine.database import (  # noqa: E402
     HEARTBEAT_MONITOR,
     HEARTBEAT_SCANNER,
@@ -227,6 +231,10 @@ async def scheduled_monitor() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global _poller_task
+
+    # After uvicorn has configured its own logging, so the /health access
+    # filter attaches to the live uvicorn.access logger and is not cleared.
+    install_health_access_suppression()
 
     log.info("trade-engine %s starting on %s:%s", config.version,
              config.trade_engine_host, config.trade_engine_port)

--- a/tests/test_health_access_filter.py
+++ b/tests/test_health_access_filter.py
@@ -1,0 +1,110 @@
+"""The /health access-log filter drops the flood, not the signal.
+
+The dashboard polls /health on a short interval, so at INFO uvicorn's access
+line for each poll buried the boot banner (633 of 662 out-log lines on
+2026-09-11). The filter drops SUCCESSFUL /health access lines only. These
+tests pin that it does not also swallow a degraded health check or ordinary
+traffic, and that it works whether uvicorn hands the record structured args or
+only a formatted line.
+
+Run: python -m pytest tests/test_health_access_filter.py -q
+"""
+
+import logging
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# config.py fail-fasts on missing env, so seed placeholders before importing it.
+for _key in (
+    "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "ANTHROPIC_API_KEY",
+    "TELEGRAM_BOT_TOKEN", "OWNER_TELEGRAM_CHAT_ID",
+    "POLYMARKET_PRIVATE_KEY", "POLYMARKET_FUNDER_ADDRESS",
+):
+    os.environ.setdefault(_key, f"test-{_key.lower()}")
+
+from src.trade_engine.config import (  # noqa: E402
+    _SuppressHealthAccess,
+    install_health_access_suppression,
+)
+
+UVICORN_ACCESS_FMT = '%s - "%s %s HTTP/%s" %d'
+
+
+def _record_with_args(method, path, status):
+    """A record shaped like uvicorn's access log: msg + 5-tuple args."""
+    return logging.LogRecord(
+        name="uvicorn.access", level=logging.INFO, pathname=__file__, lineno=0,
+        msg=UVICORN_ACCESS_FMT,
+        args=("127.0.0.1:5555", method, path, "1.1", status),
+        exc_info=None,
+    )
+
+
+def _record_preformatted(method, path, status):
+    """A record with no structured args, forcing the formatted-line fallback."""
+    line = f'127.0.0.1:5555 - "{method} {path} HTTP/1.1" {status}'
+    return logging.LogRecord(
+        name="uvicorn.access", level=logging.INFO, pathname=__file__, lineno=0,
+        msg=line, args=(), exc_info=None,
+    )
+
+
+class SuppressHealthAccessTest(unittest.TestCase):
+    def setUp(self):
+        self.f = _SuppressHealthAccess()
+
+    # ── structured-args path (the normal uvicorn case) ──
+    def test_drops_successful_health_from_args(self):
+        self.assertFalse(self.f.filter(_record_with_args("GET", "/health", 200)))
+        self.assertFalse(self.f.filter(_record_with_args("HEAD", "/health", 204)))
+        self.assertFalse(self.f.filter(_record_with_args("GET", "/health?x=1", 200)))
+
+    def test_keeps_degraded_health_from_args(self):
+        # 503 is what the handler returns on a Supabase failure. It must survive,
+        # or the filter would hide exactly the case a health check exists to show.
+        self.assertTrue(self.f.filter(_record_with_args("GET", "/health", 503)))
+        self.assertTrue(self.f.filter(_record_with_args("GET", "/health", 500)))
+
+    def test_keeps_non_health_from_args(self):
+        self.assertTrue(self.f.filter(_record_with_args("GET", "/scan", 200)))
+        self.assertTrue(self.f.filter(_record_with_args("POST", "/health", 200)))
+        # a path that merely starts with health must not be swallowed
+        self.assertTrue(self.f.filter(_record_with_args("GET", "/healthz", 200)))
+
+    # ── formatted-line fallback (unknown uvicorn shape) ──
+    def test_drops_successful_health_from_message(self):
+        self.assertFalse(self.f.filter(_record_preformatted("GET", "/health", 200)))
+
+    def test_keeps_degraded_and_non_health_from_message(self):
+        self.assertTrue(self.f.filter(_record_preformatted("GET", "/health", 503)))
+        self.assertTrue(self.f.filter(_record_preformatted("GET", "/scan", 200)))
+        self.assertTrue(self.f.filter(_record_preformatted("GET", "/healthz", 200)))
+
+    # ── never raise ──
+    def test_malformed_record_is_passed_through(self):
+        rec = logging.LogRecord(
+            name="uvicorn.access", level=logging.INFO, pathname=__file__, lineno=0,
+            msg="not an access line at all", args=(), exc_info=None,
+        )
+        self.assertTrue(self.f.filter(rec))
+
+
+class InstallTest(unittest.TestCase):
+    def test_install_is_idempotent_on_uvicorn_access(self):
+        access = logging.getLogger("uvicorn.access")
+        before = [f for f in access.filters if isinstance(f, _SuppressHealthAccess)]
+        for f in before:
+            access.removeFilter(f)
+        install_health_access_suppression()
+        install_health_access_suppression()
+        attached = [f for f in access.filters if isinstance(f, _SuppressHealthAccess)]
+        self.assertEqual(len(attached), 1)
+        # and it is live: a successful /health poll is now dropped
+        self.assertFalse(attached[0].filter(_record_with_args("GET", "/health", 200)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`/health` polling buried the trade-engine boot banner: on 2026-09-11, 633 of 662 lines in `trade-engine-out.log` were `GET /health 200 OK`, and it obstructed deploy verification three times.

**Fix:** a `uvicorn.access` filter (`src/trade_engine/config.py`) that drops SUCCESSFUL `/health` access lines only. A 4xx/5xx health check still logs, so a degraded engine (the handler returns 503 on a Supabase failure) stays visible. It prefers uvicorn's structured record args (`method`, `path`, `status`) and falls back to matching the formatted line for any other uvicorn shape. Installed from the app lifespan (`main.py`), after uvicorn applies its own logging dictConfig, so the filter attaches to the live logger and cannot be cleared.

**Test** (`tests/test_health_access_filter.py`, 7 cases): drops `GET/HEAD /health` 2xx/3xx (incl. a query string); KEEPS `/health` 503/500, `POST /health`, `/scan` 200, and `/healthz` 200; covers both the structured-args path and the formatted-line fallback; and asserts install is idempotent and live. Non-vacuous by construction (asserts both the drop and the keeps).

**Siblings checked, both clear (so no change):** trading-worker is Flask/werkzeug and logged `/health` 14 times ever, not a flood; the dashboard has no per-request logger and is the client doing the polling.

Does not touch trading logic. Trade-engine only. I do not merge; this is yours.
